### PR TITLE
fix(backup): harden backup import security

### DIFF
--- a/docs/gestion/README.md
+++ b/docs/gestion/README.md
@@ -21,6 +21,7 @@ de Gómez (2014).
 | [`firma-apk-android.md`](./firma-apk-android.md) | Política de firma, secretos y resguardo del artefacto Android | ✅ Completado |
 | [`plan-mantenibilidad-tipado-gradual-2026-06-12.md`](./plan-mantenibilidad-tipado-gradual-2026-06-12.md) | Estrategia incremental de modularidad y tipado; no habilita refactors amplios durante el cierre | 📌 Referencia |
 | [`revision-tecnica-priorizada-2026-09-01.md`](./revision-tecnica-priorizada-2026-09-01.md) | Auditoría vigente de arquitectura, seguridad, persistencia, escalabilidad y tooling con backlog priorizado | 🔄 Remediación activa |
+| [`analisis-aud-003-seguridad-importacion-backups-2026-09-01.md`](./analisis-aud-003-seguridad-importacion-backups-2026-09-01.md) | Revalidación de AUD-003, trazado ZIP/JSON a DOM, contratos, límites y plan de remediación | 🔄 Implementación pendiente |
 | [`historico/`](./historico/) | Snapshots operativos cerrados preservados como evidencia de proceso | 📦 Archivo |
 
 ---

--- a/docs/gestion/README.md
+++ b/docs/gestion/README.md
@@ -21,7 +21,7 @@ de Gómez (2014).
 | [`firma-apk-android.md`](./firma-apk-android.md) | Política de firma, secretos y resguardo del artefacto Android | ✅ Completado |
 | [`plan-mantenibilidad-tipado-gradual-2026-06-12.md`](./plan-mantenibilidad-tipado-gradual-2026-06-12.md) | Estrategia incremental de modularidad y tipado; no habilita refactors amplios durante el cierre | 📌 Referencia |
 | [`revision-tecnica-priorizada-2026-09-01.md`](./revision-tecnica-priorizada-2026-09-01.md) | Auditoría vigente de arquitectura, seguridad, persistencia, escalabilidad y tooling con backlog priorizado | 🔄 Remediación activa |
-| [`analisis-aud-003-seguridad-importacion-backups-2026-09-01.md`](./analisis-aud-003-seguridad-importacion-backups-2026-09-01.md) | Revalidación e implementación de AUD-003: frontera ZIP/JSON, integridad y defensa de presentación | ✅ Completa en rama; Android final, PR y merge pendientes |
+| [`analisis-aud-003-seguridad-importacion-backups-2026-09-01.md`](./analisis-aud-003-seguridad-importacion-backups-2026-09-01.md) | Revalidación e implementación de AUD-003: frontera ZIP/JSON, integridad y defensa de presentación | ✅ Implementación y validación completas; integración autorizada |
 | [`historico/`](./historico/) | Snapshots operativos cerrados preservados como evidencia de proceso | 📦 Archivo |
 
 ---

--- a/docs/gestion/README.md
+++ b/docs/gestion/README.md
@@ -21,7 +21,7 @@ de Gómez (2014).
 | [`firma-apk-android.md`](./firma-apk-android.md) | Política de firma, secretos y resguardo del artefacto Android | ✅ Completado |
 | [`plan-mantenibilidad-tipado-gradual-2026-06-12.md`](./plan-mantenibilidad-tipado-gradual-2026-06-12.md) | Estrategia incremental de modularidad y tipado; no habilita refactors amplios durante el cierre | 📌 Referencia |
 | [`revision-tecnica-priorizada-2026-09-01.md`](./revision-tecnica-priorizada-2026-09-01.md) | Auditoría vigente de arquitectura, seguridad, persistencia, escalabilidad y tooling con backlog priorizado | 🔄 Remediación activa |
-| [`analisis-aud-003-seguridad-importacion-backups-2026-09-01.md`](./analisis-aud-003-seguridad-importacion-backups-2026-09-01.md) | Revalidación de AUD-003, trazado ZIP/JSON a DOM, contratos, límites y plan de remediación | 🔄 Implementación pendiente |
+| [`analisis-aud-003-seguridad-importacion-backups-2026-09-01.md`](./analisis-aud-003-seguridad-importacion-backups-2026-09-01.md) | Revalidación e implementación de AUD-003: frontera ZIP/JSON, integridad y defensa de presentación | ✅ Completa en rama; Android final, PR y merge pendientes |
 | [`historico/`](./historico/) | Snapshots operativos cerrados preservados como evidencia de proceso | 📦 Archivo |
 
 ---

--- a/docs/gestion/analisis-aud-003-seguridad-importacion-backups-2026-09-01.md
+++ b/docs/gestion/analisis-aud-003-seguridad-importacion-backups-2026-09-01.md
@@ -18,6 +18,10 @@ Lumapse.
 Este documento versiona la fase de análisis. No modifica código de producción ni autoriza por sí
 solo cambios fuera del alcance descrito.
 
+La rama y el primer commit se publicaron durante la fase de análisis, antes del checkpoint de
+aprobación previsto. Ese desvío queda limitado a documentación: la implementación de producción
+continúa expresamente pendiente y requiere autorización antes de comenzar.
+
 ### Incluido
 
 - Lectura de fuentes `Blob`, `ArrayBuffer`, `Uint8Array` y base64.
@@ -384,6 +388,26 @@ La extracción de los JSON canónicos debe ser secuencial y acotada por bytes re
 JSZip se pausa y rechaza cuando la salida supera el presupuesto, aun si el directorio central
 declara un tamaño menor.
 
+#### Checkpoint obligatorio de diseño
+
+`BackupZipPreflight.ts` no debe implementarse directamente a partir de este documento. Antes de
+escribir el lector binario se debe presentar y aprobar un diseño focalizado que especifique:
+
+- métodos y flags ZIP admitidos para backups actuales `STORE` e históricos `DEFLATE`;
+- tratamiento de data descriptors, nombres UTF-8, comentarios y campos extra;
+- búsqueda acotada del EOCD y rechazo de truncamiento, multidisk y ZIP64;
+- validación de offsets, tamaños y conteos sin overflow;
+- coherencia entre directorio central y headers locales;
+- rechazo de cifrado, métodos desconocidos, rutas inseguras y nombres canónicos duplicados;
+- responsabilidad de CRC y manejo de archivos corruptos;
+- aborto por bytes reales descomprimidos aunque la metadata declare un valor menor;
+- interacción exacta con JSZip sin depender de propiedades privadas.
+
+El checkpoint también debe comparar esta alternativa con una solución más pequeña basada en APIs
+públicas existentes. Solo se conserva el parser ZIP32 propio si reduce el riesgo total y puede
+probarse como una unidad aislada; la ausencia de dependencias nuevas no justifica introducir un
+parser ambiguo o insuficientemente verificable.
+
 ### 8.4 Validación de manifest y entidades
 
 Crear `src/services/backup/BackupImportValidation.ts`. Debe:
@@ -571,16 +595,28 @@ con backups reales antes del merge.
 
 ### Evidencia de la fase de análisis
 
-Se ejecutaron los tests existentes directamente relacionados con parser, plan, datasource,
-servicio, regresión y renderizadores:
+Una revalidación independiente ejecutó el siguiente conjunto existente directamente relacionado
+con parser, plan, datasource, servicio, regresión y renderizadores:
 
-```text
-10 archivos de test
-71 tests aprobados
+```bash
+npm test -- \
+  tests/unit/services/backup/BackupImportZipService.test.js \
+  tests/unit/services/backup/BackupImportPlanService.test.js \
+  tests/unit/services/backup/BackupImportDataSource.test.js \
+  tests/unit/services/backup/BackupImportService.test.js \
+  tests/unit/services/backup/BackupImportRegression.test.js \
+  tests/unit/components/feed/NoteList.test.js \
+  tests/unit/components/feed/TrashView.test.js \
+  tests/unit/components/academic-events/AcademicEventTypes.test.js \
+  tests/unit/components/academic-events/Heatmap.test.js \
+  tests/unit/layout/drawerSubjects.test.js
 ```
 
-Se ejecutaron además cuatro pruebas temporales fuera del repositorio para evitar modificar la
-base durante la fase de análisis. Confirmaron:
+Resultado reproducido: **10 archivos y 69 tests aprobados**.
+
+El análisis original reportó pruebas exploratorias temporales fuera del repositorio. Esos
+artefactos no se conservaron y, por tanto, sus resultados no constituyen todavía un gate
+reproducible. Los seis escenarios reportados fueron:
 
 1. ZIP manipulado -> parser -> nodo DOM controlado.
 2. Inyección de atributo mediante valores persistidos.
@@ -588,6 +624,10 @@ base durante la fase de análisis. Confirmaron:
 4. Timestamp inválido -> `RangeError` en Heatmap.
 5. Expansión ZIP sin límite.
 6. Eliminación de `script` y `onerror` por DOMPurify.
+
+Cada escenario que fundamente la remediación debe convertirse en una regresión permanente,
+revisable y fallida antes del fix correspondiente, sin conservar payloads ejecutables en datos de
+producción ni depender de evidencia temporal.
 
 ### Unitarias requeridas
 
@@ -626,6 +666,7 @@ La fase final debe ejecutar `npm run verify` y validación manual Android.
 
 ### Fase 1 — frontera y límites
 
+- Checkpoint de diseño de `BackupZipPreflight.ts` y decisión explícita de proceder o simplificar.
 - Validadores de primitivas.
 - Política central.
 - Preflight ZIP.
@@ -638,8 +679,9 @@ Commit propuesto:
 fix(backup): validate and bound imported archives
 ```
 
-Esta fase cambia el contrato observable de rechazo y debe presentarse para revisión antes de
-continuar si los límites o compatibilidad difieren de este documento.
+No se inicia el código de esta fase hasta aprobar el checkpoint de preflight. Después, cualquier
+cambio en límites, compatibilidad o contrato observable de rechazo debe presentarse para revisión
+antes de continuar.
 
 ### Fase 2 — integridad estructural
 
@@ -678,12 +720,17 @@ fix(ui): harden imported data render contexts
 
 ## 15. Recomendación
 
-Proceder con **un único PR de AUD-003**, dividido internamente en fases y commits revisables.
+Mantener por ahora **una única rama de AUD-003** y tratar el objetivo de un solo PR como
+provisional. La decisión se confirma después del checkpoint de preflight y de estimar el diff real.
 
 Separar frontera y renderizadores en PRs independientes dejaría una ventana incompleta:
 
 - solo frontera no neutraliza registros contaminados ya persistidos;
 - solo presentación no limita ZIP bombs ni estructuras inválidas.
+
+Si el lector ZIP32 o la defensa de presentación no pueden revisarse de forma independiente, se
+deben usar PRs apilados o secuenciales con trazabilidad común. Ningún PR parcial se considera cierre
+de AUD-003 ni se fusiona sin evaluar la cobertura completa de frontera y sinks.
 
 El alcance debe mantenerse sin dependencias nuevas, sin cambios estéticos y sin incorporar
 AUD-004. Cualquier modificación a límites, compatibilidad o comportamiento observable debe

--- a/docs/gestion/analisis-aud-003-seguridad-importacion-backups-2026-09-01.md
+++ b/docs/gestion/analisis-aud-003-seguridad-importacion-backups-2026-09-01.md
@@ -1,10 +1,11 @@
 # AUD-003 — Análisis de seguridad de importación de backups
 
-**Estado:** Análisis revalidado; implementación pendiente  
-**Rama:** `fix/backup-import-security`  
-**Commit base revisado:** `376f7b6` (`main`)  
-**Fecha:** 2026-09-01  
-**Prioridad:** P0  
+**Estado:** Implementación completa en `fix/backup-import-security`; validación Android final, PR y merge pendientes
+**Rama:** `fix/backup-import-security`
+**Commit base revisado:** `376f7b6` (`main`)
+**Fecha:** 2026-09-01
+**Última verificación:** 2026-09-02
+**Prioridad:** P0
 **Alcance:** frontera ZIP/JSON, validación runtime, integridad estructural, consumo de recursos y renderizado de datos importados
 
 ---
@@ -19,8 +20,8 @@ Este documento versiona la fase de análisis. No modifica código de producción
 solo cambios fuera del alcance descrito.
 
 La rama y el primer commit se publicaron durante la fase de análisis, antes del checkpoint de
-aprobación previsto. Ese desvío queda limitado a documentación: la implementación de producción
-continúa expresamente pendiente y requiere autorización antes de comenzar.
+aprobación previsto. Ese desvío quedó limitado a documentación. La implementación comenzó después
+de los checkpoints explícitos y se completó en la misma rama sin crear PR ni tocar `main`.
 
 ### Incluido
 
@@ -658,80 +659,59 @@ producción ni depender de evidencia temporal.
 - Markdown legítimo y payloads de saneamiento actuales.
 - Heatmap resistente a timestamps ya persistidos inválidos.
 
-La fase final debe ejecutar `npm run verify` y validación manual Android.
+### Evidencia de implementación y cierre — 2026-09-02
+
+- Suites focalizadas de presentación: **11 archivos y 75 tests aprobados**.
+- Suite completa con `NODE_OPTIONS=--no-experimental-webstorage`: **60 archivos y 955 tests
+  aprobados**. Sin el workaround de Node 26, el baseline falla en **5 archivos y 51 tests** por la
+  colisión conocida de Web Storage; pasan 55 archivos y 904 tests.
+- Typecheck y lint aprobados; lint conserva **0 errores y 3 warnings basales** en `NoteEditor` y
+  `BackupImportPlanService`.
+- Build Vite aprobado con **117 módulos**. Presupuesto gzip: JS **178,57 kB**, CSS **10,42 kB**,
+  HTML **0,84 kB** y total **189,83 kB / 250 kB**.
+- Toolchain, smoke SQLite (**2 CREATE y 7 ALTER**), diálogos nativos y accesibilidad
+  (**0 problemas**) aprobados. La guardia de archivos conserva **20 avisos no bloqueantes**.
+- `npm run verify` queda no verde únicamente por los dos falsos positivos ya documentados de
+  `http://localhost` en el fallback CSP; no se modificó CSP ni tooling de AUD-008/AUD-009.
+- `npm run check:docs` y `npm run check:traceability` pasan sin errores ni advertencias de
+  trazabilidad.
+
+La validación manual Android de Fase 1C fue aprobada para backup actual `STORE`, backup histórico
+`DEFLATE`, fixture de 500 notas y rechazo de `pinned` inválido antes de persistir. La defensa de
+presentación está implementada y automatizada, pero requiere un checkpoint Android final antes de
+crear/fusionar el PR.
 
 ---
 
-## 14. Fases de implementación propuestas
+## 14. Fases y checkpoints implementados
 
-### Fase 1 — frontera y límites
+| Etapa | Commit(s) | Resultado |
+|---|---|---|
+| Análisis | `a766d6a`, `a9baaae` | Revalidación, alcance, contratos y checkpoints documentados. |
+| Fase 1A/1B | `405b4dd`, `34224bb` | Preflight ZIP32, límites, CRC32 y lectura acotada `STORE`/`DEFLATE`. |
+| Fase 1C | `e8f0023` | Validación runtime estricta antes del plan/persistencia. |
+| Fase 2 | `1246864` | Jerarquía máxima de dos niveles y `relationshipRepairs` visibles en preview. |
+| Fase 3 | `587da3f` | Escape por contexto, allowlist de color, selectores seguros y tolerancia a datos antiguos contaminados. |
+| Fase 4 | `docs(audit): record AUD-003 remediation status` | Verificación acumulativa y cierre documental en este checkpoint. |
 
-- Checkpoint de diseño de `BackupZipPreflight.ts` y decisión explícita de proceder o simplificar.
-- Validadores de primitivas.
-- Política central.
-- Preflight ZIP.
-- Extracción secuencial acotada.
-- Regresiones del parser.
-
-Commit propuesto:
-
-```text
-fix(backup): validate and bound imported archives
-```
-
-No se inicia el código de esta fase hasta aprobar el checkpoint de preflight. Después, cualquier
-cambio en límites, compatibilidad o contrato observable de rechazo debe presentarse para revisión
-antes de continuar.
-
-### Fase 2 — integridad estructural
-
-- Profundidad máxima de materias/secciones.
-- Ciclos y padres inválidos.
-- Preview de reparaciones.
-
-Commit propuesto:
-
-```text
-fix(backup): enforce imported subject hierarchy
-```
-
-### Fase 3 — defensa en presentación
-
-- Escape contextual.
-- Allowlist de colores en todos los sinks.
-- Selectores seguros.
-- Resistencia ante registros contaminados previamente.
-
-Commit propuesto:
-
-```text
-fix(ui): harden imported data render contexts
-```
-
-### Fase 4 — cierre
-
-- Tests específicos y `npm run verify`.
-- Revisión de diff y commits.
-- Push de `fix/backup-import-security`.
-- PR limpio y documentado.
-- Sin merge a `main`.
+La implementación técnica está completa en la rama. Solo quedan el checkpoint Android final, la
+creación del PR por el coordinador y el merge posterior a su aprobación.
 
 ---
 
 ## 15. Recomendación
 
-Mantener por ahora **una única rama de AUD-003** y tratar el objetivo de un solo PR como
-provisional. La decisión se confirma después del checkpoint de preflight y de estimar el diff real.
+Se mantuvo **una única rama de AUD-003** y los checkpoints permitieron revisar cada capa antes del
+cierre acumulativo.
 
 Separar frontera y renderizadores en PRs independientes dejaría una ventana incompleta:
 
 - solo frontera no neutraliza registros contaminados ya persistidos;
 - solo presentación no limita ZIP bombs ni estructuras inválidas.
 
-Si el lector ZIP32 o la defensa de presentación no pueden revisarse de forma independiente, se
-deben usar PRs apilados o secuenciales con trazabilidad común. Ningún PR parcial se considera cierre
-de AUD-003 ni se fusiona sin evaluar la cobertura completa de frontera y sinks.
+Ningún PR parcial se considera cierre de AUD-003 ni se fusiona sin evaluar la cobertura completa
+de frontera y sinks.
 
-El alcance debe mantenerse sin dependencias nuevas, sin cambios estéticos y sin incorporar
-AUD-004. Cualquier modificación a límites, compatibilidad o comportamiento observable debe
-presentarse antes de ampliar la implementación.
+El alcance se cerró sin dependencias nuevas, sin cambios estéticos y sin incorporar AUD-004,
+AUD-006, AUD-008 ni AUD-009. Esos hallazgos conservan su prioridad y ramas propias. No se crea ni
+fusiona un PR hasta completar la validación Android final.

--- a/docs/gestion/analisis-aud-003-seguridad-importacion-backups-2026-09-01.md
+++ b/docs/gestion/analisis-aud-003-seguridad-importacion-backups-2026-09-01.md
@@ -1,0 +1,690 @@
+# AUD-003 — Análisis de seguridad de importación de backups
+
+**Estado:** Análisis revalidado; implementación pendiente  
+**Rama:** `fix/backup-import-security`  
+**Commit base revisado:** `376f7b6` (`main`)  
+**Fecha:** 2026-09-01  
+**Prioridad:** P0  
+**Alcance:** frontera ZIP/JSON, validación runtime, integridad estructural, consumo de recursos y renderizado de datos importados
+
+---
+
+## 1. Objetivo y alcance
+
+Revalidar el hallazgo AUD-003 contra el código vigente, sin asumir que la auditoría original
+continuara siendo exacta, y definir una remediación modular que preserve backups legítimos de
+Lumapse.
+
+Este documento versiona la fase de análisis. No modifica código de producción ni autoriza por sí
+solo cambios fuera del alcance descrito.
+
+### Incluido
+
+- Lectura de fuentes `Blob`, `ArrayBuffer`, `Uint8Array` y base64.
+- Inspección y extracción del ZIP.
+- Validación de `manifest.json` y los tres JSON canónicos.
+- IDs, colores, fechas, timestamps, textos, booleans y relaciones.
+- Límites de archivo, entradas, expansión, documentos, entidades y campos.
+- Flujo de datos hasta DOM, atributos, estilos y selectores.
+- Compatibilidad con backups v1 históricos y actuales.
+- Pruebas unitarias, integración, regresión y validación Android requeridas.
+
+### Excluido
+
+- Actualizaciones de dependencias de AUD-004.
+- Refactors generales de `NoteEditor`.
+- Cambios estéticos.
+- Migraciones arquitectónicas amplias.
+- Otros hallazgos de la auditoría.
+- Firma criptográfica o autenticación de backups.
+
+---
+
+## 2. Sincronización y documentación revisada
+
+La revisión comenzó con el repositorio limpio. Se actualizó `main` mediante `fetch --prune` y
+`pull --ff-only`; el resultado quedó sincronizado con `origin/main` en `376f7b6`.
+
+Documentación leída antes de inspeccionar el flujo:
+
+- [`../../README.md`](../../README.md).
+- [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md).
+- [`revision-tecnica-priorizada-2026-09-01.md`](./revision-tecnica-priorizada-2026-09-01.md).
+- [ADR-006 — Persistencia y tooling SQLite](../adr/ADR-006-arquitectura-de-persistencia-y-tooling-sqlite-para-desarrollo-web-y-native.md).
+- [ADR-007 — Organización por feature](../adr/ADR-007-organizacion-componentes-por-feature.md).
+- [ADR-008 — Arquitectura modular y patrones](../adr/ADR-008-arquitectura-modular-y-patrones.md).
+- [Requisitos no funcionales](../producto/requisitos-no-funcionales.md).
+- [Plan histórico de importación ZIP](./historico/plan-importacion-backup-zip-2026-06-18.md).
+
+La propuesta conserva el monolito cliente modular, el Service Layer, la inyección explícita de
+dependencias y la persistencia local SQLite definidos en los ADR vigentes.
+
+---
+
+## 3. Resultado ejecutivo
+
+AUD-003 se confirma con una precisión de alcance:
+
+| Riesgo | Resultado |
+|---|---|
+| Inyección persistente de nodos DOM/HTML | Confirmada |
+| Inyección en atributos | Confirmada |
+| Inyección CSS y alteración visual | Confirmada |
+| Ejecución JavaScript/XSS | Potencial; no demostrada |
+| Datos estructuralmente inválidos | Confirmada |
+| Consumo excesivo de memoria/ZIP bomb | Confirmado |
+| Inyección SQL | Refutada en el flujo actual |
+| HTML directo desde Markdown de notas | Refutado en el flujo actual |
+| ZIP Slip con escritura arbitraria | Refutado en el flujo actual |
+
+La prioridad P0 permanece justificada. Un backup es una frontera no confiable aunque su selección
+requiera una acción explícita del usuario: sus datos se persisten y vuelven a renderizar en
+sesiones posteriores.
+
+El CSP de `index.html:18-23` reduce mecanismos de ejecución inline, pero no impide crear nodos,
+atributos o controles visuales. Además, `style-src 'unsafe-inline'` permite que una inyección CSS
+afecte la interfaz.
+
+---
+
+## 4. Revalidación de las afirmaciones originales
+
+### 4.1 Validación insuficiente en el parser — confirmada
+
+`src/services/backup/BackupImportZipService.ts` presenta los siguientes comportamientos:
+
+- `textValue()` (`51-53`) convierte números, arrays u objetos a strings.
+- `requireText()` (`60-66`) solo comprueba que el resultado no quede vacío.
+- `normalizeBoolean()` (`68-75`) convierte valores desconocidos silenciosamente a `false`.
+- `normalizeDateTime()` (`77-80`) acepta cualquier texto o aplica fallback sin validar fecha.
+- `normalizeDate()` (`82-88`) solo exige el patrón `YYYY-MM-DD`; acepta días inexistentes.
+- `normalizeSubjectId()` y `normalizeColor()` (`90-96`) aceptan cualquier texto opcional.
+- Las entidades (`119-195`) no limitan arrays ni longitudes de campos.
+- `validateManifest()` (`217-255`) admite conteos coercionados y booleans mediante `Boolean()`.
+- `loadZip()` (`300-315`) no limita el tamaño de la fuente.
+- `readJsonFile()` (`317-328`) materializa todo el archivo como string antes de `JSON.parse()`.
+- `parseBackupImportZip()` (`330-363`) extrae tres JSON en paralelo mediante `Promise.all()`.
+
+Ejemplos de estado inválido aceptado actualmente:
+
+- Un objeto como texto termina persistido como `[object Object]`.
+- `dataPolicy.includesDeletedItems: "false"` se interpreta como `true`.
+- Conteos negativos, fraccionarios, `NaN` o `Infinity` no tienen contrato estricto.
+- `2026-02-31` supera la expresión regular.
+- Un timestamp arbitrario puede llegar hasta `new Date(...).toISOString()`.
+- Cualquier valor truthy en `deletedAt` provoca la omisión silenciosa de la fila.
+
+### 4.2 Primitivas TypeScript — hecho confirmado, causa matizada
+
+`src/domain/primitives.ts` define `EntityId`, `ISODateString`, `ISODateTimeString` y `HexColor`
+como aliases de `string`. Los aliases no existen en runtime; esto es comportamiento normal de
+TypeScript.
+
+El defecto no es conservar esos aliases, sino tratarlos como prueba de validación después de
+coercionar datos no confiables. Cambiar a tipos branded tampoco sustituiría un parser runtime.
+
+### 4.3 IDs, colores, fechas y textos llegan a renderizadores — confirmada parcialmente
+
+- IDs de materias y notas llegan a templates sin codificación contextual.
+- Colores llegan a declaraciones CSS inline sin allowlist.
+- Nombres se escapan correctamente como texto en varios lugares, pero no siempre como atributo.
+- Fechas y timestamps llegan a formatters y al Heatmap sin garantizar validez real.
+- El contenido Markdown sí pasa por `MarkdownService` y DOMPurify.
+
+### 4.4 Falta de límites — confirmada
+
+No existen límites para:
+
+- bytes del archivo o fuente base64;
+- cantidad de entradas ZIP;
+- tamaño comprimido o descomprimido total;
+- tamaño individual de `manifest.json` o JSON canónicos;
+- cantidad de materias, notas o eventos;
+- longitud de IDs, rutas, nombres, títulos o contenido.
+
+El parser tampoco separa la prevalidación de metadatos ZIP de la extracción efectiva.
+
+---
+
+## 5. Recorrido completo de datos
+
+```text
+BackupView <input type=file>
+  -> BackupImportFlowController.prepareFromFile(File)
+  -> BackupImportService.prepareBackupImport(source)
+  -> BackupImportZipService.parseBackupImportZip(source)
+       -> JSZip.loadAsync(...)
+       -> manifest.json
+       -> data/subjects.json
+       -> data/notes.json
+       -> data/academic-events.json
+       -> coerción/normalización actual
+  -> BackupImportPlanService.createCurrentBackupImportPlan(parsed)
+       -> duplicados
+       -> conflictos locales
+       -> reparación de relaciones
+       -> preview
+  -> confirmación del usuario
+  -> BackupImportDataSource.applyBackupImportPlan(plan)
+       -> transacción SQLite
+       -> INSERT parametrizados
+  -> NoteList.refreshAfterBackupImport()
+       -> recarga de notas, materias, archivadas, papelera y eventos
+  -> store
+  -> renderizadores DOM/atributos/CSS
+```
+
+### 5.1 Selección y preview
+
+`src/components/backup/BackupImportFlowController.js:31-60` pasa el `File` completo al servicio.
+No hay prevalidación de `file.size`.
+
+El preview no renderiza entidades crudas. `BackupImportUI.js` codifica el filename y los errores,
+y `Toast.js` utiliza `textContent`; esta etapa no constituye un sink de inyección.
+
+### 5.2 Planificación
+
+`BackupImportPlanService.ts` conserva fortalezas importantes:
+
+- omite IDs duplicados dentro del backup;
+- evita sobrescribir IDs locales;
+- repara referencias inexistentes;
+- renombra materias en conflicto;
+- prepara un preview antes de escribir.
+
+Sin embargo, `planSubjects()` (`141-244`) puede conservar profundidad 3+ si una entidad apunta a
+una sección importada o local. También una cadena circular larga puede producir una jerarquía que
+la UI no representa por completo. Esto contradice DP-004 y la regla existente
+`validateMaxDepth()` de `SubjectService.validation.ts:68-84`.
+
+### 5.3 Persistencia
+
+`BackupImportDataSource.ts:35-90` usa placeholders `?`, y `applyBackupImportPlan()` ejecuta los
+inserts dentro de `runTransaction()`. Por ello se refuta una inyección SQL en este flujo.
+
+La persistencia conserva strings crudos, lo cual es correcto para texto de usuario siempre que la
+frontera valide estructura y la presentación aplique codificación contextual.
+
+### 5.4 Recarga y sinks
+
+`NoteList.refreshAfterBackupImport()` recarga todos los estados que pueden presentar datos
+restaurados. SQLite y el store no sanitizan esos strings antes de entregarlos a UI.
+
+| Campo | Sinks actuales | Evaluación |
+|---|---|---|
+| `subject.id` | `drawerSubjectsRender.js`, `drawerArchivedSubjects.js`, `NoteCardRenderer.js`, `drawerSubjects.js`, papelera posterior | Atributos/IDs sin escape y selectores construidos con input |
+| `subject.name` | drawer, archivadas, badges, pickers, eventos y papelera | Texto generalmente seguro; atributos del drawer usan escape de texto incorrecto |
+| `subject.color` | drawer, archivadas, badge, menú de movimiento, pickers, eventos y papelera | Inyección CSS confirmada |
+| `note.id` | `NoteList.js`, `NoteCardRenderer.js`, `TrashView.js` | Atributos sin escape |
+| `note.title` | feed y papelera | Codificado como texto en los sinks inspeccionados |
+| `note.content` | Markdown del feed, textarea del editor, preview de papelera | DOMPurify en Markdown; `textContent`/escape en los demás |
+| `note.updatedAt` | fecha relativa y `Heatmap.calculateActivity()` | Puede producir `RangeError` |
+| `event.id`, `title`, `date` | `AcademicEventTypes.ts` | Contextos HTML/atributo codificados; fecha todavía puede ser inválida |
+| `event.subjectId` | resolución de materia para label/color | El color de materia vuelve a llegar a CSS |
+
+---
+
+## 6. Riesgos confirmados por categoría
+
+### 6.1 Inyección DOM/HTML — alta
+
+Interpolaciones relevantes:
+
+- `drawerSubjectsRender.js:51-55`, `63`, `71-81`, `92-99`, `117-120`.
+- `NoteList.js:277`, `300`, `304`, `318`, `322`, `326`.
+- `NoteCardRenderer.js:69`, `75-76`.
+- `TrashView.js:87`, `115`, `141`, `144`.
+
+Un ID puede cerrar un atributo y agregar markup cuando el template se asigna mediante
+`innerHTML`. El valor persiste en SQLite y reaparece cada vez que se reconstruye la vista.
+
+La prueba temporal de revalidación creó nodos controlados por el dato importado. No se demostró
+ejecución JavaScript; la conclusión precisa es **inyección DOM persistente con XSS potencial**.
+
+### 6.2 Inyección en atributos — alta
+
+`appShell.escapeHtml()` (`173-177`) crea un nodo de texto y devuelve su `innerHTML`. Esto es
+adecuado para texto HTML, pero las comillas no necesitan codificarse en un nodo de texto.
+
+Se utiliza en atributos como:
+
+```html
+data-subject-name="${escapeHtml(subject.name)}"
+```
+
+Por tanto, el helper correcto se usa en el contexto incorrecto. Otros IDs ni siquiera pasan por
+ese helper.
+
+### 6.3 Inyección CSS — alta
+
+Ejemplos:
+
+- `drawerSubjectsRender.js:54,95`.
+- `drawerArchivedSubjects.js:39,62`.
+- `NoteList.js:44`.
+- `NoteCardRenderer.js:69`.
+- `TrashView.js:64,81,109`.
+- `SubjectPicker.js:120`.
+- `AcademicEventTypes.ts:202,233`.
+
+Escapar comillas HTML no protege la gramática CSS. Un punto y coma puede introducir nuevas
+declaraciones sin salir del atributo.
+
+La prueba temporal confirmó que un color manipulado aplicó `position: fixed` e `inset`. El CSP
+permite estilos inline, por lo que puede producir overlay, denegación visual o suplantación de UI.
+
+`AcademicEventSubjectPicker.js` no reproduce el breakout: construye nodos y utiliza CSSOM. Aun
+así, debe recibir un color válido para conservar el contrato visual.
+
+### 6.4 Integridad estructural y disponibilidad — media/alta
+
+Una prueba temporal confirmó que un `updatedAt` inválido llega a
+`Heatmap.calculateActivity()` (`59-65`) y provoca `RangeError` en `toISOString()`.
+
+Otros efectos:
+
+- relaciones de profundidad 3+ inaccesibles desde el drawer;
+- selectores CSS inválidos en `drawerSubjects.js:217,232,259,265,298,311`;
+- conteos del manifest engañosos;
+- objetos coercionados y datos semánticamente corruptos;
+- fechas académicas inexistentes que no corresponden a una celda real.
+
+### 6.5 Consumo de memoria/ZIP bomb — alta
+
+Una prueba controlada generó un JSON repetitivo de 2.097.152 bytes dentro de un ZIP de 2.264
+bytes, una expansión aproximada de 926 veces. El parser lo aceptó y no existe un punto en el flujo
+que detenga una variante mayor.
+
+El riesgo aumenta porque:
+
+- JSZip recibe la fuente completa;
+- el directorio puede contener entradas adicionales;
+- los tres JSON se descomprimen concurrentemente;
+- cada JSON existe como bytes, string UTF-16 y objetos de `JSON.parse()` durante el procesamiento.
+
+---
+
+## 7. Riesgos refutados y fortalezas conservadas
+
+### Inyección SQL
+
+Refutada. Los valores se envían mediante placeholders y la aplicación del plan es transaccional.
+
+### Markdown crudo
+
+Refutado para el código actual. `MarkdownService.ts:205` pasa la salida de `marked` por DOMPurify.
+La prueba temporal eliminó un `script` y un handler `onerror`.
+
+Esto no sustituye AUD-004: la actualización de DOMPurify y otras dependencias continúa fuera de
+este PR.
+
+### ZIP Slip
+
+No se escriben entradas del ZIP en el filesystem y solo se leen archivos canónicos. JSZip además
+normaliza componentes `..`. No hay escritura arbitraria en el flujo actual.
+
+La remediación debe igualmente rechazar rutas inseguras: una ruta normalizada puede colisionar
+con `manifest.json` u otro nombre canónico y crear ambigüedad.
+
+### Papelera importada
+
+El parser omite filas con `deletedAt`, por lo que `TrashView` no recibe elementos eliminados de
+forma inmediata. Una entidad activa contaminada sí alcanza esa vista después de un borrado
+posterior; por ello sus sinks siguen dentro del alcance defensivo.
+
+### Otros controles que deben preservarse
+
+- Preview explícito antes de persistir.
+- No sobrescritura por ID.
+- Reparación de relaciones faltantes.
+- Renombrado determinista por conflicto de nombre.
+- Escritura transaccional.
+- UI de errores mediante texto, no HTML crudo.
+
+---
+
+## 8. Diseño de remediación
+
+La solución propuesta aplica defensa en profundidad sin dependencias nuevas ni reescrituras
+generales.
+
+### 8.1 Validadores runtime de primitivas
+
+Crear `src/domain/primitiveValidation.ts` con funciones puras para:
+
+- IDs opacos seguros;
+- colores hexadecimales;
+- fechas de calendario;
+- timestamps RFC 3339;
+- strings acotados y caracteres de control.
+
+`src/domain/primitives.ts` permanece como contrato estático. Los validadores se reutilizan desde
+backup y presentación para evitar reglas de color duplicadas.
+
+### 8.2 Política central de límites
+
+Crear `src/services/backup/BackupImportPolicy.ts` como única fuente para límites de archivo,
+entradas, documentos, entidades y campos.
+
+### 8.3 Preflight ZIP32 antes de JSZip
+
+Crear `src/services/backup/BackupZipPreflight.ts` para:
+
+1. comprobar el tamaño de `Blob`/buffer/base64 antes de copiar o decodificar;
+2. normalizar la fuente a bytes una sola vez;
+3. localizar EOCD y recorrer el directorio central;
+4. limitar entradas y tamaños antes de `JSZip.loadAsync()`;
+5. rechazar rutas inseguras, colisiones, cifrado, multidisk y ZIP64;
+6. aceptar `STORE` y `DEFLATE`.
+
+No se debe depender de `zipObject._data`: es metadata privada de JSZip y no limita la cantidad de
+entradas antes del parseo.
+
+La extracción de los JSON canónicos debe ser secuencial y acotada por bytes reales. Un stream de
+JSZip se pausa y rechaza cuando la salida supera el presupuesto, aun si el directorio central
+declara un tamaño menor.
+
+### 8.4 Validación de manifest y entidades
+
+Crear `src/services/backup/BackupImportValidation.ts`. Debe:
+
+- validar tipos reales sin `String(object)`;
+- conservar compatibilidad explícita de campos opcionales;
+- devolver errores con `ruta`, índice y campo;
+- evitar incluir valores enormes o markup no confiable en mensajes;
+- producir entidades válidas antes de crear el plan.
+
+`BackupImportZipService.ts` quedaría como orquestador de fuente, preflight, extracción y
+validación, reduciendo su responsabilidad actual.
+
+### 8.5 Jerarquía
+
+`BackupImportPlanService.ts` debe reutilizar `validateMaxDepth()` de
+`SubjectService.validation.ts` contra materias locales y ya planificadas.
+
+Un padre inexistente, circular o que ya sea una sección se repara a `null` y se registra en
+`relationshipRepairs`; nunca se persiste profundidad 3+.
+
+### 8.6 Presentación por contexto
+
+Crear `src/components/common/htmlEscaping.js` con APIs explícitas:
+
+- `escapeHtmlText()`;
+- `escapeHtmlAttribute()`.
+
+Reglas:
+
+- texto visible mediante `textContent` o escape de texto;
+- atributos mediante escape de atributos;
+- CSS mediante allowlist de color, nunca un escape HTML genérico;
+- selectores sin interpolar IDs no confiables;
+- construcción DOM en listas simples cuando reduzca riesgo;
+- templates existentes pueden mantenerse si todos los tokens dinámicos tienen contexto definido.
+
+No se propone almacenar texto escapado en SQLite. El texto de usuario se preserva y se codifica
+al renderizar.
+
+---
+
+## 9. Contratos propuestos
+
+| Dato | Contrato runtime |
+|---|---|
+| ID | String recortado, 1-128 caracteres, `^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$` |
+| Color | `null` o `#[0-9A-Fa-f]{6}`; normalización a minúsculas |
+| Fecha | `YYYY-MM-DD` con día real, incluidos años bisiestos |
+| Timestamp | RFC 3339 con zona, componentes válidos y resultado finito; normalización UTC |
+| Texto de una línea | Unicode, sin NUL/C0 y con límite por campo |
+| Contenido | String o `null`/ausente como vacío; Markdown preservado; límite UTF-8 |
+| Boolean | Boolean y compatibilidad exacta con `0/1/"true"/"false"/"1"/"0"` |
+| `deletedAt` | Ausente/null o timestamp válido; si existe se omite con aviso consolidado |
+| `type` académico | Allowlist actual: `parcial`, `final`, `tp`, `exposicion` |
+| Conteos | Enteros finitos, no negativos y dentro de límites |
+| `files` | Strings únicos, acotados y sin rutas inseguras |
+
+No se exige UUID estricto: tests, fixtures y backups históricos usan IDs como `subj-math`,
+`note-1` y `event-1`.
+
+Longitudes iniciales:
+
+- ID: 128 caracteres ASCII.
+- Materia/sección: 120 code points.
+- Título de nota: 4.096 code points.
+- Contenido de una nota: 2 MiB UTF-8.
+- Estado de nota: 16 code points.
+- Título académico: `ACADEMIC_EVENT_TITLE_MAX_LENGTH` (65).
+- Filename: 255 caracteres.
+- Ruta ZIP: 512 caracteres.
+
+Los textos legítimos pueden contener `<`, `>`, comillas, emoji y Markdown; la seguridad se
+resuelve por contexto de salida, no destruyendo contenido al importar.
+
+---
+
+## 10. Límites iniciales recomendados
+
+| Recurso | Límite | Justificación |
+|---|---:|---|
+| ZIP/fuente comprimida | 64 MiB | Techo explícito para WebView y buffers/base64 |
+| Total descomprimido anunciado | 64 MiB | Acota expansión total independientemente de la ratio |
+| Entradas ZIP | 5.100 | Cinco entradas base más un Markdown por cada una de 5.000 notas |
+| `manifest.json` | 4 MiB | Puede listar miles de rutas Markdown |
+| `data/subjects.json` | 2 MiB | Amplio para 1.000 materias/secciones |
+| `data/notes.json` | 24 MiB | Presupuesto principal del backup |
+| `data/academic-events.json` | 8 MiB | Amplio para 5.000 eventos |
+| Markdown individual | 2 MiB | Alineado con el contenido máximo por nota |
+| Materias/secciones | 1.000 | Muy superior al uso normal |
+| Notas | 5.000 | Diez veces el objetivo RNF-004 de 500 notas |
+| Eventos académicos | 5.000 | Techo de seguridad, no promesa de rendimiento |
+
+No se propone un límite de ratio de compresión. Un texto legítimo repetitivo puede comprimir muy
+bien; los límites absolutos de salida son más predecibles.
+
+Estos valores deben validarse antes de congelarse con:
+
+- el backup Android real documentado;
+- una fixture de 500 notas;
+- archivos exactamente en el límite y límite + 1;
+- prueba manual en el dispositivo Samsung objetivo.
+
+---
+
+## 11. Compatibilidad con backups v1
+
+### Formatos ZIP que deben conservarse
+
+El historial Git muestra dos escritores válidos:
+
+- Antes de `e7b3ec2`, `BackupZipService.js` utilizaba JSZip con `compression: 'DEFLATE'`.
+- El escritor actual `BackupZipArchive.ts` utiliza `STORE` sin compresión.
+
+El importador endurecido debe aceptar métodos 0 y 8. Restringirlo a `STORE` rompería backups
+legítimos de versiones anteriores.
+
+### Comportamientos que deben preservarse
+
+- IDs históricos no UUID.
+- Colores hexadecimales de seis dígitos fuera de la paleta actual, por ejemplo `#38bdf8`.
+- Booleans legacy definidos explícitamente.
+- Timestamp ausente con fallback a un timestamp válido del manifest.
+- `null` en título/contenido opcional según el contrato existente.
+- Entradas Markdown adicionales.
+- Omisión de duplicados y conflictos locales.
+- Renombrado y reparación de relaciones.
+
+### Cambios deliberados
+
+- Valores anteriormente aceptados solo por coerción serán rechazados.
+- Colores CSS arbitrarios, shorthand o nombres de color no serán aceptados.
+- Backups que superen límites fallarán completos antes de escribir.
+- Timestamps válidos con offset podrán normalizarse a UTC preservando el instante.
+
+No existe un límite que conserve todos los backups posibles porque el exportador actual puede
+generar contenido sin techo. Los límites son un cambio de seguridad necesario y deben calibrarse
+con backups reales antes del merge.
+
+---
+
+## 12. Archivos previstos para implementación
+
+### Crear
+
+- `src/domain/primitiveValidation.ts`.
+- `src/services/backup/BackupImportPolicy.ts`.
+- `src/services/backup/BackupZipPreflight.ts`.
+- `src/services/backup/BackupImportValidation.ts`.
+- `src/components/common/htmlEscaping.js`.
+- Tests unitarios correspondientes.
+
+### Modificar
+
+- `src/services/backup/BackupImportZipService.ts`.
+- `src/services/backup/BackupImportPlanService.ts`.
+- `src/layout/drawerSubjectsRender.js`.
+- `src/layout/drawerSubjects.js`.
+- `src/layout/drawerArchivedSubjects.js`.
+- `src/components/feed/NoteList.js`.
+- `src/components/feed/NoteCardRenderer.js`.
+- `src/components/feed/TrashView.js`.
+- `src/components/note-editor/SubjectPicker.js`.
+- `src/components/academic-events/AcademicEventTypes.ts`.
+- `src/components/academic-events/Heatmap.js`.
+- Tests actuales de importación y renderizado directamente relacionados.
+
+### Mantener intactos
+
+- `src/domain/primitives.ts`.
+- `src/services/backup/BackupImportService.ts`.
+- `src/services/backup/BackupImportDataSource.ts`.
+- `src/services/backup/BackupZipService.ts`.
+- `src/services/backup/BackupZipArchive.ts`.
+- `src/services/MarkdownService.ts`.
+- Schema, migraciones y conexión SQLite.
+- `BackupView`, `BackupImportFlowController` y `BackupImportUI`.
+- `AcademicEventSubjectPicker.js`.
+- `NoteEditor`.
+- `package.json` y lockfile.
+
+---
+
+## 13. Plan de pruebas
+
+### Evidencia de la fase de análisis
+
+Se ejecutaron los tests existentes directamente relacionados con parser, plan, datasource,
+servicio, regresión y renderizadores:
+
+```text
+10 archivos de test
+71 tests aprobados
+```
+
+Se ejecutaron además cuatro pruebas temporales fuera del repositorio para evitar modificar la
+base durante la fase de análisis. Confirmaron:
+
+1. ZIP manipulado -> parser -> nodo DOM controlado.
+2. Inyección de atributo mediante valores persistidos.
+3. Inyección de declaraciones CSS adicionales.
+4. Timestamp inválido -> `RangeError` en Heatmap.
+5. Expansión ZIP sin límite.
+6. Eliminación de `script` y `onerror` por DOMPurify.
+
+### Unitarias requeridas
+
+- IDs válidos, históricos, excesivos y con metacaracteres.
+- Colores válidos/null y payloads CSS rechazados.
+- Fechas reales, bisiestos y timestamps con zona.
+- Tipos incorrectos y caracteres de control.
+- Límites exactos y límite + 1.
+- ZIP `STORE` y `DEFLATE`.
+- ZIP64, multidisk, cifrado, rutas inseguras, duplicados y método desconocido.
+- Tamaño central falsificado y aborto por salida real.
+- Manifest con conteos o booleans inválidos.
+- Cantidad máxima de entidades y campos.
+- Jerarquía de tres niveles, ciclos y padre local que ya es sección.
+
+### Integración y regresión
+
+- Exportador actual -> parser -> preview -> plan -> transacción.
+- Fixture histórica `DEFLATE`.
+- Backup Android real.
+- Conflictos, renombrado y reparaciones existentes.
+- Rechazo antes de cualquier escritura.
+- Rollback transaccional.
+- Feed normal y virtualizado.
+- Drawer activo, archivadas, pickers y eventos académicos.
+- Papelera después de eliminar una entidad importada.
+- Ausencia de nodos, atributos y declaraciones CSS adicionales.
+- Markdown legítimo y payloads de saneamiento actuales.
+- Heatmap resistente a timestamps ya persistidos inválidos.
+
+La fase final debe ejecutar `npm run verify` y validación manual Android.
+
+---
+
+## 14. Fases de implementación propuestas
+
+### Fase 1 — frontera y límites
+
+- Validadores de primitivas.
+- Política central.
+- Preflight ZIP.
+- Extracción secuencial acotada.
+- Regresiones del parser.
+
+Commit propuesto:
+
+```text
+fix(backup): validate and bound imported archives
+```
+
+Esta fase cambia el contrato observable de rechazo y debe presentarse para revisión antes de
+continuar si los límites o compatibilidad difieren de este documento.
+
+### Fase 2 — integridad estructural
+
+- Profundidad máxima de materias/secciones.
+- Ciclos y padres inválidos.
+- Preview de reparaciones.
+
+Commit propuesto:
+
+```text
+fix(backup): enforce imported subject hierarchy
+```
+
+### Fase 3 — defensa en presentación
+
+- Escape contextual.
+- Allowlist de colores en todos los sinks.
+- Selectores seguros.
+- Resistencia ante registros contaminados previamente.
+
+Commit propuesto:
+
+```text
+fix(ui): harden imported data render contexts
+```
+
+### Fase 4 — cierre
+
+- Tests específicos y `npm run verify`.
+- Revisión de diff y commits.
+- Push de `fix/backup-import-security`.
+- PR limpio y documentado.
+- Sin merge a `main`.
+
+---
+
+## 15. Recomendación
+
+Proceder con **un único PR de AUD-003**, dividido internamente en fases y commits revisables.
+
+Separar frontera y renderizadores en PRs independientes dejaría una ventana incompleta:
+
+- solo frontera no neutraliza registros contaminados ya persistidos;
+- solo presentación no limita ZIP bombs ni estructuras inválidas.
+
+El alcance debe mantenerse sin dependencias nuevas, sin cambios estéticos y sin incorporar
+AUD-004. Cualquier modificación a límites, compatibilidad o comportamiento observable debe
+presentarse antes de ampliar la implementación.

--- a/docs/gestion/analisis-aud-003-seguridad-importacion-backups-2026-09-01.md
+++ b/docs/gestion/analisis-aud-003-seguridad-importacion-backups-2026-09-01.md
@@ -1,6 +1,6 @@
 # AUD-003 — Análisis de seguridad de importación de backups
 
-**Estado:** Implementación completa en `fix/backup-import-security`; validación Android final, PR y merge pendientes
+**Estado:** Implementación y validación completas en `fix/backup-import-security`; integración autorizada
 **Rama:** `fix/backup-import-security`
 **Commit base revisado:** `376f7b6` (`main`)
 **Fecha:** 2026-09-01
@@ -677,9 +677,10 @@ producción ni depender de evidencia temporal.
   trazabilidad.
 
 La validación manual Android de Fase 1C fue aprobada para backup actual `STORE`, backup histórico
-`DEFLATE`, fixture de 500 notas y rechazo de `pinned` inválido antes de persistir. La defensa de
-presentación está implementada y automatizada, pero requiere un checkpoint Android final antes de
-crear/fusionar el PR.
+`DEFLATE`, fixture de 500 notas y rechazo de `pinned` inválido antes de persistir. El checkpoint
+Android final fue aprobado por el usuario el 2026-09-02 sobre la implementación completa instalada
+en Samsung SM_G965F. Con ello, la implementación y la validación de AUD-003 están completas y su
+integración quedó autorizada.
 
 ---
 
@@ -694,8 +695,9 @@ crear/fusionar el PR.
 | Fase 3 | `587da3f` | Escape por contexto, allowlist de color, selectores seguros y tolerancia a datos antiguos contaminados. |
 | Fase 4 | `docs(audit): record AUD-003 remediation status` | Verificación acumulativa y cierre documental en este checkpoint. |
 
-La implementación técnica está completa en la rama. Solo quedan el checkpoint Android final, la
-creación del PR por el coordinador y el merge posterior a su aprobación.
+La implementación y la validación están completas. El usuario autorizó su integración el
+2026-09-02; al momento de este commit documental todavía no se había creado el PR ni ejecutado el
+merge.
 
 ---
 
@@ -713,5 +715,6 @@ Ningún PR parcial se considera cierre de AUD-003 ni se fusiona sin evaluar la c
 de frontera y sinks.
 
 El alcance se cerró sin dependencias nuevas, sin cambios estéticos y sin incorporar AUD-004,
-AUD-006, AUD-008 ni AUD-009. Esos hallazgos conservan su prioridad y ramas propias. No se crea ni
-fusiona un PR hasta completar la validación Android final.
+AUD-006, AUD-008 ni AUD-009. Esos hallazgos conservan su prioridad y ramas propias. La validación
+Android final se aprobó el 2026-09-02 y el usuario autorizó la integración; al momento de este commit
+el coordinador aún no había creado el PR ni ejecutado el merge.

--- a/docs/gestion/revision-tecnica-priorizada-2026-09-01.md
+++ b/docs/gestion/revision-tecnica-priorizada-2026-09-01.md
@@ -1,8 +1,8 @@
 # Revisión Técnica Priorizada — 2026-09-01
 
-**Estado:** Vigente — línea de base para remediación incremental  
-**Rama original de auditoría:** `fix/note-save-integrity`  
-**Commit base original revisado:** `cd60c0e` (`main`)  
+**Estado:** Vigente — AUD-003 completo en rama; Android final, PR y merge pendientes
+**Rama original de auditoría:** `fix/note-save-integrity`
+**Commit base original revisado:** `cd60c0e` (`main`)
 **Versión de producto documentada:** `0.4.8` (Beta)  
 **Alcance:** arquitectura, modularidad, seguridad, persistencia, estado, asincronía, pruebas, dependencias y tooling
 
@@ -94,7 +94,7 @@ store, no como métrica integral de toda la aplicación.
 |---|---|---|---|---|
 | AUD-001 | P0 | Pérdida de borrador ante error SQLite | Bug confirmado | Resuelto en PR #2 |
 | AUD-002 | P0 | Guardados duplicados por taps concurrentes | Bug confirmado | Resuelto en PR #2 |
-| AUD-003 | P0 | Inyección HTML persistente desde campos de backup | Seguridad confirmada | Análisis revalidado; implementación pendiente |
+| AUD-003 | P0 | Inyección HTML persistente desde campos de backup | Seguridad confirmada | Implementación completa en rama; Android final/PR/merge pendientes |
 | AUD-004 | P0 | Dependencias vulnerables, incluida DOMPurify en producción | Seguridad/tooling | Pendiente |
 | AUD-005 | P1 | Propiedad global de transacciones y migraciones permisivas | Confiabilidad | Pendiente |
 | AUD-006 | P1 | Resultados async obsoletos sobrescriben vista/cache reciente | Bug de concurrencia | Pendiente |
@@ -161,9 +161,13 @@ botón y crear notas duplicadas o actualizaciones fuera de orden.
 > desarrollado en [AUD-003 — Análisis de seguridad de importación de backups](./analisis-aud-003-seguridad-importacion-backups-2026-09-01.md).
 > La evidencia confirma inyección DOM, atributos, CSS y consumo no acotado; no demostró ejecución
 > JavaScript. También refuta inyección SQL, Markdown crudo y ZIP Slip con escritura arbitraria en
-> el flujo actual. La implementación permanece pendiente en `fix/backup-import-security`.
+> el flujo auditado.
+>
+> **Estado 2026-09-02:** la remediación está completa en `fix/backup-import-security` mediante
+> `405b4dd`, `34224bb`, `e8f0023`, `1246864` y `587da3f`. Quedan la validación Android final, la
+> creación del PR por el coordinador y el merge posterior.
 
-**Evidencia**
+**Evidencia original en la base auditada**
 
 - `src/domain/primitives.ts` define `EntityId`, `HexColor` y fechas como alias directos de
   `string`; los tipos no agregan validación en runtime.
@@ -176,21 +180,22 @@ botón y crear notas duplicadas o actualizaciones fuera de orden.
 
 **Impacto**
 
-Existe inyección HTML almacenada y XSS potencial. El CSP actual reduce algunos mecanismos de
-ejecución inline, pero no sustituye validación ni escape contextual. También son posibles
-alteraciones visuales o del árbol DOM.
+En la base auditada existía inyección HTML almacenada y XSS potencial. El CSP actual reduce algunos
+mecanismos de ejecución inline, pero no sustituye validación ni escape contextual. También son
+posibles alteraciones visuales o del árbol DOM.
 
-El importador carga ZIP y JSON completos en memoria sin límites de tamaño, entradas, entidades o
-longitud, lo que habilita consumo excesivo de memoria mediante archivos especialmente preparados.
+El importador auditado cargaba ZIP y JSON completos en memoria sin límites de tamaño, entradas,
+entidades o longitud, lo que habilita consumo excesivo de memoria mediante archivos especialmente
+preparados.
 
-**Recomendación**
+**Remediación implementada en rama**
 
-- Validar formato y longitud de IDs.
-- Aceptar únicamente colores hexadecimales soportados.
-- Validar fechas reales y longitudes de texto.
-- Definir límites explícitos para archivo, tamaño descomprimido, entradas y entidades.
-- Escapar todas las interpolaciones según contexto HTML/atributo/CSS.
-- Agregar pruebas de seguridad en el parser y renderizadores.
+- ZIP32 con límites explícitos, CRC32 y compatibilidad `STORE`/`DEFLATE`.
+- Validación runtime estricta antes del plan o la persistencia.
+- Jerarquía importada de dos niveles con reparaciones visibles en preview.
+- Escape HTML por contexto, allowlist de color y selectores sin IDs interpolados.
+- Regresiones permanentes para parser, plan, feed normal/virtualizado, drawer, papelera, pickers,
+  eventos académicos y timestamps inválidos.
 
 ### AUD-004 — Dependencias vulnerables
 
@@ -324,8 +329,8 @@ Antes de modificar schema:
 ### AUD-012 — Cohesión y fronteras de features
 
 - `NoteList` funciona como renderer del feed y como router/lifecycle owner de trash, backup y about.
-- `AboutView` importa `escapeHtml` desde `feed/NoteCardRenderer`.
-- Existen al menos seis implementaciones de escape HTML.
+- Fase 3 de AUD-003 eliminó el import cruzado de `AboutView` y centralizó el escape en los sinks
+  afectados; el routing y duplicaciones ajenas al hallazgo permanecen dentro de AUD-012.
 - `src/services/ImportService.js` no tiene consumidor activo, está excluido de coverage e importa el
   store desde servicios, dirección contraria a la responsabilidad esperada.
 - Las reglas de imports están documentadas pero no tienen verificación automatizada.
@@ -396,7 +401,7 @@ test(editor): cover failed and concurrent note saves
 | Orden | Rama sugerida | Resultado esperado |
 |---:|---|---|
 | 1 | `fix/note-save-integrity` | Cerrado en PR #2: AUD-001 y AUD-002 |
-| 2 | `fix/backup-import-security` | Revalidar y corregir AUD-003 con checkpoints aprobados |
+| 2 | `fix/backup-import-security` | Implementado; checkpoint Android final, PR y merge pendientes |
 | 3 | `fix/dependency-security` | Actualizar DOMPurify y dependencias auditadas |
 | 4 | `fix/store-action-contract` | Unificar semántica de errores de mutaciones |
 | 5 | `fix/sqlite-write-coordination` | Aislar transacciones y endurecer migraciones/arranque |
@@ -441,9 +446,21 @@ Resultado consolidado:
 - la rama `fix/note-save-integrity` fue publicada inicialmente en el mismo commit que `main` y este
   documento constituye su primer cambio representativo.
 
+### Cierre automático y manual de AUD-003 — 2026-09-02
+
+- Suites focalizadas de presentación: **11 archivos/75 tests**; suite completa con workaround de
+  Node 26: **60 archivos/955 tests**.
+- Typecheck, lint (**0 errores/3 warnings basales**), build (**117 módulos**) y checks individuales
+  pasan. Bundle gzip total: **189,83 kB / 250 kB**.
+- El agregado `npm run verify` queda no verde solo por los dos localhost del fallback CSP; el fallo
+  normal de Web Storage y esos falsos positivos pertenecen a AUD-009/AUD-008.
+- Android Fase 1C aprobado: `STORE`, `DEFLATE`, 500 notas y rechazo de `pinned` inválido. La defensa
+  de presentación requiere el checkpoint Android final antes del PR/merge.
+
 ## 11. Limitaciones de la revisión
 
-- No se ejecutó benchmark en dispositivo Android ni medición FPS con 500 notas.
+- Se aprobó el escenario funcional Android con 500 notas; no se ejecutó benchmark instrumentado ni
+  medición FPS.
 - No se realizó una auditoría de seguridad externa o pentest completo.
 - La prueba de inyección fue un caso jsdom focalizado, no una explotación end-to-end en WebView.
 - Las carreras async y transaccionales se derivaron del flujo de control y necesitan regresiones
@@ -459,6 +476,6 @@ cohesión de features con cambios pequeños y medidos.
 
 La revisión inicial quedó vinculada al primer fix porque AUD-001 y AUD-002 afectaban el flujo
 central del producto y presentaban la mejor relación entre impacto, riesgo y tamaño de cambio.
-Ambos hallazgos se cerraron posteriormente en la PR #2. La remediación activa continúa con la
-revalidación de AUD-003 en `fix/backup-import-security`; su implementación permanece pendiente de
-aprobación.
+Ambos hallazgos se cerraron posteriormente en la PR #2. AUD-003 quedó implementado y verificado en
+`fix/backup-import-security`; resta el checkpoint Android final antes de que el coordinador cree el
+PR y evalúe su merge. AUD-004 y los demás hallazgos conservan alcance y seguimiento independientes.

--- a/docs/gestion/revision-tecnica-priorizada-2026-09-01.md
+++ b/docs/gestion/revision-tecnica-priorizada-2026-09-01.md
@@ -1,6 +1,6 @@
 # Revisión Técnica Priorizada — 2026-09-01
 
-**Estado:** Vigente — AUD-003 completo en rama; Android final, PR y merge pendientes
+**Estado:** Vigente — AUD-003 con implementación y validación completas; integración autorizada
 **Rama original de auditoría:** `fix/note-save-integrity`
 **Commit base original revisado:** `cd60c0e` (`main`)
 **Versión de producto documentada:** `0.4.8` (Beta)  
@@ -94,7 +94,7 @@ store, no como métrica integral de toda la aplicación.
 |---|---|---|---|---|
 | AUD-001 | P0 | Pérdida de borrador ante error SQLite | Bug confirmado | Resuelto en PR #2 |
 | AUD-002 | P0 | Guardados duplicados por taps concurrentes | Bug confirmado | Resuelto en PR #2 |
-| AUD-003 | P0 | Inyección HTML persistente desde campos de backup | Seguridad confirmada | Implementación completa en rama; Android final/PR/merge pendientes |
+| AUD-003 | P0 | Inyección HTML persistente desde campos de backup | Seguridad confirmada | Implementación y validación completas; integración autorizada |
 | AUD-004 | P0 | Dependencias vulnerables, incluida DOMPurify en producción | Seguridad/tooling | Pendiente |
 | AUD-005 | P1 | Propiedad global de transacciones y migraciones permisivas | Confiabilidad | Pendiente |
 | AUD-006 | P1 | Resultados async obsoletos sobrescriben vista/cache reciente | Bug de concurrencia | Pendiente |
@@ -164,8 +164,10 @@ botón y crear notas duplicadas o actualizaciones fuera de orden.
 > el flujo auditado.
 >
 > **Estado 2026-09-02:** la remediación está completa en `fix/backup-import-security` mediante
-> `405b4dd`, `34224bb`, `e8f0023`, `1246864` y `587da3f`. Quedan la validación Android final, la
-> creación del PR por el coordinador y el merge posterior.
+> `405b4dd`, `34224bb`, `e8f0023`, `1246864` y `587da3f`. El checkpoint Android final fue aprobado
+> por el usuario sobre la implementación completa instalada en Samsung SM_G965F; implementación y
+> validación completas, con integración autorizada. Al momento de este commit aún no se habían
+> creado el PR ni ejecutado el merge.
 
 **Evidencia original en la base auditada**
 
@@ -401,7 +403,7 @@ test(editor): cover failed and concurrent note saves
 | Orden | Rama sugerida | Resultado esperado |
 |---:|---|---|
 | 1 | `fix/note-save-integrity` | Cerrado en PR #2: AUD-001 y AUD-002 |
-| 2 | `fix/backup-import-security` | Implementado; checkpoint Android final, PR y merge pendientes |
+| 2 | `fix/backup-import-security` | Implementación y validación completas; integración autorizada |
 | 3 | `fix/dependency-security` | Actualizar DOMPurify y dependencias auditadas |
 | 4 | `fix/store-action-contract` | Unificar semántica de errores de mutaciones |
 | 5 | `fix/sqlite-write-coordination` | Aislar transacciones y endurecer migraciones/arranque |
@@ -454,8 +456,9 @@ Resultado consolidado:
   pasan. Bundle gzip total: **189,83 kB / 250 kB**.
 - El agregado `npm run verify` queda no verde solo por los dos localhost del fallback CSP; el fallo
   normal de Web Storage y esos falsos positivos pertenecen a AUD-009/AUD-008.
-- Android Fase 1C aprobado: `STORE`, `DEFLATE`, 500 notas y rechazo de `pinned` inválido. La defensa
-  de presentación requiere el checkpoint Android final antes del PR/merge.
+- Android Fase 1C aprobado: `STORE`, `DEFLATE`, 500 notas y rechazo de `pinned` inválido. El
+  checkpoint final fue aprobado el 2026-09-02 sobre la implementación completa instalada en
+  Samsung SM_G965F.
 
 ## 11. Limitaciones de la revisión
 
@@ -476,6 +479,7 @@ cohesión de features con cambios pequeños y medidos.
 
 La revisión inicial quedó vinculada al primer fix porque AUD-001 y AUD-002 afectaban el flujo
 central del producto y presentaban la mejor relación entre impacto, riesgo y tamaño de cambio.
-Ambos hallazgos se cerraron posteriormente en la PR #2. AUD-003 quedó implementado y verificado en
-`fix/backup-import-security`; resta el checkpoint Android final antes de que el coordinador cree el
-PR y evalúe su merge. AUD-004 y los demás hallazgos conservan alcance y seguimiento independientes.
+Ambos hallazgos se cerraron posteriormente en la PR #2. AUD-003 quedó implementado y validado en
+`fix/backup-import-security`; el checkpoint Android final fue aprobado el 2026-09-02 y su
+integración quedó autorizada. Al momento de este commit el coordinador aún no había creado el PR ni
+ejecutado el merge. AUD-004 y los demás hallazgos conservan alcance y seguimiento independientes.

--- a/docs/gestion/revision-tecnica-priorizada-2026-09-01.md
+++ b/docs/gestion/revision-tecnica-priorizada-2026-09-01.md
@@ -94,7 +94,7 @@ store, no como métrica integral de toda la aplicación.
 |---|---|---|---|---|
 | AUD-001 | P0 | Pérdida de borrador ante error SQLite | Bug confirmado | Seleccionado para el primer PR |
 | AUD-002 | P0 | Guardados duplicados por taps concurrentes | Bug confirmado | Seleccionado para el primer PR |
-| AUD-003 | P0 | Inyección HTML persistente desde campos de backup | Seguridad confirmada | Pendiente |
+| AUD-003 | P0 | Inyección HTML persistente desde campos de backup | Seguridad confirmada | Análisis revalidado; implementación pendiente |
 | AUD-004 | P0 | Dependencias vulnerables, incluida DOMPurify en producción | Seguridad/tooling | Pendiente |
 | AUD-005 | P1 | Propiedad global de transacciones y migraciones permisivas | Confiabilidad | Pendiente |
 | AUD-006 | P1 | Resultados async obsoletos sobrescriben vista/cache reciente | Bug de concurrencia | Pendiente |
@@ -156,6 +156,12 @@ botón y crear notas duplicadas o actualizaciones fuera de orden.
 - Probar con una promesa controlada que dos invocaciones concurrentes producen una sola mutación.
 
 ### AUD-003 — Inyección HTML persistente desde backups
+
+> **Revalidación vigente:** el hallazgo se volvió a comprobar sobre `main` en `376f7b6` y quedó
+> desarrollado en [AUD-003 — Análisis de seguridad de importación de backups](./analisis-aud-003-seguridad-importacion-backups-2026-09-01.md).
+> La evidencia confirma inyección DOM, atributos, CSS y consumo no acotado; no demostró ejecución
+> JavaScript. También refuta inyección SQL, Markdown crudo y ZIP Slip con escritura arbitraria en
+> el flujo actual. La implementación permanece pendiente en `fix/backup-import-security`.
 
 **Evidencia**
 

--- a/docs/gestion/revision-tecnica-priorizada-2026-09-01.md
+++ b/docs/gestion/revision-tecnica-priorizada-2026-09-01.md
@@ -1,8 +1,8 @@
 # Revisión Técnica Priorizada — 2026-09-01
 
 **Estado:** Vigente — línea de base para remediación incremental  
-**Rama de trabajo:** `fix/note-save-integrity`  
-**Commit base revisado:** `cd60c0e` (`main`)  
+**Rama original de auditoría:** `fix/note-save-integrity`  
+**Commit base original revisado:** `cd60c0e` (`main`)  
 **Versión de producto documentada:** `0.4.8` (Beta)  
 **Alcance:** arquitectura, modularidad, seguridad, persistencia, estado, asincronía, pruebas, dependencias y tooling
 
@@ -92,8 +92,8 @@ store, no como métrica integral de toda la aplicación.
 
 | ID | Prioridad | Hallazgo | Naturaleza | Estado |
 |---|---|---|---|---|
-| AUD-001 | P0 | Pérdida de borrador ante error SQLite | Bug confirmado | Seleccionado para el primer PR |
-| AUD-002 | P0 | Guardados duplicados por taps concurrentes | Bug confirmado | Seleccionado para el primer PR |
+| AUD-001 | P0 | Pérdida de borrador ante error SQLite | Bug confirmado | Resuelto en PR #2 |
+| AUD-002 | P0 | Guardados duplicados por taps concurrentes | Bug confirmado | Resuelto en PR #2 |
 | AUD-003 | P0 | Inyección HTML persistente desde campos de backup | Seguridad confirmada | Análisis revalidado; implementación pendiente |
 | AUD-004 | P0 | Dependencias vulnerables, incluida DOMPurify en producción | Seguridad/tooling | Pendiente |
 | AUD-005 | P1 | Propiedad global de transacciones y migraciones permisivas | Confiabilidad | Pendiente |
@@ -395,8 +395,8 @@ test(editor): cover failed and concurrent note saves
 
 | Orden | Rama sugerida | Resultado esperado |
 |---:|---|---|
-| 1 | `fix/note-save-integrity` | Cerrar AUD-001 y AUD-002 |
-| 2 | `fix/backup-input-hardening` | Validar importación, limitar ZIP y escapar atributos |
+| 1 | `fix/note-save-integrity` | Cerrado en PR #2: AUD-001 y AUD-002 |
+| 2 | `fix/backup-import-security` | Revalidar y corregir AUD-003 con checkpoints aprobados |
 | 3 | `fix/dependency-security` | Actualizar DOMPurify y dependencias auditadas |
 | 4 | `fix/store-action-contract` | Unificar semántica de errores de mutaciones |
 | 5 | `fix/sqlite-write-coordination` | Aislar transacciones y endurecer migraciones/arranque |
@@ -457,5 +457,8 @@ Lumapse no necesita una nueva arquitectura base. Necesita cerrar primero integri
 límites de confianza y coordinación de persistencia; después puede optimizar reactividad, queries y
 cohesión de features con cambios pequeños y medidos.
 
-La rama actual queda vinculada al primer fix porque AUD-001 y AUD-002 afectan el flujo central del
-producto y presentan la mejor relación entre impacto, riesgo y tamaño de cambio.
+La revisión inicial quedó vinculada al primer fix porque AUD-001 y AUD-002 afectaban el flujo
+central del producto y presentaban la mejor relación entre impacto, riesgo y tamaño de cambio.
+Ambos hallazgos se cerraron posteriormente en la PR #2. La remediación activa continúa con la
+revalidación de AUD-003 en `fix/backup-import-security`; su implementación permanece pendiente de
+aprobación.

--- a/src/components/about/AboutView.js
+++ b/src/components/about/AboutView.js
@@ -1,5 +1,5 @@
 import { APP_METADATA } from '../../config/appMetadata.js'
-import { escapeHtml } from '../feed/NoteCardRenderer.js'
+import { escapeHtmlText as escapeHtml } from '../common/htmlEscaping.js'
 import './AboutView.css'
 
 function renderMetadataItem(label, value) {

--- a/src/components/academic-events/AcademicEventTypes.ts
+++ b/src/components/academic-events/AcademicEventTypes.ts
@@ -7,6 +7,8 @@
 // =============================================================
 
 import type { AcademicEventType } from '../../domain/academicEvents'
+import { escapeHtmlAttribute, escapeHtmlText } from '../common/htmlEscaping.js'
+import { getSafeHexColor, getSafeISODate } from '../common/presentationValidation.js'
 
 interface AcademicEventTypeConfig {
   id: AcademicEventType
@@ -112,32 +114,19 @@ function isAcademicEventType(value: unknown): value is AcademicEventType {
   return typeof value === 'string' && ACADEMIC_EVENT_TYPE_ORDER.includes(value as AcademicEventType)
 }
 
-function escapeHtml(value: unknown): string {
-  return String(value ?? '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;')
-}
-
-function escapeAttribute(value: unknown): string {
-  return escapeHtml(value)
-}
-
 function dateLabel(date: string | null | undefined): string {
-  if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) return ''
+  const safeDate = getSafeISODate(date)
+  if (!safeDate) return ''
 
   const monthLabels = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic']
-  const [, month, day] = date.split('-').map(Number)
+  const [, month, day] = safeDate.split('-').map(Number)
 
-  if (month < 1 || month > 12 || day < 1 || day > 31) return date
   return `${String(day).padStart(2, '0')} ${monthLabels[month - 1]}`
 }
 
 function renderEventActions(event: RenderableAcademicEvent, title: string): string {
-  const eventId = escapeAttribute(event.id || '')
-  const safeTitle = escapeAttribute(title)
+  const eventId = escapeHtmlAttribute(event.id || '')
+  const safeTitle = escapeHtmlAttribute(title)
 
   return `
     <span class="academic-event-item__actions" aria-label="Acciones de fecha academica">
@@ -179,7 +168,9 @@ export function getAcademicEventColor(
   fallbackColor: string | null = null,
 ): string {
   const type = typeof eventOrType === 'string' ? eventOrType : eventOrType?.type
-  return fallbackColor || getAcademicEventType(type)?.color || '#71717a'
+  return getSafeHexColor(fallbackColor)
+    || getSafeHexColor(getAcademicEventType(type)?.color)
+    || '#71717a'
 }
 
 export function renderAcademicEventIcon(type: unknown): string {
@@ -198,10 +189,10 @@ export function renderAcademicEventDot(
 
   return `
     <span class="academic-event-dot academic-event-dot--${type.id}"
-          data-event-type="${escapeAttribute(type.id)}"
-          style="--academic-event-color: ${escapeAttribute(color)}"
-          title="${escapeAttribute(label)}"
-          aria-label="${escapeAttribute(label)}"></span>
+          data-event-type="${escapeHtmlAttribute(type.id)}"
+          style="--academic-event-color: ${color}"
+          title="${escapeHtmlAttribute(label)}"
+          aria-label="${escapeHtmlAttribute(label)}"></span>
   `
 }
 
@@ -216,28 +207,29 @@ export function renderAcademicEventListItem(
   const color = getAcademicEventColor(item, options.color)
   const subjectLabel = options.subjectLabel ?? item.subjectName ?? ''
   const title = item.title || type.label
-  const date = dateLabel(item.date)
+  const safeDate = getSafeISODate(item.date)
+  const date = dateLabel(safeDate)
   const subjectClass = options.subjectArchived
     ? 'academic-event-item__subject academic-event-item__subject--archived'
     : 'academic-event-item__subject'
   const subject = subjectLabel
-    ? `<span class="${subjectClass}">${escapeHtml(subjectLabel)}</span>`
+    ? `<span class="${subjectClass}">${escapeHtmlText(subjectLabel)}</span>`
     : ''
   const actions = options.actions ? renderEventActions(item, title) : ''
   const actionsClass = options.actions ? ' academic-event-item--with-actions' : ''
 
   return `
     <article class="academic-event-item academic-event-item--${type.id}${actionsClass}"
-             data-event-id="${escapeAttribute(item.id || '')}"
-             data-event-type="${escapeAttribute(type.id)}"
-             style="--academic-event-color: ${escapeAttribute(color)}">
+             data-event-id="${escapeHtmlAttribute(item.id || '')}"
+             data-event-type="${escapeHtmlAttribute(type.id)}"
+             style="--academic-event-color: ${color}">
       <span class="academic-event-item__icon" aria-hidden="true">${type.icon}</span>
       <span class="academic-event-item__body">
         <span class="academic-event-item__meta">
-          <time class="academic-event-item__date" datetime="${escapeAttribute(item.date || '')}">${escapeHtml(date)}</time>
-          <span class="academic-event-item__type">${escapeHtml(type.shortLabel)}</span>
+          <time class="academic-event-item__date" datetime="${escapeHtmlAttribute(safeDate || '')}">${escapeHtmlText(date)}</time>
+          <span class="academic-event-item__type">${escapeHtmlText(type.shortLabel)}</span>
         </span>
-        <span class="academic-event-item__title">${escapeHtml(title)}</span>
+        <span class="academic-event-item__title">${escapeHtmlText(title)}</span>
         ${subject}
       </span>
       ${actions}

--- a/src/components/academic-events/Heatmap.js
+++ b/src/components/academic-events/Heatmap.js
@@ -4,6 +4,8 @@
 // =============================================================
 
 import * as NoteStore from '../../store/NoteStore.js'
+import { escapeHtmlText } from '../common/htmlEscaping.js'
+import { getSafeISODate } from '../common/presentationValidation.js'
 import { bindAcademicEventActions } from './AcademicEventActions.js'
 import {
   renderAcademicEventDot,
@@ -17,15 +19,6 @@ import {
 } from './AcademicEventSubjects.js'
 import { openAcademicEventDialog } from './AcademicEventDialog.js'
 import './Heatmap.css'
-
-function escapeHtml(value) {
-  return String(value ?? '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;')
-}
 
 export class Heatmap {
   constructor(containerId) {
@@ -60,7 +53,15 @@ export class Heatmap {
     this.activityMap = {}
     notes.forEach(note => {
       if (!note.updatedAt) return
-      const dateStr = new Date(note.updatedAt).toISOString().split('T')[0]
+      let date
+      try {
+        date = new Date(note.updatedAt)
+      } catch {
+        return
+      }
+      if (!Number.isFinite(date.getTime())) return
+
+      const dateStr = date.toISOString().split('T')[0]
       this.activityMap[dateStr] = (this.activityMap[dateStr] || 0) + 1
     })
   }
@@ -71,8 +72,9 @@ export class Heatmap {
   calculateEventMap(events) {
     this.eventMap = {}
     events.forEach(event => {
-      if (!event.date) return
-      this.eventMap[event.date] = [...(this.eventMap[event.date] || []), event]
+      const date = getSafeISODate(event.date)
+      if (!date) return
+      this.eventMap[date] = [...(this.eventMap[date] || []), event]
     })
 
     Object.keys(this.eventMap).forEach(date => {
@@ -255,7 +257,7 @@ export class Heatmap {
     html += this.renderSelectedDateActions()
 
     if (this.selectedDate) {
-      html += `<button class="heatmap-clear" id="hm-clear" title="Limpiar filtro de fecha">Limpiar filtro: ${escapeHtml(this.selectedDate)}</button>`
+      html += `<button class="heatmap-clear" id="hm-clear" title="Limpiar filtro de fecha">Limpiar filtro: ${escapeHtmlText(this.selectedDate)}</button>`
     }
 
     html += `</div>` // close container

--- a/src/components/common/htmlEscaping.js
+++ b/src/components/common/htmlEscaping.js
@@ -1,0 +1,35 @@
+function toPresentationString(value) {
+  if (value === null || value === undefined) return ''
+
+  try {
+    return String(value)
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Codifica un valor para insertarlo como texto dentro de HTML.
+ * @param {unknown} value Valor de presentacion
+ * @returns {string} Texto codificado
+ */
+export function escapeHtmlText(value) {
+  return toPresentationString(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+/**
+ * Codifica un valor para insertarlo en un atributo HTML entre comillas.
+ * @param {unknown} value Valor de presentacion
+ * @returns {string} Valor de atributo codificado
+ */
+export function escapeHtmlAttribute(value) {
+  return toPresentationString(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}

--- a/src/components/common/presentationValidation.js
+++ b/src/components/common/presentationValidation.js
@@ -1,0 +1,27 @@
+import { parseHexColor, parseISODate } from '../../domain/primitiveValidation.ts'
+
+/**
+ * Devuelve un color CSS apto para presentacion o null si el dato persistido es invalido.
+ * @param {unknown} value Color potencialmente contaminado
+ * @returns {string|null} Color hexadecimal canonico
+ */
+export function getSafeHexColor(value) {
+  try {
+    return parseHexColor(value)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Devuelve una fecha de calendario valida o null para datos persistidos invalidos.
+ * @param {unknown} value Fecha potencialmente contaminada
+ * @returns {string|null} Fecha YYYY-MM-DD valida
+ */
+export function getSafeISODate(value) {
+  try {
+    return parseISODate(value)
+  } catch {
+    return null
+  }
+}

--- a/src/components/feed/NoteCardRenderer.js
+++ b/src/components/feed/NoteCardRenderer.js
@@ -3,9 +3,21 @@
 // Extraído de NoteList.js para reducir LOC.
 // =============================================================
 
+import { escapeHtmlAttribute, escapeHtmlText } from '../common/htmlEscaping.js'
+import { getSafeHexColor } from '../common/presentationValidation.js'
+
+export { escapeHtmlAttribute as escapeHtml }
+
 // UX-03: Timestamps relativos
 export function formatRelativeDate(isoString) {
-  const date = new Date(isoString);
+  let date
+  try {
+    date = new Date(isoString)
+  } catch {
+    return ''
+  }
+  if (!Number.isFinite(date.getTime())) return ''
+
   const now = new Date();
   const diffMs = now - date;
   const diffMins = Math.floor(diffMs / 60000);
@@ -20,17 +32,6 @@ export function formatRelativeDate(isoString) {
     
   // Fallback: ej. "16 may 2026"
   return date.toLocaleDateString('es-ES', { day: 'numeric', month: 'short', year: 'numeric' });
-}
-
-// Prevenir inyección de HTML en campos de texto puro
-export function escapeHtml(unsafe) {
-  if (!unsafe) return '';
-  return unsafe
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
 }
 
 /**
@@ -65,18 +66,21 @@ export function findSubject(subjectId, subjectsData) {
 export function renderMoveItem(noteId, subjectId, label, color, isCurrent, isChild = false) {
   const currentClass = isCurrent ? ' note-card__dropdown-btn--current' : ''
   const childClass = isChild ? ' note-card__dropdown-btn--child' : ''
-  const colorDot = color
-    ? `<span class="note-card__move-color" style="background-color: ${color}"></span>`
-    : `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 16 12 14 15 10 15 8 12 2 12"></polyline><path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"></path></svg>`
+  const safeColor = getSafeHexColor(color)
+  const colorDot = safeColor
+    ? `<span class="note-card__move-color" style="background-color: ${safeColor}"></span>`
+    : subjectId
+      ? '<span class="note-card__move-color"></span>'
+      : `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 16 12 14 15 10 15 8 12 2 12"></polyline><path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"></path></svg>`
   const check = isCurrent ? ' ✓' : ''
 
   return `
-    <button class="note-card__dropdown-btn${childClass} js-btn-move-to${currentClass}" title="Mover a ${escapeHtml(label)}"
-            data-note-id="${noteId}"
-            data-subject-id="${subjectId}"
+    <button class="note-card__dropdown-btn${childClass} js-btn-move-to${currentClass}" title="Mover a ${escapeHtmlAttribute(label)}"
+            data-note-id="${escapeHtmlAttribute(noteId)}"
+            data-subject-id="${escapeHtmlAttribute(subjectId)}"
             ${isCurrent ? 'disabled' : ''}>
       ${colorDot}
-      ${escapeHtml(label)}${check}
+      ${escapeHtmlText(label)}${check}
     </button>
   `
 }
@@ -98,9 +102,11 @@ export function buildMoveMenu(noteId, currentSubjectId, subjectsData) {
   // Materias del árbol
   if (subjectsData && subjectsData.tree) {
     for (const subject of subjectsData.tree) {
-      items.push(renderMoveItem(noteId, subject.id, subject.name, subject.color, currentSubjectId === subject.id))
+      const subjectColor = getSafeHexColor(subject.color)
+      items.push(renderMoveItem(noteId, subject.id, subject.name, subjectColor, currentSubjectId === subject.id))
       for (const child of (subject.children || [])) {
-        items.push(renderMoveItem(noteId, child.id, child.name, child.color || subject.color, currentSubjectId === child.id, true))
+        const childColor = getSafeHexColor(child.color) || subjectColor
+        items.push(renderMoveItem(noteId, child.id, child.name, childColor, currentSubjectId === child.id, true))
       }
     }
   }

--- a/src/components/feed/NoteList.js
+++ b/src/components/feed/NoteList.js
@@ -6,7 +6,9 @@
 import * as NoteStore from '../../store/NoteStore.js';
 import * as MarkdownService from '../../services/MarkdownService.ts';
 import { getNoteContentPresentation } from '../../services/NoteTitleService.ts';
-import { formatRelativeDate, escapeHtml, findSubject, buildMoveMenu } from './NoteCardRenderer.js';
+import { escapeHtmlAttribute, escapeHtmlText } from '../common/htmlEscaping.js';
+import { getSafeHexColor } from '../common/presentationValidation.js';
+import { formatRelativeDate, findSubject, buildMoveMenu } from './NoteCardRenderer.js';
 import { createFeedActionRouter } from './FeedActionRouter.js';
 import { renderTrashView } from './TrashView.js';
 import { BackupView } from '../backup/BackupView.js';
@@ -26,7 +28,7 @@ function renderImplicitTitleBlock(note) {
     ? MarkdownService.renderMarkdown(bodyMarkdown, { lineOffset: titlePresentation.lineOffset || 0 })
     : '';
   const titleHtml = titlePresentation.title
-    ? `<h2 class="note-card__implicit-title">${escapeHtml(titlePresentation.title)}</h2>`
+    ? `<h2 class="note-card__implicit-title">${escapeHtmlText(titlePresentation.title)}</h2>`
     : '';
 
   return `${titleHtml}${renderedContent}`;
@@ -36,12 +38,11 @@ function renderSubjectBadge(note, subjectsData) {
   const found = findSubject(note.subjectId, subjectsData);
   if (!found) return '';
 
-  const color = found.subject.color || (found.parent ? found.parent.color : '');
+  const color = getSafeHexColor(found.subject.color) || getSafeHexColor(found.parent?.color);
   const label = found.parent
-    ? `${escapeHtml(found.parent.name)} \u203A ${escapeHtml(found.subject.name)}`
-    : escapeHtml(found.subject.name);
-
-  return `<span class="note-card__subject-badge" style="--subject-color: ${color}">${label}</span>`;
+    ? `${escapeHtmlText(found.parent.name)} \u203A ${escapeHtmlText(found.subject.name)}`
+    : escapeHtmlText(found.subject.name);
+  return `<span class="note-card__subject-badge"${color ? ` style="--subject-color: ${color}"` : ''}>${label}</span>`;
 }
 
 function renderEmptyState(state) {
@@ -55,14 +56,14 @@ function renderEmptyState(state) {
   let copy = 'Escribí una idea arriba o asignala a una materia cuando la guardes.';
 
   if (query) {
-    title = `No encontramos notas para "${escapeHtml(query)}".`;
+    title = `No encontramos notas para "${escapeHtmlText(query)}".`;
     copy = 'Probá con otra palabra o limpiá la búsqueda para volver al feed.';
   } else if (state.dateFilter) {
     title = 'No hay notas en esta fecha.';
     copy = 'El calendario sigue marcando actividad cuando guardes apuntes ese día.';
   } else if (state.viewMode === 'subject') {
     title = activeSubject
-      ? `${escapeHtml(activeSubject.name)} todavía no tiene notas.`
+      ? `${escapeHtmlText(activeSubject.name)} todavía no tiene notas.`
       : 'Esta materia todavía no tiene notas.';
     copy = 'Guardá la próxima idea con esta materia seleccionada.';
   } else if (state.viewMode === 'archived') {
@@ -257,10 +258,10 @@ export class NoteList {
     // Usar MarkdownService para renderizar el contenido completo de forma segura
     const renderedContent = renderImplicitTitleBlock(note);
     const timeStr = formatRelativeDate(note.updatedAt);
-    const isPinned = note.pinned;
-    const isArchived = note.archived;
+    const { pinned: isPinned, archived: isArchived } = note;
     const pinLabel = isPinned ? 'Desfijar' : 'Fijar';
     const archiveLabel = isArchived ? 'Desarchivar' : 'Archivar';
+    const noteId = escapeHtmlAttribute(note.id);
 
     // Badge de archivo
     const archivedBadge = isArchived
@@ -274,11 +275,11 @@ export class NoteList {
       : '';
 
     return `
-      <article class="note-card${isPinned ? ' note-card--pinned' : ''}" data-id="${note.id}">
+      <article class="note-card${isPinned ? ' note-card--pinned' : ''}" data-id="${noteId}">
         <header class="note-card__header">
           <span class="note-card__time">
             ${isPinned ? '<svg class="note-card__pin-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.15" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 2l-4 4-6-2-2 2 5 5-5 7 2 2 7-5 5 5 2-2-2-6 4-4z"></path></svg>' : ''}
-            ${timeStr}
+            ${escapeHtmlText(timeStr)}
             ${renderSubjectBadge(note, subjectsData)}
             ${archivedBadge}
             ${statusBadge}
@@ -297,11 +298,11 @@ export class NoteList {
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"></circle><circle cx="12" cy="5" r="1"></circle><circle cx="12" cy="19" r="1"></circle></svg>
             </button>
             <div class="note-card__dropdown">
-              <button class="note-card__dropdown-btn js-btn-pin" data-id="${note.id}" title="${pinLabel} nota">
+              <button class="note-card__dropdown-btn js-btn-pin" data-id="${noteId}" title="${pinLabel} nota">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 2l-4 4-6-2-2 2 5 5-5 7 2 2 7-5 5 5 2-2-2-6 4-4z"/></svg>
                 ${pinLabel}
               </button>
-              <button class="note-card__dropdown-btn js-btn-archive" data-id="${note.id}" title="${archiveLabel} nota">
+              <button class="note-card__dropdown-btn js-btn-archive" data-id="${noteId}" title="${archiveLabel} nota">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="21 8 21 21 3 21 3 8"></polyline><rect x="1" y="3" width="22" height="5"></rect><line x1="10" y1="12" x2="14" y2="12"></line></svg>
                 ${archiveLabel}
               </button>
@@ -315,15 +316,15 @@ export class NoteList {
                   ${buildMoveMenu(note.id, note.subjectId, subjectsData)}
                 </div>
               </div>
-              <button class="note-card__dropdown-btn js-btn-edit" data-id="${note.id}" title="Editar nota">
+              <button class="note-card__dropdown-btn js-btn-edit" data-id="${noteId}" title="Editar nota">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
                 Editar
               </button>
-              <button class="note-card__dropdown-btn js-btn-copy" data-id="${note.id}" title="Copiar nota">
+              <button class="note-card__dropdown-btn js-btn-copy" data-id="${noteId}" title="Copiar nota">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
                 Copiar
               </button>
-              <button class="note-card__dropdown-btn note-card__dropdown-btn--delete js-btn-delete" data-id="${note.id}" title="Eliminar nota">
+              <button class="note-card__dropdown-btn note-card__dropdown-btn--delete js-btn-delete" data-id="${noteId}" title="Eliminar nota">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>
                 Eliminar
               </button>

--- a/src/components/feed/NoteStatus.js
+++ b/src/components/feed/NoteStatus.js
@@ -6,6 +6,8 @@
 // conservar compatibilidad con notas existentes. La UI renderiza SVGs
 // lineales propios para mantener una estética consistente con Lumapse.
 
+import { escapeHtmlAttribute } from '../common/htmlEscaping.js'
+
 const STATUS_ICONS = {
   reading: `
     <svg class="note-status-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
@@ -68,14 +70,6 @@ export const NOTE_STATUSES = [
   },
 ]
 
-function escapeAttribute(value) {
-  return String(value ?? '')
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-}
-
 export function getNoteStatus(value) {
   return NOTE_STATUSES.find(status => status.value === value) || null
 }
@@ -86,24 +80,24 @@ export function renderNoteStatusBadge(value) {
 
   return `
     <span class="note-card__status-badge note-card__status-badge--${status.id}"
-          title="${escapeAttribute(status.label)}"
-          aria-label="${escapeAttribute(status.label)}">
+          title="${escapeHtmlAttribute(status.label)}"
+          aria-label="${escapeHtmlAttribute(status.label)}">
       ${status.icon}
     </span>
   `
 }
 
 export function renderNoteStatusMenuItems(noteId, currentValue) {
-  const safeNoteId = escapeAttribute(noteId)
+  const safeNoteId = escapeHtmlAttribute(noteId)
 
   return NOTE_STATUSES.map(status => {
     const currentClass = currentValue === status.value ? ' note-card__status-btn--current' : ''
     return `
       <button class="note-card__status-btn js-btn-status${currentClass}"
               data-note-id="${safeNoteId}"
-              data-emoji="${escapeAttribute(status.value)}"
-              title="${escapeAttribute(status.label)}"
-              aria-label="${escapeAttribute(status.label)}">
+              data-emoji="${escapeHtmlAttribute(status.value)}"
+              title="${escapeHtmlAttribute(status.label)}"
+              aria-label="${escapeHtmlAttribute(status.label)}">
         ${status.icon}
       </button>
     `
@@ -113,7 +107,7 @@ export function renderNoteStatusMenuItems(noteId, currentValue) {
 export function renderClearNoteStatusButton(noteId) {
   return `
     <button class="note-card__status-btn js-btn-status"
-            data-note-id="${escapeAttribute(noteId)}"
+            data-note-id="${escapeHtmlAttribute(noteId)}"
             data-emoji=""
             title="Quitar estado"
             aria-label="Quitar estado">

--- a/src/components/feed/TrashView.js
+++ b/src/components/feed/TrashView.js
@@ -4,7 +4,14 @@
 // =============================================================
 
 import * as SubjectService from '../../services/SubjectService.js';
-import { escapeHtml } from './NoteCardRenderer.js';
+import { escapeHtmlAttribute, escapeHtmlText } from '../common/htmlEscaping.js';
+import { getSafeHexColor } from '../common/presentationValidation.js';
+
+function renderSubjectColor(color, fallbackColor = null) {
+  const safeColor = getSafeHexColor(color) || getSafeHexColor(fallbackColor);
+  const style = safeColor ? ` style="background-color: ${safeColor}"` : '';
+  return `<span class="drawer__subject-color"${style}></span>`;
+}
 
 function createDuplicateLabeler(getBaseName) {
   const seen = new Map();
@@ -50,7 +57,7 @@ function renderTrashHeader(totalCount) {
       <h2 class="trash-header__title">
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>
         Papelera de reciclaje
-        <span class="trash-header__count">${totalCount}</span>
+        <span class="trash-header__count">${escapeHtmlText(totalCount)}</span>
       </h2>
       <button class="trash-header__empty js-btn-empty-trash" title="Vaciar papelera">Vaciar papelera</button>
     </div>
@@ -61,10 +68,10 @@ function renderDeletedSubjectChild(child, subject) {
   return `
     <div class="trash-item trash-item--section trash-item--nested">
       <div class="trash-item__info">
-        <span class="drawer__subject-color" style="background-color: ${child.color || subject.color}"></span>
-        <span class="trash-item__name">${escapeHtml(child.name)}</span>
-        <span class="trash-item__meta">${child.noteCount || 0} nota(s) · incluida en la materia eliminada</span>
-        <span class="trash-item__date">${formatDeletedAgo(child.deletedAt)}</span>
+        ${renderSubjectColor(child.color, subject.color)}
+        <span class="trash-item__name">${escapeHtmlText(child.name)}</span>
+        <span class="trash-item__meta">${escapeHtmlText(child.noteCount || 0)} nota(s) · incluida en la materia eliminada</span>
+        <span class="trash-item__date">${escapeHtmlText(formatDeletedAgo(child.deletedAt))}</span>
       </div>
     </div>
   `;
@@ -78,13 +85,13 @@ function renderDeletedSubject(subject) {
   const subjectRow = `
     <div class="trash-item trash-item--subject">
       <div class="trash-item__info">
-        <span class="drawer__subject-color" style="background-color: ${subject.color}"></span>
-        <span class="trash-item__name">${escapeHtml(subject.name)}</span>
-        <span class="trash-item__meta">${totalNotes} nota(s)${sectionsInfo}</span>
-        <span class="trash-item__date">${formatDeletedAgo(subject.deletedAt)}</span>
+        ${renderSubjectColor(subject.color)}
+        <span class="trash-item__name">${escapeHtmlText(subject.name)}</span>
+        <span class="trash-item__meta">${escapeHtmlText(totalNotes)} nota(s)${escapeHtmlText(sectionsInfo)}</span>
+        <span class="trash-item__date">${escapeHtmlText(formatDeletedAgo(subject.deletedAt))}</span>
       </div>
       <div class="trash-item__actions">
-        <button class="trash-item__btn trash-item__btn--restore js-btn-restore-subject" data-id="${subject.id}" title="Restaurar materia completa">
+        <button class="trash-item__btn trash-item__btn--restore js-btn-restore-subject" data-id="${escapeHtmlAttribute(subject.id)}" title="Restaurar materia completa">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="1 4 1 10 7 10"></polyline><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"></path></svg>
           Restaurar
         </button>
@@ -106,13 +113,13 @@ function renderDeletedSection(section) {
   return `
     <div class="trash-item trash-item--section">
       <div class="trash-item__info">
-        <span class="drawer__subject-color" style="background-color: ${section.color || section.parentColor}"></span>
-        <span class="trash-item__name">${escapeHtml(section.name)}</span>
-        <span class="trash-item__meta">${section.noteCount || 0} nota(s) · ${escapeHtml(section.parentName)}</span>
-        <span class="trash-item__date">${formatDeletedAgo(section.deletedAt)}</span>
+        ${renderSubjectColor(section.color, section.parentColor)}
+        <span class="trash-item__name">${escapeHtmlText(section.name)}</span>
+        <span class="trash-item__meta">${escapeHtmlText(section.noteCount || 0)} nota(s) · ${escapeHtmlText(section.parentName)}</span>
+        <span class="trash-item__date">${escapeHtmlText(formatDeletedAgo(section.deletedAt))}</span>
       </div>
       <div class="trash-item__actions">
-        <button class="trash-item__btn trash-item__btn--restore js-btn-restore-section" data-id="${section.id}" title="Restaurar sección">
+        <button class="trash-item__btn trash-item__btn--restore js-btn-restore-section" data-id="${escapeHtmlAttribute(section.id)}" title="Restaurar sección">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="1 4 1 10 7 10"></polyline><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"></path></svg>
           Restaurar
         </button>
@@ -133,15 +140,15 @@ function renderDeletedNote(note, getDisplayName) {
   return `
     <div class="trash-item">
       <div class="trash-item__info">
-        <span class="trash-item__name">${escapeHtml(getDisplayName(note))}</span>
-        <span class="trash-item__preview">${escapeHtml(preview)}</span>
-        <span class="trash-item__date">${formatDeletedAgo(note.deletedAt)}</span>
+        <span class="trash-item__name">${escapeHtmlText(getDisplayName(note))}</span>
+        <span class="trash-item__preview">${escapeHtmlText(preview)}</span>
+        <span class="trash-item__date">${escapeHtmlText(formatDeletedAgo(note.deletedAt))}</span>
       </div>
       <div class="trash-item__actions">
-        <button class="trash-item__btn trash-item__btn--restore js-btn-restore" data-id="${note.id}" title="Restaurar nota">
+        <button class="trash-item__btn trash-item__btn--restore js-btn-restore" data-id="${escapeHtmlAttribute(note.id)}" title="Restaurar nota">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="1 4 1 10 7 10"></polyline><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"></path></svg>
         </button>
-        <button class="trash-item__btn trash-item__btn--danger js-btn-permanent-delete" data-id="${note.id}" title="Eliminar permanentemente">
+        <button class="trash-item__btn trash-item__btn--danger js-btn-permanent-delete" data-id="${escapeHtmlAttribute(note.id)}" title="Eliminar permanentemente">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
         </button>
       </div>

--- a/src/components/note-editor/SubjectPicker.js
+++ b/src/components/note-editor/SubjectPicker.js
@@ -3,6 +3,9 @@
 // Selector compacto de materias para el composer.
 // =============================================================
 
+import { escapeHtmlAttribute, escapeHtmlText } from '../common/htmlEscaping.js';
+import { getSafeHexColor } from '../common/presentationValidation.js';
+
 export class SubjectPicker {
   constructor(root) {
     this.root = root;
@@ -90,10 +93,11 @@ export class SubjectPicker {
   buildOptions(subjectsData) {
     const options = [{ id: '', label: 'Entrada', color: '', isChild: false }];
     for (const subject of subjectsData.tree) {
+      const subjectColor = getSafeHexColor(subject.color) || '';
       options.push({
         id: subject.id,
         label: subject.name,
-        color: subject.color || '',
+        color: subjectColor,
         isChild: false,
       });
 
@@ -101,7 +105,7 @@ export class SubjectPicker {
         options.push({
           id: child.id,
           label: child.name,
-          color: child.color || subject.color || '',
+          color: getSafeHexColor(child.color) || subjectColor,
           isChild: true,
         });
       }
@@ -117,21 +121,22 @@ export class SubjectPicker {
       const selected = option.id === selectedValue;
       const childClass = option.isChild ? ' composer__subject-option--child' : '';
       const inboxClass = option.id ? '' : ' composer__subject-option--inbox';
-      const dotStyle = option.color ? ` style="--subject-color: ${this.escapeAttribute(option.color)}"` : '';
-      const safeLabel = this.escapeAttribute(option.label);
+      const safeColor = getSafeHexColor(option.color);
+      const dotStyle = safeColor ? ` style="--subject-color: ${safeColor}"` : '';
+      const safeLabel = escapeHtmlAttribute(option.label);
 
       return `
         <button
           class="composer__subject-option${childClass}${inboxClass}"
           type="button"
           role="option"
-          data-subject-id="${this.escapeAttribute(option.id)}"
+          data-subject-id="${escapeHtmlAttribute(option.id)}"
           aria-selected="${selected}"
           aria-label="${safeLabel}"
           title="${safeLabel}"
         >
           <span class="composer__subject-option-dot"${dotStyle}></span>
-          <span class="composer__subject-option-label">${this.escapeHtml(option.label)}</span>
+          <span class="composer__subject-option-label">${escapeHtmlText(option.label)}</span>
         </button>
       `;
     }).join('');
@@ -146,7 +151,12 @@ export class SubjectPicker {
 
     this.input.value = selected.id;
     this.label.textContent = selected.label;
-    this.trigger.style.setProperty('--subject-color', selected.color || 'var(--color-accent)');
+    const safeColor = getSafeHexColor(selected.color);
+    if (safeColor) {
+      this.trigger.style.setProperty('--subject-color', safeColor);
+    } else {
+      this.trigger.style.removeProperty('--subject-color');
+    }
     this.trigger.classList.toggle('composer__subject-trigger--inbox', !selected.id);
 
     if (renderMenu) {
@@ -160,15 +170,6 @@ export class SubjectPicker {
 
   getValue() {
     return this.input?.value || '';
-  }
-
-  escapeHtml(text) {
-    if (!text) return '';
-    return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  }
-
-  escapeAttribute(text) {
-    return this.escapeHtml(text).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   }
 
   destroy() {

--- a/src/domain/primitiveValidation.ts
+++ b/src/domain/primitiveValidation.ts
@@ -1,0 +1,200 @@
+import type {
+  EntityId,
+  HexColor,
+  ISODateString,
+  ISODateTimeString,
+} from './primitives'
+
+const OPAQUE_ID_FORMAT = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/u
+const HEX_COLOR_FORMAT = /^#[0-9A-Fa-f]{6}$/u
+const ISO_DATE_FORMAT = /^(\d{4})-(\d{2})-(\d{2})$/u
+const RFC3339_FORMAT = /^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})(\.\d+)?([Zz]|[+-](\d{2}):(\d{2}))$/u
+
+export class PrimitiveValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PrimitiveValidationError'
+  }
+}
+
+export interface BoundedOneLineTextOptions {
+  maxCodePoints: number
+  trim?: boolean
+  allowEmpty?: boolean
+}
+
+function invalid(message: string): never {
+  throw new PrimitiveValidationError(message)
+}
+
+function assertLimit(limit: number, unit: string): void {
+  if (!Number.isSafeInteger(limit) || limit < 0) {
+    throw new RangeError(`El limite de ${unit} debe ser un entero no negativo.`)
+  }
+}
+
+function exceedsCodePointLimit(value: string, limit: number): boolean {
+  let count = 0
+  for (let index = 0; index < value.length;) {
+    const codePoint = value.codePointAt(index) || 0
+    index += codePoint > 0xffff ? 2 : 1
+    count += 1
+    if (count > limit) return true
+  }
+  return false
+}
+
+function hasOneLineControl(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) || 0
+    if (
+      codePoint <= 0x1f ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      codePoint === 0x2028 || codePoint === 0x2029
+    ) return true
+  }
+  return false
+}
+
+function hasContentControl(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) || 0
+    const forbiddenC0 = codePoint <= 0x08 ||
+      (codePoint >= 0x0b && codePoint <= 0x0c) ||
+      (codePoint >= 0x0e && codePoint <= 0x1f)
+    if (forbiddenC0 || (codePoint >= 0x7f && codePoint <= 0x9f)) return true
+  }
+  return false
+}
+
+function utf8Width(character: string): number {
+  const codePoint = character.codePointAt(0) || 0
+  if (codePoint <= 0x7f) return 1
+  if (codePoint <= 0x7ff) return 2
+  if (codePoint <= 0xffff) return 3
+  return 4
+}
+
+function exceedsUtf8ByteLimit(value: string, limit: number): boolean {
+  let bytes = 0
+  for (const character of value) {
+    bytes += utf8Width(character)
+    if (bytes > limit) return true
+  }
+  return false
+}
+
+function isLeapYear(year: number): boolean {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0)
+}
+
+function isRealCalendarDate(year: number, month: number, day: number): boolean {
+  if (year < 1 || month < 1 || month > 12 || day < 1) return false
+  const daysByMonth = [31, isLeapYear(year) ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+  return day <= daysByMonth[month - 1]
+}
+
+export function parseOpaqueId(value: unknown, maxAsciiCharacters: number): EntityId {
+  assertLimit(maxAsciiCharacters, 'caracteres ASCII')
+  if (typeof value !== 'string') return invalid('debe ser un ID string')
+  if (hasOneLineControl(value)) return invalid('no puede contener caracteres de control')
+
+  const normalized = value.trim()
+  if (
+    !normalized ||
+    normalized.length > maxAsciiCharacters ||
+    !OPAQUE_ID_FORMAT.test(normalized)
+  ) {
+    return invalid('debe ser un ID ASCII opaco valido')
+  }
+  return normalized
+}
+
+export function parseHexColor(value: unknown): HexColor | null {
+  if (value === null) return null
+  if (typeof value !== 'string' || !HEX_COLOR_FORMAT.test(value)) {
+    return invalid('debe ser null o un color hexadecimal de seis digitos')
+  }
+  return value.toLowerCase()
+}
+
+export function parseISODate(value: unknown): ISODateString {
+  if (typeof value !== 'string') return invalid('debe ser una fecha YYYY-MM-DD')
+  const match = ISO_DATE_FORMAT.exec(value)
+  if (!match) return invalid('debe ser una fecha YYYY-MM-DD')
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  if (!isRealCalendarDate(year, month, day)) {
+    return invalid('debe ser una fecha de calendario real')
+  }
+  return value
+}
+
+export function parseRFC3339Timestamp(value: unknown): ISODateTimeString {
+  if (typeof value !== 'string') return invalid('debe ser un timestamp RFC 3339 con zona')
+  const match = RFC3339_FORMAT.exec(value)
+  if (!match) return invalid('debe ser un timestamp RFC 3339 con zona')
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  const hour = Number(match[4])
+  const minute = Number(match[5])
+  const second = Number(match[6])
+  const offsetHour = Number(match[9] || 0)
+  const offsetMinute = Number(match[10] || 0)
+
+  if (
+    !isRealCalendarDate(year, month, day) ||
+    hour > 23 || minute > 59 || second > 59 ||
+    offsetHour > 23 || offsetMinute > 59
+  ) {
+    return invalid('contiene componentes de fecha, hora o zona invalidos')
+  }
+
+  const canonical = `${match[1]}-${match[2]}-${match[3]}T${match[4]}:${match[5]}:${match[6]}`
+    + `${match[7] || ''}${match[8].toUpperCase()}`
+  const instant = Date.parse(canonical)
+  if (!Number.isFinite(instant)) return invalid('no representa un instante finito')
+  return new Date(instant).toISOString()
+}
+
+export function parseBoundedOneLineText(
+  value: unknown,
+  options: BoundedOneLineTextOptions,
+): string {
+  assertLimit(options.maxCodePoints, 'code points')
+  if (typeof value !== 'string') return invalid('debe ser texto de una linea')
+
+  if (hasOneLineControl(value)) {
+    return invalid('no puede contener controles ni saltos de linea')
+  }
+  if (exceedsCodePointLimit(value, options.maxCodePoints)) {
+    return invalid('supera el limite de code points')
+  }
+  const normalized = options.trim ? value.trim() : value
+  if (options.allowEmpty === false && normalized.length === 0) {
+    return invalid('no puede estar vacio')
+  }
+  return normalized
+}
+
+export function parseUtf8ByteBoundedContent(value: unknown, maxBytes: number): string {
+  assertLimit(maxBytes, 'bytes UTF-8')
+  if (typeof value !== 'string') return invalid('debe ser contenido de texto')
+  if (hasContentControl(value)) {
+    return invalid('contiene caracteres de control no permitidos')
+  }
+  if (exceedsUtf8ByteLimit(value, maxBytes)) {
+    return invalid('supera el limite de bytes UTF-8')
+  }
+  return value
+}
+
+export function parseLegacyBoolean(value: unknown): boolean {
+  if (value === true || value === 1 || value === 'true' || value === '1') return true
+  if (value === false || value === 0 || value === 'false' || value === '0') return false
+  return invalid('debe ser un boolean legacy exacto')
+}

--- a/src/layout/appShell.js
+++ b/src/layout/appShell.js
@@ -165,14 +165,4 @@ export function renderAppShell() {
   `
 }
 
-/**
- * Escapa HTML para prevenir XSS en textos renderizados dinámicamente.
- * @param {string} text Texto a escapar
- * @returns {string} Texto con entidades HTML escapadas
- */
-export function escapeHtml(text) {
-  if (!text) return ''
-  const div = document.createElement('div')
-  div.textContent = text
-  return div.innerHTML
-}
+export { escapeHtmlText as escapeHtml } from '../components/common/htmlEscaping.js'

--- a/src/layout/drawerArchivedSubjects.js
+++ b/src/layout/drawerArchivedSubjects.js
@@ -3,7 +3,8 @@
 // =============================================================
 
 import { confirmDialog } from '../components/common/ConfirmDialog.js'
-import { escapeHtml } from './appShell.js'
+import { escapeHtmlAttribute, escapeHtmlText } from '../components/common/htmlEscaping.js'
+import { getSafeHexColor } from '../components/common/presentationValidation.js'
 
 /**
  * Renderiza las materias archivadas con opción de desarchivar.
@@ -16,12 +17,17 @@ export function renderArchivedSubjects(archivedData) {
   }
 
   return archivedData.tree.map(subject => {
+    const subjectColor = getSafeHexColor(subject.color)
+    const subjectOpacity = subject.archived ? '0.5' : '1'
+    const subjectColorStyle = subjectColor
+      ? `background-color: ${subjectColor}; opacity: ${subjectOpacity}`
+      : `opacity: ${subjectOpacity}`
     const rootButton = subject.archived
       ? `
           <button class="drawer__section-add drawer__section-add--visible js-btn-unarchive-subject"
-                  data-subject-id="${subject.id}"
+                  data-subject-id="${escapeHtmlAttribute(subject.id)}"
                   data-is-section="false"
-                  data-subject-name="${escapeHtml(subject.name)}"
+                  data-subject-name="${escapeHtmlAttribute(subject.name)}"
                   title="Desarchivar materia">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <polyline points="21 8 21 21 3 21 3 8"></polyline>
@@ -33,35 +39,42 @@ export function renderArchivedSubjects(archivedData) {
         `
       : ''
 
-    const childrenHtml = (subject.children || []).map(child => `
-      <div class="drawer__subject-row drawer__subject-row--child">
-        <div class="drawer__subject-btn drawer__subject-btn--child drawer__subject-btn--archived">
-          <span class="drawer__subject-color" style="background-color: ${child.color || subject.color}; opacity: 0.5"></span>
-          <span class="drawer__subject-name">${escapeHtml(child.name)}</span>
-          <span class="drawer__subject-count">${child.noteCount || 0}</span>
+    const childrenHtml = (subject.children || []).map(child => {
+      const childColor = getSafeHexColor(child.color) || subjectColor
+      const childColorStyle = childColor
+        ? `background-color: ${childColor}; opacity: 0.5`
+        : 'opacity: 0.5'
+
+      return `
+        <div class="drawer__subject-row drawer__subject-row--child">
+          <div class="drawer__subject-btn drawer__subject-btn--child drawer__subject-btn--archived">
+            <span class="drawer__subject-color" style="${childColorStyle}"></span>
+            <span class="drawer__subject-name">${escapeHtmlText(child.name)}</span>
+            <span class="drawer__subject-count">${escapeHtmlText(child.noteCount || 0)}</span>
+          </div>
+          <button class="drawer__section-add drawer__section-add--visible js-btn-unarchive-subject"
+                  data-subject-id="${escapeHtmlAttribute(child.id)}"
+                  data-is-section="true"
+                  data-subject-name="${escapeHtmlAttribute(child.name)}"
+                  title="Desarchivar sección">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="21 8 21 21 3 21 3 8"></polyline>
+              <rect x="1" y="3" width="22" height="5"></rect>
+              <line x1="12" y1="12" x2="12" y2="18"></line>
+              <polyline points="9 15 12 12 15 15"></polyline>
+            </svg>
+          </button>
         </div>
-        <button class="drawer__section-add drawer__section-add--visible js-btn-unarchive-subject"
-                data-subject-id="${child.id}"
-                data-is-section="true"
-                data-subject-name="${escapeHtml(child.name)}"
-                title="Desarchivar sección">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <polyline points="21 8 21 21 3 21 3 8"></polyline>
-            <rect x="1" y="3" width="22" height="5"></rect>
-            <line x1="12" y1="12" x2="12" y2="18"></line>
-            <polyline points="9 15 12 12 15 15"></polyline>
-          </svg>
-        </button>
-      </div>
-    `).join('')
+      `
+    }).join('')
 
     return `
       <div class="drawer__subject-group drawer__subject-group--archived">
         <div class="drawer__subject-row">
           <div class="drawer__subject-btn ${subject.archived ? 'drawer__subject-btn--archived' : 'drawer__subject-btn--archive-context'}">
-            <span class="drawer__subject-color" style="background-color: ${subject.color}; opacity: ${subject.archived ? '0.5' : '1'}"></span>
-            <span class="drawer__subject-name">${escapeHtml(subject.name)}</span>
-            <span class="drawer__subject-count">${subject.archived ? subject.noteCount || 0 : ''}</span>
+            <span class="drawer__subject-color" style="${subjectColorStyle}"></span>
+            <span class="drawer__subject-name">${escapeHtmlText(subject.name)}</span>
+            <span class="drawer__subject-count">${escapeHtmlText(subject.archived ? subject.noteCount || 0 : '')}</span>
           </div>
           ${rootButton}
         </div>

--- a/src/layout/drawerSubjects.js
+++ b/src/layout/drawerSubjects.js
@@ -204,6 +204,20 @@ export function initSubjects({ NoteStore, SUBJECT_COLORS, closeDrawer, getShowin
     closeDrawer()
   }
 
+  /** Busca datasets por igualdad exacta sin interpretar el ID como selector CSS. */
+  function findByDataset(selector, key, value) {
+    return [...subjectsList.querySelectorAll(selector)]
+      .find(element => element.dataset[key] === value) || null
+  }
+
+  function findSectionForm(parentId) {
+    return findByDataset('.drawer__section-form', 'parentId', parentId)
+  }
+
+  function findRenameInput(subjectId) {
+    return findByDataset('.js-rename-input', 'subjectId', subjectId)
+  }
+
   /** Muestra/oculta el formulario inline de sección para una materia */
   function toggleSectionForm(parentId) {
     if (expandSubject(parentId)) {
@@ -214,7 +228,7 @@ export function initSubjects({ NoteStore, SUBJECT_COLORS, closeDrawer, getShowin
     subjectsList.querySelectorAll('.drawer__section-form').forEach(form => {
       form.style.display = 'none'
     })
-    const form = subjectsList.querySelector(`#section-form-${parentId}`)
+    const form = findSectionForm(parentId)
     if (!form) return
     const isVisible = form.style.display !== 'none'
     form.style.display = isVisible ? 'none' : 'block'
@@ -229,7 +243,7 @@ export function initSubjects({ NoteStore, SUBJECT_COLORS, closeDrawer, getShowin
 
   /** Guarda una nueva sección bajo la materia padre */
   async function saveSectionForm(parentId, parentColor) {
-    const form = subjectsList.querySelector(`#section-form-${parentId}`)
+    const form = findSectionForm(parentId)
     if (!form) return
     const input = form.querySelector('.js-section-name-input')
     const name = input ? input.value.trim() : ''
@@ -256,13 +270,13 @@ export function initSubjects({ NoteStore, SUBJECT_COLORS, closeDrawer, getShowin
 
   /** Cierra el formulario de sección */
   function closeSectionForm(parentId) {
-    const form = subjectsList.querySelector(`#section-form-${parentId}`)
+    const form = findSectionForm(parentId)
     if (form) form.style.display = 'none'
   }
 
   /** Activa el modo edición inline para renombrar una materia/sección */
   function startRenameSubject(subjectId) {
-    const nameSpan = subjectsList.querySelector(`.drawer__subject-name[data-name-id="${subjectId}"]`)
+    const nameSpan = findByDataset('.drawer__subject-name', 'nameId', subjectId)
     if (!nameSpan) return
     const currentName = nameSpan.textContent
 
@@ -295,7 +309,7 @@ export function initSubjects({ NoteStore, SUBJECT_COLORS, closeDrawer, getShowin
     const trimmed = newName.trim()
     if (!trimmed) {
       // Si está vacío, cancelar y restaurar
-      const input = subjectsList.querySelector(`.js-rename-input[data-subject-id="${subjectId}"]`)
+      const input = findRenameInput(subjectId)
       if (input) cancelRenameSubject(subjectId, input.dataset.originalName)
       return
     }
@@ -308,7 +322,7 @@ export function initSubjects({ NoteStore, SUBJECT_COLORS, closeDrawer, getShowin
 
   /** Cancela el renombrado y restaura el nombre original */
   function cancelRenameSubject(subjectId, originalName) {
-    const input = subjectsList.querySelector(`.js-rename-input[data-subject-id="${subjectId}"]`)
+    const input = findRenameInput(subjectId)
     if (!input) return
 
     const span = document.createElement('span')

--- a/src/layout/drawerSubjectsRender.js
+++ b/src/layout/drawerSubjectsRender.js
@@ -1,4 +1,5 @@
-import { escapeHtml } from './appShell.js'
+import { escapeHtmlAttribute, escapeHtmlText } from '../components/common/htmlEscaping.js'
+import { getSafeHexColor } from '../components/common/presentationValidation.js'
 import { renderArchivedSubjects } from './drawerArchivedSubjects.js'
 import {
   isSubjectCollapsed,
@@ -32,6 +33,14 @@ export function renderSubjectsList(subjectsData, { NoteStore, subjectsList, inbo
   subjectsList.innerHTML = subjectsData.tree.map(subject => {
     const isActive = state.activeSubjectId === subject.id
     const children = subject.children || []
+    const subjectId = escapeHtmlAttribute(subject.id)
+    const subjectName = escapeHtmlText(subject.name)
+    const subjectNameAttribute = escapeHtmlAttribute(subject.name)
+    const subjectColor = getSafeHexColor(subject.color)
+    const subjectColorAttribute = escapeHtmlAttribute(subjectColor || '')
+    const subjectColorStyle = subjectColor
+      ? ` style="background-color: ${subjectColor}"`
+      : ''
     const hasChildren = children.length > 0
     const hasActiveChild = children.some(child => child.id === state.activeSubjectId)
     if (hasChildren && hasActiveChild && isSubjectCollapsed(subject.id, collapsedSubjectIds)) {
@@ -44,23 +53,28 @@ export function renderSubjectsList(subjectsData, { NoteStore, subjectsList, inbo
       : ''
     const childrenHtml = isCollapsed ? '' : children.map(child => {
       const isChildActive = state.activeSubjectId === child.id
+      const childId = escapeHtmlAttribute(child.id)
+      const childColor = getSafeHexColor(child.color) || subjectColor
+      const childColorStyle = childColor
+        ? ` style="background-color: ${childColor}"`
+        : ''
       return `
         <div class="drawer__subject-row drawer__subject-row--child">
           <div class="drawer__subject-btn drawer__subject-btn--child js-subject-nav${isChildActive ? ' drawer__subject-btn--active' : ''}" 
                role="button" tabindex="0" 
-               data-subject="${child.id}"
-               data-subject-name="${escapeHtml(child.name)}"
+               data-subject="${childId}"
+               data-subject-name="${escapeHtmlAttribute(child.name)}"
                data-is-section="true">
-            <span class="drawer__subject-color" style="background-color: ${child.color || subject.color}"></span>
-            <span class="drawer__subject-name" data-name-id="${child.id}">${escapeHtml(child.name)}</span>
-            <span class="drawer__subject-count">${child.noteCount || 0}</span>
+            <span class="drawer__subject-color"${childColorStyle}></span>
+            <span class="drawer__subject-name" data-name-id="${childId}">${escapeHtmlText(child.name)}</span>
+            <span class="drawer__subject-count">${escapeHtmlText(child.noteCount || 0)}</span>
           </div>
         </div>
       `
     }).join('')
     const childrenGroupHtml = hasChildren
       ? `
-        <div id="subject-children-${subject.id}" class="drawer__subject-children"${isCollapsed ? ' hidden' : ''}>
+        <div id="subject-children-${subjectId}" class="drawer__subject-children"${isCollapsed ? ' hidden' : ''}>
           ${childrenHtml}
         </div>
       `
@@ -68,17 +82,17 @@ export function renderSubjectsList(subjectsData, { NoteStore, subjectsList, inbo
 
     // Formulario inline para crear sección (oculto por defecto)
     const sectionFormHtml = `
-      <div id="section-form-${subject.id}" class="drawer__section-form" style="display:none">
+      <div id="section-form-${subjectId}" class="drawer__section-form" data-parent-id="${subjectId}" style="display:none">
         <input type="text" 
                class="drawer__section-form-input js-section-name-input" 
                placeholder="Nombre de sección" 
                maxlength="40" 
                autocomplete="off"
-               data-parent-id="${subject.id}"
-               data-parent-color="${subject.color}">
+               data-parent-id="${subjectId}"
+               data-parent-color="${subjectColorAttribute}">
         <div class="drawer__section-form-actions">
-          <button class="drawer__subject-form-btn js-btn-section-cancel" data-parent-id="${subject.id}">Cancelar</button>
-          <button class="drawer__subject-form-btn drawer__subject-form-btn--primary js-btn-section-save" data-parent-id="${subject.id}" data-parent-color="${subject.color}">Crear</button>
+          <button class="drawer__subject-form-btn js-btn-section-cancel" data-parent-id="${subjectId}">Cancelar</button>
+          <button class="drawer__subject-form-btn drawer__subject-form-btn--primary js-btn-section-save" data-parent-id="${subjectId}" data-parent-color="${subjectColorAttribute}">Crear</button>
         </div>
       </div>
     `
@@ -89,14 +103,14 @@ export function renderSubjectsList(subjectsData, { NoteStore, subjectsList, inbo
           ${collapseButtonHtml}
           <div class="drawer__subject-btn js-subject-nav${isActive ? ' drawer__subject-btn--active' : ''}" 
                role="button" tabindex="0" 
-               data-subject="${subject.id}"
-               data-subject-name="${escapeHtml(subject.name)}"
+               data-subject="${subjectId}"
+               data-subject-name="${subjectNameAttribute}"
                data-is-section="false">
-            <span class="drawer__subject-color" style="background-color: ${subject.color}"></span>
-            <span class="drawer__subject-name" data-name-id="${subject.id}">${escapeHtml(subject.name)}</span>
-            <span class="drawer__subject-count">${subject.noteCount || 0}</span>
+            <span class="drawer__subject-color"${subjectColorStyle}></span>
+            <span class="drawer__subject-name" data-name-id="${subjectId}">${subjectName}</span>
+            <span class="drawer__subject-count">${escapeHtmlText(subject.noteCount || 0)}</span>
           </div>
-          <button class="drawer__section-add js-btn-add-section" data-parent-id="${subject.id}" data-parent-color="${subject.color}" title="Agregar sección">
+          <button class="drawer__section-add js-btn-add-section" data-parent-id="${subjectId}" data-parent-color="${subjectColorAttribute}" title="Agregar sección">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
           </button>
         </div>
@@ -108,15 +122,16 @@ export function renderSubjectsList(subjectsData, { NoteStore, subjectsList, inbo
 }
 
 function renderCollapseButton(subject, isCollapsed) {
-  const subjectName = escapeHtml(subject.name)
+  const subjectId = escapeHtmlAttribute(subject.id)
+  const subjectName = escapeHtmlAttribute(subject.name)
   const action = isCollapsed ? 'Expandir' : 'Contraer'
 
   return `
     <button class="drawer__subject-collapse js-subject-collapse"
             type="button"
-            data-subject="${subject.id}"
+            data-subject="${subjectId}"
             aria-expanded="${String(!isCollapsed)}"
-            aria-controls="subject-children-${subject.id}"
+            aria-controls="subject-children-${subjectId}"
             aria-label="${action} secciones de ${subjectName}"
             title="${action} secciones">
       <svg class="drawer__subject-collapse-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/src/services/backup/BackupImportEntityValidation.ts
+++ b/src/services/backup/BackupImportEntityValidation.ts
@@ -1,0 +1,223 @@
+import { BACKUP_IMPORT_DATA_POLICY } from './BackupImportPolicy'
+import type { AcademicEvent, AcademicEventType } from '../../domain/academicEvents'
+import type { BackupData } from '../../domain/backup'
+import { BackupImportError } from '../../domain/backupImport'
+import type { Note } from '../../domain/notes'
+import {
+  parseBoundedOneLineText,
+  parseHexColor,
+  parseISODate,
+  parseLegacyBoolean,
+  parseOpaqueId,
+  parseRFC3339Timestamp,
+  parseUtf8ByteBoundedContent,
+  PrimitiveValidationError,
+} from '../../domain/primitiveValidation'
+import type { ISODateTimeString } from '../../domain/primitives'
+import type { Subject } from '../../domain/subjects'
+
+const SUBJECTS_PATH = 'data/subjects.json'
+const NOTES_PATH = 'data/notes.json'
+const ACADEMIC_EVENTS_PATH = 'data/academic-events.json'
+const ACADEMIC_EVENT_TYPES = new Set<AcademicEventType>(['parcial', 'final', 'tp', 'exposicion'])
+
+type UnknownRecord = Record<string, unknown>
+type NormalizedRows<T> = { items: T[]; deleted: number }
+
+export interface BackupImportJsonDocuments {
+  subjects: unknown
+  notes: unknown
+  academicEvents: unknown
+}
+
+export interface NormalizedBackupImportEntities {
+  data: BackupData
+  deleted: { subjects: number; notes: number; academicEvents: number }
+}
+
+function invalid(path: string, reason: string): never {
+  throw new BackupImportError(`Backup invalido: ${path} ${reason}.`)
+}
+
+function recordAt(value: unknown, path: string): UnknownRecord {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return invalid(path, 'debe ser un objeto')
+  }
+  return value as UnknownRecord
+}
+
+function primitiveAt<T>(path: string, parser: () => T): T {
+  try {
+    return parser()
+  } catch (error) {
+    if (error instanceof PrimitiveValidationError) return invalid(path, error.message)
+    throw error
+  }
+}
+
+function rowsAt(value: unknown, path: string, maxItems: number): unknown[] {
+  if (!Array.isArray(value)) return invalid(path, 'debe contener una lista')
+  if (value.length > maxItems) return invalid(path, 'supera el limite de entidades')
+  return value
+}
+
+function idAt(value: unknown, path: string): string {
+  return primitiveAt(path, () => parseOpaqueId(value, BACKUP_IMPORT_DATA_POLICY.maxIdAsciiCharacters))
+}
+
+function optionalIdAt(value: unknown, path: string): string | null {
+  if (value === undefined || value === null) return null
+  if (typeof value === 'string' && value.trim() === '') {
+    primitiveAt(path, () => parseBoundedOneLineText(value, {
+      maxCodePoints: BACKUP_IMPORT_DATA_POLICY.maxIdAsciiCharacters,
+      trim: true,
+    }))
+    return null
+  }
+  return idAt(value, path)
+}
+
+function oneLineAt(value: unknown, path: string, maxCodePoints: number): string {
+  return primitiveAt(path, () => parseBoundedOneLineText(value, {
+    maxCodePoints,
+    trim: true,
+    allowEmpty: false,
+  }))
+}
+
+function optionalOneLineAt(value: unknown, path: string, maxCodePoints: number): string | null {
+  if (value === undefined || value === null) return null
+  const normalized = primitiveAt(path, () => parseBoundedOneLineText(value, {
+    maxCodePoints,
+    trim: true,
+  }))
+  return normalized || null
+}
+
+function timestampAt(value: unknown, path: string): ISODateTimeString {
+  return primitiveAt(path, () => parseRFC3339Timestamp(value))
+}
+
+function optionalTimestampAt(
+  value: unknown,
+  path: string,
+  fallback: ISODateTimeString,
+): ISODateTimeString {
+  if (value === undefined || value === null || value === '') return fallback
+  return timestampAt(value, path)
+}
+
+function isDeleted(row: UnknownRecord, path: string): boolean {
+  if (row.deletedAt === undefined || row.deletedAt === null) return false
+  timestampAt(row.deletedAt, `${path}.deletedAt`)
+  return true
+}
+
+function normalizeSubjects(value: unknown, fallback: ISODateTimeString): NormalizedRows<Subject> {
+  const rows = rowsAt(value, SUBJECTS_PATH, BACKUP_IMPORT_DATA_POLICY.maxSubjects)
+  const items: Subject[] = []
+  let deleted = 0
+  for (let index = 0; index < rows.length; index += 1) {
+    const path = `${SUBJECTS_PATH}[${index}]`
+    const row = recordAt(rows[index], path)
+    if (isDeleted(row, path)) {
+      deleted += 1
+      continue
+    }
+    items.push({
+      id: idAt(row.id, `${path}.id`),
+      name: oneLineAt(row.name, `${path}.name`, BACKUP_IMPORT_DATA_POLICY.maxSubjectNameCodePoints),
+      parentSubjectId: optionalIdAt(row.parentSubjectId, `${path}.parentSubjectId`),
+      archived: primitiveAt(`${path}.archived`, () => parseLegacyBoolean(row.archived)),
+      color: primitiveAt(`${path}.color`, () => parseHexColor(row.color === undefined ? null : row.color)),
+      createdAt: optionalTimestampAt(row.createdAt, `${path}.createdAt`, fallback),
+    })
+  }
+  return { items, deleted }
+}
+
+function normalizeNotes(value: unknown, fallback: ISODateTimeString): NormalizedRows<Note> {
+  const rows = rowsAt(value, NOTES_PATH, BACKUP_IMPORT_DATA_POLICY.maxNotes)
+  const items: Note[] = []
+  let deleted = 0
+  for (let index = 0; index < rows.length; index += 1) {
+    const path = `${NOTES_PATH}[${index}]`
+    const row = recordAt(rows[index], path)
+    if (isDeleted(row, path)) {
+      deleted += 1
+      continue
+    }
+    const createdAt = optionalTimestampAt(row.createdAt, `${path}.createdAt`, fallback)
+    items.push({
+      id: idAt(row.id, `${path}.id`),
+      title: optionalOneLineAt(row.title, `${path}.title`, BACKUP_IMPORT_DATA_POLICY.maxNoteTitleCodePoints) || 'Sin titulo',
+      content: primitiveAt(`${path}.content`, () => parseUtf8ByteBoundedContent(
+        row.content === undefined || row.content === null ? '' : row.content,
+        BACKUP_IMPORT_DATA_POLICY.maxNoteContentBytes,
+      )),
+      pinned: primitiveAt(`${path}.pinned`, () => parseLegacyBoolean(row.pinned)),
+      archived: primitiveAt(`${path}.archived`, () => parseLegacyBoolean(row.archived)),
+      statusEmoji: optionalOneLineAt(row.statusEmoji, `${path}.statusEmoji`, BACKUP_IMPORT_DATA_POLICY.maxNoteStatusCodePoints),
+      subjectId: optionalIdAt(row.subjectId, `${path}.subjectId`),
+      createdAt,
+      updatedAt: optionalTimestampAt(row.updatedAt, `${path}.updatedAt`, createdAt),
+    })
+  }
+  return { items, deleted }
+}
+
+function academicEventTypeAt(value: unknown, path: string): AcademicEventType {
+  if (typeof value !== 'string' || !ACADEMIC_EVENT_TYPES.has(value as AcademicEventType)) {
+    return invalid(path, 'no pertenece a la allowlist academica')
+  }
+  return value as AcademicEventType
+}
+
+function normalizeAcademicEvents(
+  value: unknown,
+  fallback: ISODateTimeString,
+): NormalizedRows<AcademicEvent> {
+  const rows = rowsAt(value, ACADEMIC_EVENTS_PATH, BACKUP_IMPORT_DATA_POLICY.maxAcademicEvents)
+  const items: AcademicEvent[] = []
+  let deleted = 0
+  for (let index = 0; index < rows.length; index += 1) {
+    const path = `${ACADEMIC_EVENTS_PATH}[${index}]`
+    const row = recordAt(rows[index], path)
+    if (isDeleted(row, path)) {
+      deleted += 1
+      continue
+    }
+    const createdAt = optionalTimestampAt(row.createdAt, `${path}.createdAt`, fallback)
+    items.push({
+      id: idAt(row.id, `${path}.id`),
+      type: academicEventTypeAt(row.type, `${path}.type`),
+      title: optionalOneLineAt(row.title, `${path}.title`, BACKUP_IMPORT_DATA_POLICY.maxAcademicEventTitleCodePoints),
+      date: primitiveAt(`${path}.date`, () => parseISODate(row.date)),
+      subjectId: optionalIdAt(row.subjectId, `${path}.subjectId`),
+      createdAt,
+      updatedAt: optionalTimestampAt(row.updatedAt, `${path}.updatedAt`, createdAt),
+    })
+  }
+  return { items, deleted }
+}
+
+export function normalizeBackupImportEntities(
+  documents: BackupImportJsonDocuments,
+  fallback: ISODateTimeString,
+): NormalizedBackupImportEntities {
+  const subjects = normalizeSubjects(documents.subjects, fallback)
+  const notes = normalizeNotes(documents.notes, fallback)
+  const academicEvents = normalizeAcademicEvents(documents.academicEvents, fallback)
+  return {
+    data: {
+      subjects: subjects.items,
+      notes: notes.items,
+      academicEvents: academicEvents.items,
+    },
+    deleted: {
+      subjects: subjects.deleted,
+      notes: notes.deleted,
+      academicEvents: academicEvents.deleted,
+    },
+  }
+}

--- a/src/services/backup/BackupImportPlanService.ts
+++ b/src/services/backup/BackupImportPlanService.ts
@@ -6,6 +6,7 @@
 // =============================================================
 
 import { collectBackupData } from './BackupDataSource'
+import { validateMaxDepth } from '../SubjectService.validation'
 import type { AcademicEvent } from '../../domain/academicEvents'
 import type { BackupData } from '../../domain/backup'
 import type {
@@ -138,6 +139,64 @@ function countSkipped(skipped: BackupImportSkippedItem[], entity: BackupImportEn
   return skipped.filter(item => item.entity === entity).length
 }
 
+function findCircularSubjectIds(subjectsById: Map<EntityId, Subject>): Set<EntityId> {
+  const circularSubjectIds = new Set<EntityId>()
+  const visited = new Set<EntityId>()
+
+  for (const subjectId of subjectsById.keys()) {
+    if (visited.has(subjectId)) continue
+
+    const path: EntityId[] = []
+    const pathIndexById = new Map<EntityId, number>()
+    let currentId: EntityId | null = subjectId
+
+    while (currentId && subjectsById.has(currentId) && !visited.has(currentId)) {
+      const cycleStart = pathIndexById.get(currentId)
+      if (cycleStart !== undefined) {
+        for (let index = cycleStart; index < path.length; index += 1) {
+          circularSubjectIds.add(path[index])
+        }
+        break
+      }
+
+      pathIndexById.set(currentId, path.length)
+      path.push(currentId)
+      currentId = subjectsById.get(currentId)?.parentSubjectId || null
+    }
+
+    for (const pathSubjectId of path) {
+      visited.add(pathSubjectId)
+    }
+  }
+
+  return circularSubjectIds
+}
+
+function resolveSubjectParent(
+  subject: Subject,
+  circularSubjectIds: Set<EntityId>,
+  validationSubjects: Subject[],
+  availableById: Map<EntityId, Subject>,
+): { parentSubjectId: EntityId | null; repairReason: string | null } {
+  if (circularSubjectIds.has(subject.id)) {
+    return {
+      parentSubjectId: null,
+      repairReason: 'Se detecto una relacion circular entre materias/secciones.',
+    }
+  }
+
+  try {
+    validateMaxDepth(subject.parentSubjectId, validationSubjects)
+    return { parentSubjectId: subject.parentSubjectId, repairReason: null }
+  } catch {
+    const repairReason = subject.parentSubjectId && availableById.has(subject.parentSubjectId)
+      ? 'La materia padre ya es una seccion; no se permiten mas de 2 niveles.'
+      : 'La materia padre no existe en el backup ni en los datos locales.'
+
+    return { parentSubjectId: null, repairReason }
+  }
+}
+
 function planSubjects(
   importedSubjects: Subject[],
   localSubjects: Subject[],
@@ -146,74 +205,25 @@ function planSubjects(
   relationshipRepairs: BackupImportRelationshipRepair[],
 ): Subject[] {
   const localSubjectIds = idSet(localSubjects)
-  const importedById = new Map(importedSubjects.map(subject => [subject.id, subject]))
-  const plannedById = new Map<EntityId, Subject>()
-  const usedNamesByParent = createSubjectNameRegistry(localSubjects)
-  const planning = new Set<EntityId>()
-  const finished = new Set<EntityId>()
+  const candidateSubjects: Subject[] = []
 
-  function subjectExists(subjectId: EntityId): boolean {
-    return localSubjectIds.has(subjectId) || plannedById.has(subjectId)
-  }
-
-  function planSubject(subject: Subject): void {
-    if (finished.has(subject.id)) return
-    if (plannedById.has(subject.id)) return
-
+  for (const subject of importedSubjects) {
     if (localSubjectIds.has(subject.id)) {
       skipItem(skipped, 'subject', subject.id, 'Ya existe una materia o seccion con el mismo ID.')
-      finished.add(subject.id)
-      return
+      continue
     }
 
-    if (planning.has(subject.id)) {
-      addRepair(relationshipRepairs, {
-        entity: 'subject',
-        id: subject.id,
-        field: 'parentSubjectId',
-        from: subject.parentSubjectId,
-        to: null,
-        reason: 'Se detecto una relacion circular entre materias/secciones.',
-      })
-      const planned = reservePlannedSubject(subject, null)
-      plannedById.set(planned.id, planned)
-      finished.add(planned.id)
-      return
-    }
-
-    planning.add(subject.id)
-
-    let parentSubjectId = subject.parentSubjectId
-    if (parentSubjectId && !localSubjectIds.has(parentSubjectId)) {
-      const importedParent = importedById.get(parentSubjectId)
-      if (importedParent) {
-        planSubject(importedParent)
-      }
-
-      if (!subjectExists(parentSubjectId)) {
-        addRepair(relationshipRepairs, {
-          entity: 'subject',
-          id: subject.id,
-          field: 'parentSubjectId',
-          from: parentSubjectId,
-          to: null,
-          reason: 'La materia padre no existe en el backup ni en los datos locales.',
-        })
-        parentSubjectId = null
-      }
-
-      if (plannedById.has(subject.id)) {
-        planning.delete(subject.id)
-        finished.add(subject.id)
-        return
-      }
-    }
-
-    const planned = reservePlannedSubject(subject, parentSubjectId)
-    plannedById.set(planned.id, planned)
-    finished.add(planned.id)
-    planning.delete(subject.id)
+    candidateSubjects.push(subject)
   }
+
+  const importedById = new Map(candidateSubjects.map(subject => [subject.id, subject]))
+  const circularSubjectIds = findCircularSubjectIds(importedById)
+  const plannedById = new Map<EntityId, Subject>()
+  const availableById = new Map(localSubjects.map(subject => [subject.id, subject]))
+  const validationSubjects = [...localSubjects]
+  const usedNamesByParent = createSubjectNameRegistry(localSubjects)
+  const childrenByParentId = new Map<EntityId, Subject[]>()
+  const readySubjects: Subject[] = []
 
   function reservePlannedSubject(subject: Subject, parentSubjectId: EntityId | null): Subject {
     const name = createUniqueImportedSubjectName(subject.name, parentSubjectId, usedNamesByParent)
@@ -236,8 +246,50 @@ function planSubjects(
     }
   }
 
-  for (const subject of importedSubjects) {
-    planSubject(subject)
+  for (const subject of candidateSubjects) {
+    const importedParentId = subject.parentSubjectId
+    if (
+      importedParentId &&
+      importedById.has(importedParentId) &&
+      !circularSubjectIds.has(subject.id)
+    ) {
+      const children = childrenByParentId.get(importedParentId) || []
+      children.push(subject)
+      childrenByParentId.set(importedParentId, children)
+      continue
+    }
+
+    readySubjects.push(subject)
+  }
+
+  for (let index = 0; index < readySubjects.length; index += 1) {
+    const subject = readySubjects[index]
+    const { parentSubjectId, repairReason } = resolveSubjectParent(
+      subject,
+      circularSubjectIds,
+      validationSubjects,
+      availableById,
+    )
+
+    if (repairReason) {
+      addRepair(relationshipRepairs, {
+        entity: 'subject',
+        id: subject.id,
+        field: 'parentSubjectId',
+        from: subject.parentSubjectId,
+        to: null,
+        reason: repairReason,
+      })
+    }
+
+    const planned = reservePlannedSubject(subject, parentSubjectId)
+    plannedById.set(planned.id, planned)
+    availableById.set(planned.id, planned)
+    validationSubjects.push(planned)
+
+    for (const child of childrenByParentId.get(subject.id) || []) {
+      readySubjects.push(child)
+    }
   }
 
   return [...plannedById.values()]

--- a/src/services/backup/BackupImportPolicy.ts
+++ b/src/services/backup/BackupImportPolicy.ts
@@ -1,3 +1,5 @@
+import { ACADEMIC_EVENT_TITLE_MAX_LENGTH } from '../AcademicEventRules'
+
 const MEBIBYTE = 1024 * 1024
 
 export const BACKUP_JSON_PATHS = Object.freeze([
@@ -20,6 +22,20 @@ export interface BackupZipPolicy {
   jsonBytes: Readonly<Record<BackupJsonPath, number>>
 }
 
+export interface BackupImportDataPolicy {
+  maxSubjects: number
+  maxNotes: number
+  maxAcademicEvents: number
+  maxSubjectNameCodePoints: number
+  maxNoteTitleCodePoints: number
+  maxNoteContentBytes: number
+  maxNoteStatusCodePoints: number
+  maxAcademicEventTitleCodePoints: number
+  maxManifestFilenameCodePoints: number
+  maxIdAsciiCharacters: number
+  maxManifestFiles: number
+}
+
 export const BACKUP_IMPORT_ZIP_POLICY: BackupZipPolicy = Object.freeze({
   maxSourceBytes: 64 * MEBIBYTE,
   maxEntries: 5_100,
@@ -34,6 +50,20 @@ export const BACKUP_IMPORT_ZIP_POLICY: BackupZipPolicy = Object.freeze({
     'data/notes.json': 24 * MEBIBYTE,
     'data/academic-events.json': 8 * MEBIBYTE,
   }),
+})
+
+export const BACKUP_IMPORT_DATA_POLICY: BackupImportDataPolicy = Object.freeze({
+  maxSubjects: 1_000,
+  maxNotes: 5_000,
+  maxAcademicEvents: 5_000,
+  maxSubjectNameCodePoints: 120,
+  maxNoteTitleCodePoints: 4_096,
+  maxNoteContentBytes: BACKUP_IMPORT_ZIP_POLICY.maxMarkdownBytes,
+  maxNoteStatusCodePoints: 16,
+  maxAcademicEventTitleCodePoints: ACADEMIC_EVENT_TITLE_MAX_LENGTH,
+  maxManifestFilenameCodePoints: 255,
+  maxIdAsciiCharacters: 128,
+  maxManifestFiles: BACKUP_IMPORT_ZIP_POLICY.maxEntries,
 })
 
 export function getBackupZipEntryLimit(path: string, policy: BackupZipPolicy): number | null {

--- a/src/services/backup/BackupImportPolicy.ts
+++ b/src/services/backup/BackupImportPolicy.ts
@@ -41,7 +41,7 @@ export function getBackupZipEntryLimit(path: string, policy: BackupZipPolicy): n
     return policy.jsonBytes[path as BackupJsonPath]
   }
   if (path === 'README.txt') return policy.maxReadmeBytes
-  if (/^notes\/[^/]+\.md$/u.test(path)) return policy.maxMarkdownBytes
-  if (path === 'data/' || path === 'notes/') return 0
+  if (/^notes\/(?:[^/]+\/)*[^/]+\.md$/u.test(path)) return policy.maxMarkdownBytes
+  if (path === 'data/' || /^notes\/(?:[^/]+\/)*$/u.test(path)) return 0
   return null
 }

--- a/src/services/backup/BackupImportPolicy.ts
+++ b/src/services/backup/BackupImportPolicy.ts
@@ -1,0 +1,47 @@
+const MEBIBYTE = 1024 * 1024
+
+export const BACKUP_JSON_PATHS = Object.freeze([
+  'manifest.json',
+  'data/subjects.json',
+  'data/notes.json',
+  'data/academic-events.json',
+] as const)
+
+export type BackupJsonPath = typeof BACKUP_JSON_PATHS[number]
+
+export interface BackupZipPolicy {
+  maxSourceBytes: number
+  maxEntries: number
+  maxCentralDirectoryBytes: number
+  maxDeclaredUncompressedBytes: number
+  maxPathBytes: number
+  maxReadmeBytes: number
+  maxMarkdownBytes: number
+  jsonBytes: Readonly<Record<BackupJsonPath, number>>
+}
+
+export const BACKUP_IMPORT_ZIP_POLICY: BackupZipPolicy = Object.freeze({
+  maxSourceBytes: 64 * MEBIBYTE,
+  maxEntries: 5_100,
+  maxCentralDirectoryBytes: 4 * MEBIBYTE,
+  maxDeclaredUncompressedBytes: 64 * MEBIBYTE,
+  maxPathBytes: 512,
+  maxReadmeBytes: 1 * MEBIBYTE,
+  maxMarkdownBytes: 2 * MEBIBYTE,
+  jsonBytes: Object.freeze({
+    'manifest.json': 4 * MEBIBYTE,
+    'data/subjects.json': 2 * MEBIBYTE,
+    'data/notes.json': 24 * MEBIBYTE,
+    'data/academic-events.json': 8 * MEBIBYTE,
+  }),
+})
+
+export function getBackupZipEntryLimit(path: string, policy: BackupZipPolicy): number | null {
+  if (Object.prototype.hasOwnProperty.call(policy.jsonBytes, path)) {
+    return policy.jsonBytes[path as BackupJsonPath]
+  }
+  if (path === 'README.txt') return policy.maxReadmeBytes
+  if (/^notes\/[^/]+\.md$/u.test(path)) return policy.maxMarkdownBytes
+  if (path === 'data/' || path === 'notes/') return 0
+  return null
+}

--- a/src/services/backup/BackupImportValidation.ts
+++ b/src/services/backup/BackupImportValidation.ts
@@ -1,0 +1,224 @@
+import {
+  normalizeBackupImportEntities,
+  type BackupImportJsonDocuments,
+} from './BackupImportEntityValidation'
+import { BACKUP_APP_NAME, BACKUP_FORMAT_VERSION } from './BackupFormat'
+import { BACKUP_IMPORT_DATA_POLICY, BACKUP_IMPORT_ZIP_POLICY } from './BackupImportPolicy'
+import type { BackupItemCounts, BackupManifest } from '../../domain/backup'
+import { BackupImportError, type ParsedBackupImport } from '../../domain/backupImport'
+import {
+  parseBoundedOneLineText,
+  parseLegacyBoolean,
+  parseRFC3339Timestamp,
+  parseUtf8ByteBoundedContent,
+  PrimitiveValidationError,
+} from '../../domain/primitiveValidation'
+
+const SUBJECTS_PATH = 'data/subjects.json'
+const NOTES_PATH = 'data/notes.json'
+const ACADEMIC_EVENTS_PATH = 'data/academic-events.json'
+const REQUIRED_JSON_FILES = [SUBJECTS_PATH, NOTES_PATH, ACADEMIC_EVENTS_PATH] as const
+
+type UnknownRecord = Record<string, unknown>
+
+function invalid(path: string, reason: string): never {
+  throw new BackupImportError(`Backup invalido: ${path} ${reason}.`)
+}
+
+function recordAt(value: unknown, path: string): UnknownRecord {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return invalid(path, 'debe ser un objeto')
+  }
+  return value as UnknownRecord
+}
+
+function primitiveAt<T>(path: string, parser: () => T): T {
+  try {
+    return parser()
+  } catch (error) {
+    if (error instanceof PrimitiveValidationError) return invalid(path, error.message)
+    throw error
+  }
+}
+
+function oneLineAt(value: unknown, path: string, maxCodePoints: number): string {
+  return primitiveAt(path, () => parseBoundedOneLineText(value, {
+    maxCodePoints,
+    trim: true,
+    allowEmpty: false,
+  }))
+}
+
+function countAt(value: unknown, path: string, maxCount: number): number {
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    !Number.isSafeInteger(value) ||
+    value < 0 || value > maxCount
+  ) {
+    return invalid(path, 'debe ser un entero finito no negativo dentro del limite')
+  }
+  return value
+}
+
+function safeManifestPathAt(value: unknown, path: string): string {
+  const file = primitiveAt(path, () => parseBoundedOneLineText(value, {
+    maxCodePoints: BACKUP_IMPORT_ZIP_POLICY.maxPathBytes,
+    allowEmpty: false,
+  }))
+  primitiveAt(path, () => parseUtf8ByteBoundedContent(
+    file,
+    BACKUP_IMPORT_ZIP_POLICY.maxPathBytes,
+  ))
+  const segments = file.split('/')
+  if (
+    file.includes('\\') ||
+    file.startsWith('/') ||
+    /^[A-Za-z]:/u.test(file) ||
+    file.endsWith('/') ||
+    segments.some(segment => !segment || segment === '.' || segment === '..')
+  ) {
+    return invalid(path, 'contiene una ruta insegura o ambigua')
+  }
+  return file
+}
+
+function manifestFilesAt(value: unknown): string[] {
+  if (!Array.isArray(value)) return invalid('manifest.json.files', 'debe contener una lista')
+  if (value.length > BACKUP_IMPORT_DATA_POLICY.maxManifestFiles) {
+    return invalid('manifest.json.files', 'supera el limite de archivos')
+  }
+
+  const files: string[] = []
+  const seen = new Set<string>()
+  for (let index = 0; index < value.length; index += 1) {
+    const file = safeManifestPathAt(value[index], `manifest.json.files[${index}]`)
+    if (seen.has(file)) return invalid(`manifest.json.files[${index}]`, 'duplica una ruta anterior')
+    seen.add(file)
+    files.push(file)
+  }
+  return files
+}
+
+export function validateBackupManifest(value: unknown): BackupManifest {
+  const manifest = recordAt(value, 'manifest.json')
+  if (manifest.app !== BACKUP_APP_NAME) {
+    throw new BackupImportError('El ZIP seleccionado no parece ser un backup de Lumapse.')
+  }
+  if (manifest.backupFormatVersion !== BACKUP_FORMAT_VERSION) {
+    throw new BackupImportError('Version de backup no soportada.')
+  }
+  if (manifest.exportMode !== 'manual') return invalid('manifest.json.exportMode', 'debe ser manual')
+
+  const dataPolicy = recordAt(manifest.dataPolicy, 'manifest.json.dataPolicy')
+  const counts = recordAt(manifest.counts, 'manifest.json.counts')
+  return {
+    app: BACKUP_APP_NAME,
+    backupFormatVersion: BACKUP_FORMAT_VERSION,
+    createdAt: primitiveAt('manifest.json.createdAt', () => (
+      parseRFC3339Timestamp(manifest.createdAt)
+    )),
+    filename: oneLineAt(
+      manifest.filename,
+      'manifest.json.filename',
+      BACKUP_IMPORT_DATA_POLICY.maxManifestFilenameCodePoints,
+    ),
+    exportMode: 'manual',
+    dataPolicy: {
+      includesDeletedItems: primitiveAt('manifest.json.dataPolicy.includesDeletedItems', () => (
+        parseLegacyBoolean(dataPolicy.includesDeletedItems)
+      )),
+      includesArchivedItems: primitiveAt('manifest.json.dataPolicy.includesArchivedItems', () => (
+        parseLegacyBoolean(dataPolicy.includesArchivedItems)
+      )),
+      includesAttachments: primitiveAt('manifest.json.dataPolicy.includesAttachments', () => (
+        parseLegacyBoolean(dataPolicy.includesAttachments)
+      )),
+    },
+    counts: {
+      subjects: countAt(
+        counts.subjects,
+        'manifest.json.counts.subjects',
+        BACKUP_IMPORT_DATA_POLICY.maxSubjects,
+      ),
+      notes: countAt(
+        counts.notes,
+        'manifest.json.counts.notes',
+        BACKUP_IMPORT_DATA_POLICY.maxNotes,
+      ),
+      academicEvents: countAt(
+        counts.academicEvents,
+        'manifest.json.counts.academicEvents',
+        BACKUP_IMPORT_DATA_POLICY.maxAcademicEvents,
+      ),
+      attachments: countAt(
+        counts.attachments === undefined ? 0 : counts.attachments,
+        'manifest.json.counts.attachments',
+        BACKUP_IMPORT_DATA_POLICY.maxManifestFiles,
+      ),
+    },
+    files: manifestFilesAt(manifest.files),
+  }
+}
+
+function addManifestWarnings(manifest: BackupManifest, warnings: string[]): void {
+  if (manifest.dataPolicy.includesDeletedItems) {
+    warnings.push('El manifest declara items eliminados; Lumapse no importara papelera en esta version.')
+  }
+  if (manifest.dataPolicy.includesAttachments) {
+    warnings.push('El manifest declara adjuntos, pero la importacion actual no soporta adjuntos.')
+  }
+  for (const path of REQUIRED_JSON_FILES) {
+    if (manifest.files.length > 0 && !manifest.files.includes(path)) {
+      warnings.push(`El manifest no lista ${path}, aunque se intentara leer el archivo canonico.`)
+    }
+  }
+}
+
+function addDeletedWarning(count: number, singular: string, plural: string, warnings: string[]): void {
+  if (count === 1) warnings.push(`Se omitio ${singular} en papelera incluida en el backup.`)
+  if (count > 1) warnings.push(`Se omitieron ${count} ${plural} en papelera incluidas en el backup.`)
+}
+
+function addCountWarnings(manifest: BackupManifest, counts: BackupItemCounts, warnings: string[]): void {
+  if (manifest.counts.subjects !== counts.subjects) {
+    warnings.push('El conteo de materias del manifest no coincide con los datos del backup.')
+  }
+  if (manifest.counts.notes !== counts.notes) {
+    warnings.push('El conteo de notas del manifest no coincide con los datos del backup.')
+  }
+  if (manifest.counts.academicEvents !== counts.academicEvents) {
+    warnings.push('El conteo de fechas academicas del manifest no coincide con los datos del backup.')
+  }
+}
+
+export function validateBackupImportEntities(
+  manifest: BackupManifest,
+  documents: BackupImportJsonDocuments,
+): ParsedBackupImport {
+  const warnings: string[] = []
+  addManifestWarnings(manifest, warnings)
+
+  const normalized = normalizeBackupImportEntities(documents, manifest.createdAt)
+  const counts = {
+    subjects: normalized.data.subjects.length,
+    notes: normalized.data.notes.length,
+    academicEvents: normalized.data.academicEvents.length,
+  }
+  addDeletedWarning(normalized.deleted.subjects, 'una materia', 'materias', warnings)
+  addDeletedWarning(normalized.deleted.notes, 'una nota', 'notas', warnings)
+  addDeletedWarning(
+    normalized.deleted.academicEvents,
+    'una fecha academica',
+    'fechas academicas',
+    warnings,
+  )
+  addCountWarnings(manifest, counts, warnings)
+
+  if (counts.subjects + counts.notes + counts.academicEvents === 0) {
+    throw new BackupImportError('El backup no contiene datos importables.')
+  }
+  return { manifest, data: normalized.data, counts, warnings }
+}
+
+export type { BackupImportJsonDocuments }

--- a/src/services/backup/BackupImportZipService.ts
+++ b/src/services/backup/BackupImportZipService.ts
@@ -5,11 +5,15 @@
 // Lumapse, sin tocar SQLite ni UI.
 // =============================================================
 
-import JSZip from 'jszip'
 import {
   BACKUP_APP_NAME,
   BACKUP_FORMAT_VERSION,
 } from './BackupFormat'
+import { readBackupZipText } from './BackupZipEntryReader'
+import {
+  preflightBackupZip,
+  type PreflightedBackupZip,
+} from './BackupZipPreflight'
 import {
   BackupImportError,
   type BackupImportAcademicEvent,
@@ -269,59 +273,10 @@ function addManifestWarnings(manifest: BackupManifest, warnings: string[]): void
   }
 }
 
-function normalizeSource(source: BackupImportSource | Blob | ArrayBuffer | Uint8Array | string): Blob | ArrayBuffer | Uint8Array | string {
-  if (isRecord(source) && 'content' in source) {
-    const content = source.content
-    if (
-      typeof content === 'string' ||
-      content instanceof ArrayBuffer ||
-      content instanceof Uint8Array ||
-      (typeof Blob !== 'undefined' && content instanceof Blob)
-    ) {
-      return content
-    }
-  }
-
-  return source as Blob | ArrayBuffer | Uint8Array | string
-}
-
-function normalizeStringSource(content: string): { content: string, base64: boolean } {
-  if (content.startsWith('data:') && content.includes(',')) {
-    return {
-      content: content.slice(content.indexOf(',') + 1),
-      base64: true,
-    }
-  }
-
-  return {
-    content,
-    base64: true,
-  }
-}
-
-async function loadZip(source: BackupImportSource | Blob | ArrayBuffer | Uint8Array | string): Promise<JSZip> {
-  const content = normalizeSource(source)
-
+async function readJsonFile(zip: PreflightedBackupZip, path: string): Promise<unknown> {
+  const content = await readBackupZipText(zip, path)
   try {
-    if (typeof content === 'string') {
-      const normalized = normalizeStringSource(content)
-      return await JSZip.loadAsync(normalized.content, { base64: normalized.base64 })
-    }
-
-    return await JSZip.loadAsync(content)
-  } catch {
-    throw new BackupImportError('No se pudo leer el ZIP de backup seleccionado.')
-  }
-}
-
-async function readJsonFile(zip: JSZip, path: string): Promise<unknown> {
-  const file = zip.file(path)
-  if (!file) {
-    throw new BackupImportError(`Backup invalido: falta ${path}.`)
-  }
-
-  try {
-    return JSON.parse(await file.async('string'))
+    return JSON.parse(content)
   } catch {
     throw new BackupImportError(`Backup invalido: ${path} no contiene JSON valido.`)
   }
@@ -330,17 +285,15 @@ async function readJsonFile(zip: JSZip, path: string): Promise<unknown> {
 export async function parseBackupImportZip(
   source: BackupImportSource | Blob | ArrayBuffer | Uint8Array | string,
 ): Promise<ParsedBackupImport> {
-  const zip = await loadZip(source)
+  const zip = await preflightBackupZip(source)
   const warnings: string[] = []
   const manifest = validateManifest(await readJsonFile(zip, MANIFEST_PATH))
 
   addManifestWarnings(manifest, warnings)
 
-  const [subjectsJson, notesJson, academicEventsJson] = await Promise.all([
-    readJsonFile(zip, SUBJECTS_PATH),
-    readJsonFile(zip, NOTES_PATH),
-    readJsonFile(zip, ACADEMIC_EVENTS_PATH),
-  ])
+  const subjectsJson = await readJsonFile(zip, SUBJECTS_PATH)
+  const notesJson = await readJsonFile(zip, NOTES_PATH)
+  const academicEventsJson = await readJsonFile(zip, ACADEMIC_EVENTS_PATH)
   const data: BackupData = {
     subjects: normalizeSubjects(subjectsJson, manifest.createdAt, warnings),
     notes: normalizeNotes(notesJson, manifest.createdAt, warnings),

--- a/src/services/backup/BackupImportZipService.ts
+++ b/src/services/backup/BackupImportZipService.ts
@@ -1,277 +1,29 @@
 // =============================================================
 // backup/BackupImportZipService
 //
-// Responsabilidad: leer y validar backups ZIP generados por
-// Lumapse, sin tocar SQLite ni UI.
+// Responsabilidad: orquestar la fuente ZIP, preflight, lectura
+// JSON secuencial y validacion runtime, sin tocar SQLite ni UI.
 // =============================================================
 
-import {
-  BACKUP_APP_NAME,
-  BACKUP_FORMAT_VERSION,
-} from './BackupFormat'
 import { readBackupZipText } from './BackupZipEntryReader'
+import {
+  validateBackupImportEntities,
+  validateBackupManifest,
+} from './BackupImportValidation'
 import {
   preflightBackupZip,
   type PreflightedBackupZip,
 } from './BackupZipPreflight'
 import {
   BackupImportError,
-  type BackupImportAcademicEvent,
-  type BackupImportNote,
   type BackupImportSource,
-  type BackupImportSubject,
   type ParsedBackupImport,
 } from '../../domain/backupImport'
-import type { BackupData, BackupItemCounts, BackupManifest } from '../../domain/backup'
-import type { AcademicEventType } from '../../domain/academicEvents'
-import type { EntityId, HexColor, ISODateString, ISODateTimeString } from '../../domain/primitives'
 
 const MANIFEST_PATH = 'manifest.json'
 const SUBJECTS_PATH = 'data/subjects.json'
 const NOTES_PATH = 'data/notes.json'
 const ACADEMIC_EVENTS_PATH = 'data/academic-events.json'
-
-const REQUIRED_JSON_FILES = Object.freeze([
-  SUBJECTS_PATH,
-  NOTES_PATH,
-  ACADEMIC_EVENTS_PATH,
-])
-
-const ACADEMIC_EVENT_TYPES = new Set<AcademicEventType>([
-  'parcial',
-  'final',
-  'tp',
-  'exposicion',
-])
-
-const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
-
-type UnknownRecord = Record<string, unknown>
-
-function isRecord(value: unknown): value is UnknownRecord {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
-
-function textValue(value: unknown): string {
-  return String(value ?? '').trim()
-}
-
-function optionalText(value: unknown): string | null {
-  const normalized = textValue(value)
-  return normalized || null
-}
-
-function requireText(value: unknown, field: string, itemType: string): string {
-  const normalized = textValue(value)
-  if (!normalized) {
-    throw new BackupImportError(`Backup invalido: falta ${field} en ${itemType}.`)
-  }
-  return normalized
-}
-
-function normalizeBoolean(value: unknown): boolean {
-  if (value === true || value === 1) return true
-  if (typeof value === 'string') {
-    const normalized = value.trim().toLowerCase()
-    return normalized === 'true' || normalized === '1'
-  }
-  return false
-}
-
-function normalizeDateTime(value: unknown, fallback: ISODateTimeString): ISODateTimeString {
-  const normalized = textValue(value)
-  return normalized || fallback
-}
-
-function normalizeDate(value: unknown, itemType: string): ISODateString {
-  const normalized = requireText(value, 'date', itemType)
-  if (!ISO_DATE_RE.test(normalized)) {
-    throw new BackupImportError(`Backup invalido: fecha academica con date invalida "${normalized}".`)
-  }
-  return normalized
-}
-
-function normalizeSubjectId(value: unknown): EntityId | null {
-  return optionalText(value)
-}
-
-function normalizeColor(value: unknown): HexColor | null {
-  return optionalText(value)
-}
-
-function parseAcademicEventType(value: unknown): AcademicEventType {
-  const normalized = requireText(value, 'type', 'fecha academica')
-  if (!ACADEMIC_EVENT_TYPES.has(normalized as AcademicEventType)) {
-    throw new BackupImportError(`Backup invalido: tipo de fecha academica no soportado "${normalized}".`)
-  }
-  return normalized as AcademicEventType
-}
-
-function normalizeArray(value: unknown, path: string): UnknownRecord[] {
-  if (!Array.isArray(value)) {
-    throw new BackupImportError(`Backup invalido: ${path} debe contener una lista.`)
-  }
-
-  return value.map((item, index) => {
-    if (!isRecord(item)) {
-      throw new BackupImportError(`Backup invalido: item ${index + 1} de ${path} no es un objeto.`)
-    }
-    return item
-  })
-}
-
-function normalizeSubjects(
-  value: unknown,
-  fallbackDate: ISODateTimeString,
-  warnings: string[],
-): BackupImportSubject[] {
-  const rows = normalizeArray(value, SUBJECTS_PATH)
-  const subjects: BackupImportSubject[] = []
-
-  for (const row of rows) {
-    if (row.deletedAt) {
-      warnings.push('Se omitio una materia en papelera incluida en el backup.')
-      continue
-    }
-
-    subjects.push({
-      id: requireText(row.id, 'id', 'materia'),
-      name: requireText(row.name, 'name', 'materia'),
-      parentSubjectId: normalizeSubjectId(row.parentSubjectId),
-      archived: normalizeBoolean(row.archived),
-      color: normalizeColor(row.color),
-      createdAt: normalizeDateTime(row.createdAt, fallbackDate),
-    })
-  }
-
-  return subjects
-}
-
-function normalizeNotes(
-  value: unknown,
-  fallbackDate: ISODateTimeString,
-  warnings: string[],
-): BackupImportNote[] {
-  const rows = normalizeArray(value, NOTES_PATH)
-  const notes: BackupImportNote[] = []
-
-  for (const row of rows) {
-    if (row.deletedAt) {
-      warnings.push('Se omitio una nota en papelera incluida en el backup.')
-      continue
-    }
-
-    const createdAt = normalizeDateTime(row.createdAt, fallbackDate)
-    notes.push({
-      id: requireText(row.id, 'id', 'nota'),
-      title: textValue(row.title) || 'Sin titulo',
-      content: String(row.content ?? ''),
-      pinned: normalizeBoolean(row.pinned),
-      archived: normalizeBoolean(row.archived),
-      statusEmoji: optionalText(row.statusEmoji),
-      subjectId: normalizeSubjectId(row.subjectId),
-      createdAt,
-      updatedAt: normalizeDateTime(row.updatedAt, createdAt),
-    })
-  }
-
-  return notes
-}
-
-function normalizeAcademicEvents(
-  value: unknown,
-  fallbackDate: ISODateTimeString,
-): BackupImportAcademicEvent[] {
-  const rows = normalizeArray(value, ACADEMIC_EVENTS_PATH)
-
-  return rows.map(row => {
-    const createdAt = normalizeDateTime(row.createdAt, fallbackDate)
-    return {
-      id: requireText(row.id, 'id', 'fecha academica'),
-      type: parseAcademicEventType(row.type),
-      title: optionalText(row.title),
-      date: normalizeDate(row.date, 'fecha academica'),
-      subjectId: normalizeSubjectId(row.subjectId),
-      createdAt,
-      updatedAt: normalizeDateTime(row.updatedAt, createdAt),
-    }
-  })
-}
-
-function countItems(data: BackupData): BackupItemCounts {
-  return {
-    subjects: data.subjects.length,
-    notes: data.notes.length,
-    academicEvents: data.academicEvents.length,
-  }
-}
-
-function addCountWarnings(manifest: BackupManifest, counts: BackupItemCounts, warnings: string[]): void {
-  if (manifest.counts.subjects !== counts.subjects) {
-    warnings.push('El conteo de materias del manifest no coincide con los datos del backup.')
-  }
-  if (manifest.counts.notes !== counts.notes) {
-    warnings.push('El conteo de notas del manifest no coincide con los datos del backup.')
-  }
-  if (manifest.counts.academicEvents !== counts.academicEvents) {
-    warnings.push('El conteo de fechas academicas del manifest no coincide con los datos del backup.')
-  }
-}
-
-function validateManifest(value: unknown): BackupManifest {
-  if (!isRecord(value)) {
-    throw new BackupImportError('Backup invalido: manifest.json no es un objeto.')
-  }
-
-  if (value.app !== BACKUP_APP_NAME) {
-    throw new BackupImportError('El ZIP seleccionado no parece ser un backup de Lumapse.')
-  }
-
-  if (value.backupFormatVersion !== BACKUP_FORMAT_VERSION) {
-    throw new BackupImportError(`Version de backup no soportada: ${String(value.backupFormatVersion)}.`)
-  }
-
-  if (!isRecord(value.counts)) {
-    throw new BackupImportError('Backup invalido: manifest.json no incluye conteos validos.')
-  }
-
-  return {
-    app: BACKUP_APP_NAME,
-    backupFormatVersion: BACKUP_FORMAT_VERSION,
-    createdAt: requireText(value.createdAt, 'createdAt', 'manifest') as ISODateTimeString,
-    filename: textValue(value.filename),
-    exportMode: 'manual',
-    dataPolicy: {
-      includesDeletedItems: Boolean(isRecord(value.dataPolicy) && value.dataPolicy.includesDeletedItems),
-      includesArchivedItems: Boolean(isRecord(value.dataPolicy) && value.dataPolicy.includesArchivedItems),
-      includesAttachments: Boolean(isRecord(value.dataPolicy) && value.dataPolicy.includesAttachments),
-    },
-    counts: {
-      subjects: Number(value.counts.subjects || 0),
-      notes: Number(value.counts.notes || 0),
-      academicEvents: Number(value.counts.academicEvents || 0),
-      attachments: Number(value.counts.attachments || 0),
-    },
-    files: Array.isArray(value.files)
-      ? value.files.map(file => String(file))
-      : [],
-  }
-}
-
-function addManifestWarnings(manifest: BackupManifest, warnings: string[]): void {
-  if (manifest.dataPolicy.includesDeletedItems) {
-    warnings.push('El manifest declara items eliminados; Lumapse no importara papelera en esta version.')
-  }
-  if (manifest.dataPolicy.includesAttachments) {
-    warnings.push('El manifest declara adjuntos, pero la importacion actual no soporta adjuntos.')
-  }
-
-  for (const path of REQUIRED_JSON_FILES) {
-    if (manifest.files.length > 0 && !manifest.files.includes(path)) {
-      warnings.push(`El manifest no lista ${path}, aunque se intentara leer el archivo canonico.`)
-    }
-  }
-}
 
 async function readJsonFile(zip: PreflightedBackupZip, path: string): Promise<unknown> {
   const content = await readBackupZipText(zip, path)
@@ -286,33 +38,12 @@ export async function parseBackupImportZip(
   source: BackupImportSource | Blob | ArrayBuffer | Uint8Array | string,
 ): Promise<ParsedBackupImport> {
   const zip = await preflightBackupZip(source)
-  const warnings: string[] = []
-  const manifest = validateManifest(await readJsonFile(zip, MANIFEST_PATH))
+  const manifest = validateBackupManifest(await readJsonFile(zip, MANIFEST_PATH))
+  const subjects = await readJsonFile(zip, SUBJECTS_PATH)
+  const notes = await readJsonFile(zip, NOTES_PATH)
+  const academicEvents = await readJsonFile(zip, ACADEMIC_EVENTS_PATH)
 
-  addManifestWarnings(manifest, warnings)
-
-  const subjectsJson = await readJsonFile(zip, SUBJECTS_PATH)
-  const notesJson = await readJsonFile(zip, NOTES_PATH)
-  const academicEventsJson = await readJsonFile(zip, ACADEMIC_EVENTS_PATH)
-  const data: BackupData = {
-    subjects: normalizeSubjects(subjectsJson, manifest.createdAt, warnings),
-    notes: normalizeNotes(notesJson, manifest.createdAt, warnings),
-    academicEvents: normalizeAcademicEvents(academicEventsJson, manifest.createdAt),
-  }
-  const counts = countItems(data)
-
-  addCountWarnings(manifest, counts, warnings)
-
-  if (counts.subjects + counts.notes + counts.academicEvents === 0) {
-    throw new BackupImportError('El backup no contiene datos importables.')
-  }
-
-  return {
-    manifest,
-    data,
-    counts,
-    warnings,
-  }
+  return validateBackupImportEntities(manifest, { subjects, notes, academicEvents })
 }
 
 export {

--- a/src/services/backup/BackupZipArchive.ts
+++ b/src/services/backup/BackupZipArchive.ts
@@ -5,10 +5,11 @@
 // archivos de texto del backup. Evita cargar dependencias pesadas.
 // =============================================================
 
+import { crc32 } from './BackupZipCrc32'
+
 const ZIP_UTF8_FLAG = 0x0800
 const ZIP_STORE_METHOD = 0
 const ZIP_VERSION = 20
-const CRC32_TABLE = createCrc32Table()
 const encoder = new globalThis.TextEncoder()
 
 export interface ZipArchiveFile {
@@ -27,32 +28,6 @@ export type ZipArchiveContent = Blob | ArrayBuffer | string
 interface DosDateParts {
   time: number
   date: number
-}
-
-function createCrc32Table(): Uint32Array {
-  const table = new Uint32Array(256)
-
-  for (let index = 0; index < 256; index += 1) {
-    let value = index
-    for (let bit = 0; bit < 8; bit += 1) {
-      value = value & 1
-        ? 0xedb88320 ^ (value >>> 1)
-        : value >>> 1
-    }
-    table[index] = value >>> 0
-  }
-
-  return table
-}
-
-function crc32(bytes: Uint8Array): number {
-  let crc = 0xffffffff
-
-  for (const byte of bytes) {
-    crc = CRC32_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8)
-  }
-
-  return (crc ^ 0xffffffff) >>> 0
 }
 
 function dateToDosParts(value: Date | string | number): DosDateParts {

--- a/src/services/backup/BackupZipCrc32.ts
+++ b/src/services/backup/BackupZipCrc32.ts
@@ -1,0 +1,33 @@
+const CRC32_TABLE = createCrc32Table()
+
+function createCrc32Table(): Uint32Array {
+  const table = new Uint32Array(256)
+  for (let index = 0; index < table.length; index += 1) {
+    let value = index
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1
+    }
+    table[index] = value >>> 0
+  }
+  return table
+}
+
+export function beginCrc32(): number {
+  return 0xffffffff
+}
+
+export function updateCrc32(checksum: number, bytes: Uint8Array): number {
+  let next = checksum >>> 0
+  for (const byte of bytes) {
+    next = CRC32_TABLE[(next ^ byte) & 0xff] ^ (next >>> 8)
+  }
+  return next >>> 0
+}
+
+export function finishCrc32(checksum: number): number {
+  return (checksum ^ 0xffffffff) >>> 0
+}
+
+export function crc32(bytes: Uint8Array): number {
+  return finishCrc32(updateCrc32(beginCrc32(), bytes))
+}

--- a/src/services/backup/BackupZipEntryReader.ts
+++ b/src/services/backup/BackupZipEntryReader.ts
@@ -1,0 +1,135 @@
+import { BackupImportError } from '../../domain/backupImport'
+import { beginCrc32, finishCrc32, updateCrc32 } from './BackupZipCrc32'
+import {
+  ZIP_METHOD_DEFLATE,
+  ZIP_METHOD_STORE,
+  type BackupZipEntry,
+  type PreflightedBackupZip,
+} from './BackupZipPreflight'
+
+interface CollectedEntry {
+  bytes: Uint8Array
+  checksum: number
+}
+
+function invalid(reason: string): BackupImportError {
+  return new BackupImportError(`Backup invalido: ${reason}.`)
+}
+
+function findEntry(archive: PreflightedBackupZip, path: string): BackupZipEntry {
+  const entry = archive.entries.find(candidate => candidate.path === path)
+  if (!entry || entry.directory) throw invalid(`falta ${path}`)
+  return entry
+}
+
+function compressedBytes(archive: PreflightedBackupZip, entry: BackupZipEntry): Uint8Array {
+  return archive.bytes.subarray(entry.dataOffset, entry.dataOffset + entry.compressedSize)
+}
+
+function joinChunks(chunks: Uint8Array[], totalBytes: number): Uint8Array {
+  const output = new Uint8Array(totalBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    output.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return output
+}
+
+function collectStoredEntry(archive: PreflightedBackupZip, entry: BackupZipEntry): CollectedEntry {
+  const bytes = compressedBytes(archive, entry)
+  if (bytes.byteLength > entry.maxOutputBytes) {
+    throw invalid(`${entry.path} supera el limite permitido`)
+  }
+  return {
+    bytes,
+    checksum: finishCrc32(updateCrc32(beginCrc32(), bytes)),
+  }
+}
+
+function createRawDeflateStream(): DecompressionStream {
+  if (typeof globalThis.DecompressionStream !== 'function') {
+    throw invalid('el WebView debe actualizarse para importar backups DEFLATE historicos')
+  }
+
+  try {
+    return new globalThis.DecompressionStream('deflate-raw')
+  } catch {
+    throw invalid('el WebView no soporta backups DEFLATE historicos')
+  }
+}
+
+async function collectDeflatedEntry(
+  archive: PreflightedBackupZip,
+  entry: BackupZipEntry,
+): Promise<CollectedEntry> {
+  const compressed = compressedBytes(archive, entry)
+  const decompressor = createRawDeflateStream()
+  const compressedStream = new ReadableStream<BufferSource>({
+    start(controller) {
+      controller.enqueue(Uint8Array.from(compressed))
+      controller.close()
+    },
+  })
+  const stream = compressedStream.pipeThrough(decompressor)
+  const reader = stream.getReader()
+  const chunks: Uint8Array[] = []
+  let totalBytes = 0
+  let checksum = beginCrc32()
+
+  try {
+    while (true) {
+      const result = await reader.read()
+      if (result.done) break
+      const chunk = result.value
+      totalBytes += chunk.byteLength
+      if (totalBytes > entry.maxOutputBytes) {
+        await reader.cancel('backup entry limit exceeded')
+        throw invalid(`${entry.path} supera el limite real descomprimido`)
+      }
+      checksum = updateCrc32(checksum, chunk)
+      chunks.push(chunk)
+    }
+  } catch (error) {
+    if (error instanceof BackupImportError) throw error
+    throw invalid(`no se pudo descomprimir ${entry.path}`)
+  } finally {
+    reader.releaseLock()
+  }
+
+  return {
+    bytes: joinChunks(chunks, totalBytes),
+    checksum: finishCrc32(checksum),
+  }
+}
+
+function validateCollectedEntry(entry: BackupZipEntry, collected: CollectedEntry): Uint8Array {
+  if (collected.bytes.byteLength !== entry.declaredUncompressedSize) {
+    throw invalid(`${entry.path} no coincide con el tamano declarado`)
+  }
+  if (collected.checksum !== entry.crc32) {
+    throw invalid(`${entry.path} no supera la verificacion CRC32`)
+  }
+  return collected.bytes
+}
+
+export async function readBackupZipText(
+  archive: PreflightedBackupZip,
+  path: string,
+): Promise<string> {
+  const entry = findEntry(archive, path)
+  const collected = entry.method === ZIP_METHOD_STORE
+    ? collectStoredEntry(archive, entry)
+    : entry.method === ZIP_METHOD_DEFLATE
+      ? await collectDeflatedEntry(archive, entry)
+      : null
+
+  if (!collected) throw invalid(`${path} usa un metodo no soportado`)
+  const bytes = validateCollectedEntry(entry, collected)
+
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+  } catch {
+    throw invalid(`${path} no contiene UTF-8 valido`)
+  }
+}

--- a/src/services/backup/BackupZipPreflight.ts
+++ b/src/services/backup/BackupZipPreflight.ts
@@ -1,0 +1,325 @@
+import { BackupImportError, type BackupImportSource } from '../../domain/backupImport'
+import {
+  BACKUP_IMPORT_ZIP_POLICY,
+  BACKUP_JSON_PATHS,
+  getBackupZipEntryLimit,
+  type BackupZipPolicy,
+} from './BackupImportPolicy'
+import { normalizeBackupZipSource } from './BackupZipSource'
+import {
+  CENTRAL_SIGNATURE,
+  LOCAL_SIGNATURE,
+  readEndOfCentralDirectory,
+  readUint16,
+  readUint32,
+  ZIP32_SENTINEL_32,
+  type EndOfCentralDirectory,
+} from './BackupZipStructure'
+
+const UTF8_FLAG = 0x0800
+const ALLOWED_FLAGS = UTF8_FLAG
+const ZIP_VERSION_20 = 20
+
+export const ZIP_METHOD_STORE = 0 as const
+export const ZIP_METHOD_DEFLATE = 8 as const
+export type SupportedZipMethod = typeof ZIP_METHOD_STORE | typeof ZIP_METHOD_DEFLATE
+
+export interface BackupZipEntry {
+  path: string
+  method: SupportedZipMethod
+  crc32: number
+  compressedSize: number
+  declaredUncompressedSize: number
+  dataOffset: number
+  maxOutputBytes: number
+  directory: boolean
+}
+
+export interface PreflightedBackupZip {
+  bytes: Uint8Array
+  entries: readonly BackupZipEntry[]
+}
+
+interface EntryRange {
+  start: number
+  end: number
+  path: string
+}
+
+interface CentralDirectoryRecord {
+  version: number
+  flags: number
+  rawMethod: number
+  crc32: number
+  compressedSize: number
+  declaredUncompressedSize: number
+  nameLength: number
+  diskStart: number
+  localOffset: number
+  entryEnd: number
+}
+
+function invalid(reason: string): never {
+  throw new BackupImportError(`Backup invalido: ${reason}.`)
+}
+
+function decodeEntryPath(nameBytes: Uint8Array, flags: number): string {
+  if (flags & UTF8_FLAG) {
+    try {
+      return new TextDecoder('utf-8', { fatal: true }).decode(nameBytes)
+    } catch {
+      return invalid('una ruta ZIP no contiene UTF-8 valido')
+    }
+  }
+  if (nameBytes.some(byte => byte > 0x7f)) {
+    return invalid('una ruta ZIP no ASCII no declara UTF-8')
+  }
+  return String.fromCharCode(...nameBytes)
+}
+
+function validateEntryPath(path: string, directory: boolean): void {
+  if (!path || path.includes('\\') || path.startsWith('/') || /^[A-Za-z]:/u.test(path)) {
+    return invalid('una entrada contiene una ruta insegura')
+  }
+  if ([...path].some(character => {
+    const codePoint = character.codePointAt(0) || 0
+    return codePoint < 0x20 || codePoint === 0x7f
+  })) {
+    return invalid('una entrada contiene caracteres de control en la ruta')
+  }
+
+  const comparablePath = directory ? path.slice(0, -1) : path
+  const segments = comparablePath.split('/')
+  if (!comparablePath || segments.some(segment => !segment || segment === '.' || segment === '..')) {
+    return invalid('una entrada contiene una ruta ambigua')
+  }
+}
+
+function validateLocalHeader(
+  bytes: Uint8Array,
+  view: DataView,
+  centralOffset: number,
+  centralName: Uint8Array,
+  centralFlags: number,
+  entry: Omit<BackupZipEntry, 'dataOffset'>,
+  localOffset: number,
+): { dataOffset: number, range: EntryRange } {
+  if (localOffset + 30 > centralOffset || readUint32(view, localOffset) !== LOCAL_SIGNATURE) {
+    return invalid('una entrada no tiene un header local valido')
+  }
+
+  const version = readUint16(view, localOffset + 4)
+  const flags = readUint16(view, localOffset + 6)
+  const method = readUint16(view, localOffset + 8)
+  const crc = readUint32(view, localOffset + 14)
+  const compressedSize = readUint32(view, localOffset + 18)
+  const uncompressedSize = readUint32(view, localOffset + 22)
+  const nameLength = readUint16(view, localOffset + 26)
+  const extraLength = readUint16(view, localOffset + 28)
+  const nameStart = localOffset + 30
+  const dataOffset = nameStart + nameLength + extraLength
+  const dataEnd = dataOffset + entry.compressedSize
+
+  if (
+    version > ZIP_VERSION_20 ||
+    flags !== centralFlags ||
+    method !== entry.method ||
+    crc !== entry.crc32 ||
+    compressedSize !== entry.compressedSize ||
+    uncompressedSize !== entry.declaredUncompressedSize ||
+    nameLength !== centralName.byteLength ||
+    dataOffset > centralOffset ||
+    dataEnd > centralOffset
+  ) {
+    return invalid('el header local no coincide con el directorio central')
+  }
+
+  const localName = bytes.subarray(nameStart, nameStart + nameLength)
+  if (localName.some((byte, index) => byte !== centralName[index])) {
+    return invalid('la ruta local no coincide con el directorio central')
+  }
+
+  return {
+    dataOffset,
+    range: { start: localOffset, end: dataEnd, path: entry.path },
+  }
+}
+
+function validateMethod(method: number, directory: boolean): SupportedZipMethod {
+  if (method !== ZIP_METHOD_STORE && method !== ZIP_METHOD_DEFLATE) {
+    return invalid('una entrada usa un metodo de compresion no soportado')
+  }
+  if (directory && method !== ZIP_METHOD_STORE) {
+    return invalid('una carpeta ZIP no usa el metodo STORE')
+  }
+  return method
+}
+
+function validateRanges(ranges: EntryRange[]): void {
+  const sorted = [...ranges].sort((left, right) => left.start - right.start)
+  for (let index = 1; index < sorted.length; index += 1) {
+    if (sorted[index].start < sorted[index - 1].end) {
+      return invalid('dos entradas ZIP comparten bytes locales')
+    }
+  }
+}
+
+function validateRequiredEntries(entries: BackupZipEntry[]): void {
+  const paths = new Set(entries.map(entry => entry.path))
+  for (const requiredPath of BACKUP_JSON_PATHS) {
+    if (!paths.has(requiredPath)) return invalid(`falta ${requiredPath}`)
+  }
+}
+
+function readCentralDirectoryRecord(
+  view: DataView,
+  offset: number,
+  centralEnd: number,
+): CentralDirectoryRecord {
+  if (offset + 46 > centralEnd || readUint32(view, offset) !== CENTRAL_SIGNATURE) {
+    return invalid('el directorio central esta truncado')
+  }
+
+  const nameLength = readUint16(view, offset + 28)
+  const extraLength = readUint16(view, offset + 30)
+  const commentLength = readUint16(view, offset + 32)
+  return {
+    version: readUint16(view, offset + 6),
+    flags: readUint16(view, offset + 8),
+    rawMethod: readUint16(view, offset + 10),
+    crc32: readUint32(view, offset + 16),
+    compressedSize: readUint32(view, offset + 20),
+    declaredUncompressedSize: readUint32(view, offset + 24),
+    nameLength,
+    diskStart: readUint16(view, offset + 34),
+    localOffset: readUint32(view, offset + 42),
+    entryEnd: offset + 46 + nameLength + extraLength + commentLength,
+  }
+}
+
+function validateCentralDirectoryRecord(
+  record: CentralDirectoryRecord,
+  centralEnd: number,
+  policy: BackupZipPolicy,
+): void {
+  if (record.version > ZIP_VERSION_20 || record.flags & ~ALLOWED_FLAGS) {
+    return invalid('una entrada usa flags o version ZIP no soportados')
+  }
+  if (record.diskStart !== 0 || record.localOffset === ZIP32_SENTINEL_32) {
+    return invalid('una entrada requiere multidisk o ZIP64')
+  }
+  if (!record.nameLength || record.nameLength > policy.maxPathBytes || record.entryEnd > centralEnd) {
+    return invalid('una entrada tiene metadata o ruta fuera de limite')
+  }
+}
+
+function validateEntrySizes(
+  method: SupportedZipMethod,
+  directory: boolean,
+  compressedSize: number,
+  declaredUncompressedSize: number,
+  maxOutputBytes: number,
+): void {
+  if (declaredUncompressedSize > maxOutputBytes) {
+    return invalid('una entrada supera el limite descomprimido declarado')
+  }
+  if (method === ZIP_METHOD_STORE && compressedSize !== declaredUncompressedSize) {
+    return invalid('una entrada STORE declara tamanos incompatibles')
+  }
+  if (directory && (compressedSize !== 0 || declaredUncompressedSize !== 0)) {
+    return invalid('una carpeta ZIP contiene datos inesperados')
+  }
+}
+
+function parseEntries(
+  bytes: Uint8Array,
+  view: DataView,
+  eocd: EndOfCentralDirectory,
+  policy: BackupZipPolicy,
+): BackupZipEntry[] {
+  const entries: BackupZipEntry[] = []
+  const ranges: EntryRange[] = []
+  const paths = new Set<string>()
+  const centralEnd = eocd.centralOffset + eocd.centralSize
+  let offset = eocd.centralOffset
+  let declaredTotal = 0
+
+  for (let index = 0; index < eocd.entryCount; index += 1) {
+    const record = readCentralDirectoryRecord(view, offset, centralEnd)
+    validateCentralDirectoryRecord(record, centralEnd, policy)
+
+    const centralName = bytes.subarray(offset + 46, offset + 46 + record.nameLength)
+    const path = decodeEntryPath(centralName, record.flags)
+    const directory = path.endsWith('/')
+    validateEntryPath(path, directory)
+    if (paths.has(path)) return invalid('el ZIP contiene rutas duplicadas')
+    paths.add(path)
+
+    const maxOutputBytes = getBackupZipEntryLimit(path, policy)
+    if (maxOutputBytes === null) return invalid('el ZIP contiene una entrada no soportada')
+    const method = validateMethod(record.rawMethod, directory)
+    validateEntrySizes(
+      method,
+      directory,
+      record.compressedSize,
+      record.declaredUncompressedSize,
+      maxOutputBytes,
+    )
+
+    const withoutOffset = {
+      path,
+      method,
+      crc32: record.crc32,
+      compressedSize: record.compressedSize,
+      declaredUncompressedSize: record.declaredUncompressedSize,
+      maxOutputBytes,
+      directory,
+    }
+    const local = validateLocalHeader(
+      bytes,
+      view,
+      eocd.centralOffset,
+      centralName,
+      record.flags,
+      withoutOffset,
+      record.localOffset,
+    )
+    entries.push(Object.freeze({ ...withoutOffset, dataOffset: local.dataOffset }))
+    ranges.push(local.range)
+    declaredTotal += record.declaredUncompressedSize
+    if (declaredTotal > policy.maxDeclaredUncompressedBytes) {
+      return invalid('el contenido descomprimido declarado supera el limite total')
+    }
+
+    offset = record.entryEnd
+  }
+
+  if (offset !== centralEnd) return invalid('el directorio central contiene bytes inesperados')
+  validateRanges(ranges)
+  validateRequiredEntries(entries)
+  return entries
+}
+
+export async function preflightBackupZip(
+  source: BackupImportSource | Blob | ArrayBuffer | Uint8Array | string,
+  policy: BackupZipPolicy = BACKUP_IMPORT_ZIP_POLICY,
+): Promise<PreflightedBackupZip> {
+  const bytes = await normalizeBackupZipSource(source, policy)
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  const eocd = readEndOfCentralDirectory(bytes, view)
+
+  if (!eocd.entryCount || eocd.entryCount > policy.maxEntries) {
+    return invalid('la cantidad de entradas ZIP esta fuera de limite')
+  }
+  if (!eocd.centralSize || eocd.centralSize > policy.maxCentralDirectoryBytes) {
+    return invalid('el directorio central supera el limite permitido')
+  }
+  if (eocd.centralOffset + eocd.centralSize !== eocd.offset) {
+    return invalid('el directorio central tiene offsets inconsistentes')
+  }
+
+  return Object.freeze({
+    bytes,
+    entries: Object.freeze(parseEntries(bytes, view, eocd, policy)),
+  })
+}

--- a/src/services/backup/BackupZipSource.ts
+++ b/src/services/backup/BackupZipSource.ts
@@ -1,0 +1,78 @@
+import { BackupImportError, type BackupImportSource } from '../../domain/backupImport'
+import type { BackupZipPolicy } from './BackupImportPolicy'
+
+type BackupZipSource = BackupImportSource | Blob | ArrayBuffer | Uint8Array | string
+
+function sourceContent(source: BackupZipSource): Blob | ArrayBuffer | Uint8Array | string {
+  if (typeof source === 'object' && source !== null && 'content' in source) {
+    return source.content
+  }
+  return source
+}
+
+function assertSourceSize(size: number, policy: BackupZipPolicy): void {
+  if (size <= 0) {
+    throw new BackupImportError('El archivo de backup esta vacio.')
+  }
+  if (size > policy.maxSourceBytes) {
+    throw new BackupImportError('El archivo de backup supera el limite permitido.')
+  }
+}
+
+function base64Payload(value: string): string {
+  if (!value.startsWith('data:')) return value
+
+  const separator = value.indexOf(',')
+  const header = separator >= 0 ? value.slice(0, separator).toLowerCase() : ''
+  if (separator < 0 || !header.endsWith(';base64')) {
+    throw new BackupImportError('El contenido del backup no usa base64 valido.')
+  }
+  return value.slice(separator + 1)
+}
+
+function decodeBase64(value: string, policy: BackupZipPolicy): Uint8Array {
+  const payload = base64Payload(value)
+  const maximumEncodedLength = Math.ceil(policy.maxSourceBytes / 3) * 4
+  if (!payload || payload.length > maximumEncodedLength || payload.length % 4 !== 0) {
+    throw new BackupImportError('El contenido base64 del backup supera el limite o es invalido.')
+  }
+  if (!/^[A-Za-z0-9+/]*={0,2}$/u.test(payload) || payload.slice(0, -2).includes('=')) {
+    throw new BackupImportError('El contenido del backup no usa base64 valido.')
+  }
+
+  try {
+    const binary = globalThis.atob(payload)
+    assertSourceSize(binary.length, policy)
+    const bytes = new Uint8Array(binary.length)
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index)
+    }
+    return bytes
+  } catch (error) {
+    if (error instanceof BackupImportError) throw error
+    throw new BackupImportError('El contenido del backup no usa base64 valido.')
+  }
+}
+
+export async function normalizeBackupZipSource(
+  source: BackupZipSource,
+  policy: BackupZipPolicy,
+): Promise<Uint8Array> {
+  const content = sourceContent(source)
+
+  if (typeof content === 'string') return decodeBase64(content, policy)
+  if (content instanceof Uint8Array) {
+    assertSourceSize(content.byteLength, policy)
+    return Uint8Array.from(content)
+  }
+  if (content instanceof ArrayBuffer) {
+    assertSourceSize(content.byteLength, policy)
+    return new Uint8Array(content.slice(0))
+  }
+  if (typeof Blob !== 'undefined' && content instanceof Blob) {
+    assertSourceSize(content.size, policy)
+    return new Uint8Array(await content.arrayBuffer())
+  }
+
+  throw new BackupImportError('El contenido del backup usa un formato no soportado.')
+}

--- a/src/services/backup/BackupZipStructure.ts
+++ b/src/services/backup/BackupZipStructure.ts
@@ -1,0 +1,64 @@
+import { BackupImportError } from '../../domain/backupImport'
+
+const EOCD_SIGNATURE = 0x06054b50
+const MAX_EOCD_SEARCH_BYTES = 65_557
+const ZIP32_SENTINEL_16 = 0xffff
+
+export const CENTRAL_SIGNATURE = 0x02014b50
+export const LOCAL_SIGNATURE = 0x04034b50
+export const ZIP32_SENTINEL_32 = 0xffffffff
+
+export interface EndOfCentralDirectory {
+  offset: number
+  centralOffset: number
+  centralSize: number
+  entryCount: number
+}
+
+function invalid(reason: string): never {
+  throw new BackupImportError(`Backup invalido: ${reason}.`)
+}
+
+export function readUint16(view: DataView, offset: number): number {
+  return view.getUint16(offset, true)
+}
+
+export function readUint32(view: DataView, offset: number): number {
+  return view.getUint32(offset, true)
+}
+
+function findEndOfCentralDirectory(bytes: Uint8Array, view: DataView): number {
+  const minimumOffset = Math.max(0, bytes.byteLength - MAX_EOCD_SEARCH_BYTES)
+  for (let offset = bytes.byteLength - 22; offset >= minimumOffset; offset -= 1) {
+    if (readUint32(view, offset) !== EOCD_SIGNATURE) continue
+    const commentLength = readUint16(view, offset + 20)
+    if (offset + 22 + commentLength === bytes.byteLength) return offset
+  }
+  return invalid('no se encontro un cierre ZIP32 valido')
+}
+
+export function readEndOfCentralDirectory(
+  bytes: Uint8Array,
+  view: DataView,
+): EndOfCentralDirectory {
+  if (bytes.byteLength < 22) return invalid('el archivo ZIP esta truncado')
+  const offset = findEndOfCentralDirectory(bytes, view)
+  const diskNumber = readUint16(view, offset + 4)
+  const centralDisk = readUint16(view, offset + 6)
+  const entriesOnDisk = readUint16(view, offset + 8)
+  const entryCount = readUint16(view, offset + 10)
+  const centralSize = readUint32(view, offset + 12)
+  const centralOffset = readUint32(view, offset + 16)
+
+  if (diskNumber !== 0 || centralDisk !== 0 || entriesOnDisk !== entryCount) {
+    return invalid('los ZIP multidisk no estan soportados')
+  }
+  if (
+    entryCount === ZIP32_SENTINEL_16 ||
+    centralSize === ZIP32_SENTINEL_32 ||
+    centralOffset === ZIP32_SENTINEL_32
+  ) {
+    return invalid('ZIP64 no esta soportado')
+  }
+  return { offset, centralOffset, centralSize, entryCount }
+}

--- a/tests/unit/components/academic-events/AcademicEventTypes.test.js
+++ b/tests/unit/components/academic-events/AcademicEventTypes.test.js
@@ -106,8 +106,54 @@ describe('AcademicEventTypes', () => {
   })
 
   it('permite usar color de materia como override visual', () => {
-    expect(getAcademicEventColor({ type: 'parcial' }, '#818cf8')).toBe('#818cf8')
-    expect(renderAcademicEventDot({ type: 'parcial' }, { color: '#818cf8' })).toContain('#818cf8')
+    expect(getAcademicEventColor({ type: 'parcial' }, '#38bdf8')).toBe('#38bdf8')
+    expect(renderAcademicEventDot({ type: 'parcial' }, { color: '#38bdf8' })).toContain('#38bdf8')
+  })
+
+  it('codifica atributos, ignora fechas invalidas y rechaza declaraciones CSS adicionales', () => {
+    const eventId = 'event-id"] data-injected="true # [odd'
+    const title = 'Parcial "A" <B> & 😀'
+    const wrapper = render(renderAcademicEventListItem(
+      {
+        id: eventId,
+        type: 'parcial',
+        title,
+        date: '2026-06-14" data-date-injected="true',
+      },
+      {
+        color: '#38bdf8; position: fixed',
+        subjectLabel: 'Materia "segura" <2026> & 🧪',
+        actions: true,
+      },
+    ))
+    const item = wrapper.querySelector('.academic-event-item')
+    const time = wrapper.querySelector('time')
+
+    expect(wrapper.querySelector('[data-injected]')).toBeNull()
+    expect(wrapper.querySelector('[data-date-injected]')).toBeNull()
+    expect(item?.dataset.eventId).toBe(eventId)
+    expect(item?.style.getPropertyValue('--academic-event-color')).toBe('#b45309')
+    expect(item?.style.position).toBe('')
+    expect(time?.getAttribute('datetime')).toBe('')
+    expect(time?.textContent).toBe('')
+    expect(wrapper.querySelector('.academic-event-item__title')?.textContent).toBe(title)
+    expect(wrapper.querySelector('[data-event-action="edit"]')?.getAttribute('title'))
+      .toBe(`Editar ${title}`)
+  })
+
+  it('aplica la misma allowlist a dots y usa el color semantico como fallback', () => {
+    const wrapper = render(renderAcademicEventDot(
+      { type: 'final' },
+      {
+        color: '#dc2626; inset: 0',
+        label: 'Final "especial" < > & 😀',
+      },
+    ))
+    const dot = wrapper.querySelector('.academic-event-dot')
+
+    expect(dot?.style.getPropertyValue('--academic-event-color')).toBe('#dc2626')
+    expect(dot?.style.inset).toBe('')
+    expect(dot?.getAttribute('aria-label')).toBe('Final "especial" < > & 😀')
   })
 
   it('mantiene contraste minimo contra superficies dark y light', () => {

--- a/tests/unit/components/academic-events/Heatmap.test.js
+++ b/tests/unit/components/academic-events/Heatmap.test.js
@@ -108,6 +108,48 @@ afterEach(() => {
 })
 
 describe('Heatmap eventos academicos read-only', () => {
+  it('ignora timestamps persistidos invalidos y conserva toda actividad valida', () => {
+    storeMock.state = defaultState({
+      notes: [
+        note({ id: 'valid-1' }),
+        note({ id: 'invalid', updatedAt: 'not-a-date' }),
+        note({ id: 'valid-2', updatedAt: '2026-06-14T23:59:59-03:00' }),
+      ],
+    })
+
+    let heatmap
+    expect(() => {
+      heatmap = createHeatmap()
+    }).not.toThrow()
+
+    expect(heatmap.activityMap['2026-06-14']).toBe(1)
+    expect(heatmap.activityMap['2026-06-15']).toBe(1)
+    expect(Object.keys(heatmap.activityMap)).toEqual(['2026-06-14', '2026-06-15'])
+
+    heatmap.destroy()
+  })
+
+  it('ignora fechas academicas invalidas sin contaminar el mapa de eventos', () => {
+    storeMock.state = defaultState({
+      academicEventsForMonth: [
+        event({ id: 'valid-event' }),
+        event({ id: 'prototype-event', date: '__proto__' }),
+        event({ id: 'impossible-event', date: '2026-02-30' }),
+      ],
+    })
+
+    let heatmap
+    expect(() => {
+      heatmap = createHeatmap()
+    }).not.toThrow()
+
+    expect(heatmap.eventMap['2026-06-14']).toHaveLength(1)
+    expect(Object.hasOwn(heatmap.eventMap, '__proto__')).toBe(false)
+    expect(Object.hasOwn(heatmap.eventMap, '2026-02-30')).toBe(false)
+
+    heatmap.destroy()
+  })
+
   it('mantiene legible un dia con notas pero sin eventos', () => {
     storeMock.state = defaultState({
       notes: [note()],

--- a/tests/unit/components/common/htmlEscaping.test.js
+++ b/tests/unit/components/common/htmlEscaping.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  escapeHtmlAttribute,
+  escapeHtmlText,
+} from '../../../../src/components/common/htmlEscaping.js'
+
+describe('htmlEscaping', () => {
+  it('distingue texto visible de valores de atributo', () => {
+    const value = `Comillas "dobles" y 'simples' < > & 😀`
+
+    expect(escapeHtmlText(value))
+      .toBe(`Comillas "dobles" y 'simples' &lt; &gt; &amp; 😀`)
+    expect(escapeHtmlAttribute(value))
+      .toBe('Comillas &quot;dobles&quot; y &#39;simples&#39; &lt; &gt; &amp; 😀')
+  })
+
+  it('convierte primitivas defensivamente sin lanzar ante coercion hostil', () => {
+    const hostileValue = {
+      toString() {
+        throw new Error('coercion blocked')
+      },
+    }
+
+    expect(escapeHtmlText(42)).toBe('42')
+    expect(escapeHtmlText(null)).toBe('')
+    expect(escapeHtmlAttribute(undefined)).toBe('')
+    expect(() => escapeHtmlText(hostileValue)).not.toThrow()
+    expect(escapeHtmlText(hostileValue)).toBe('')
+  })
+})

--- a/tests/unit/components/common/presentationValidation.test.js
+++ b/tests/unit/components/common/presentationValidation.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getSafeHexColor,
+  getSafeISODate,
+} from '../../../../src/components/common/presentationValidation.js'
+
+describe('presentationValidation', () => {
+  it('conserva colores hex historicos y normaliza mayusculas', () => {
+    expect(getSafeHexColor('#38bdf8')).toBe('#38bdf8')
+    expect(getSafeHexColor('#A78BFA')).toBe('#a78bfa')
+  })
+
+  it.each([
+    '#38bdf8; position: fixed',
+    'red',
+    '#fff',
+    undefined,
+  ])('descarta colores CSS fuera de la allowlist sin lanzar: %p', value => {
+    expect(() => getSafeHexColor(value)).not.toThrow()
+    expect(getSafeHexColor(value)).toBeNull()
+  })
+
+  it('acepta fechas reales y descarta fechas antiguas contaminadas', () => {
+    expect(getSafeISODate('2024-02-29')).toBe('2024-02-29')
+    expect(getSafeISODate('2026-02-29')).toBeNull()
+    expect(getSafeISODate('__proto__')).toBeNull()
+  })
+})

--- a/tests/unit/components/feed/NoteList.test.js
+++ b/tests/unit/components/feed/NoteList.test.js
@@ -12,6 +12,10 @@ vi.mock('../../../../src/store/NoteStore.js', () => ({
 import * as NoteStore from '../../../../src/store/NoteStore.js'
 import { NoteList } from '../../../../src/components/feed/NoteList.js'
 
+const ADVERSARIAL_NOTE_ID = 'note-id"] data-injected="true # [odd'
+const ADVERSARIAL_SUBJECT_ID = 'subject-id"] data-injected="true # [odd'
+const INVALID_CSS_COLOR = '#38bdf8; position: fixed'
+
 function makeNote(overrides = {}) {
   return {
     id: 'note-1',
@@ -147,6 +151,95 @@ describe('NoteList copy feedback', () => {
     expect(dropdown.classList.contains('is-closing')).toBe(false)
     expect(button.disabled).toBe(false)
     expect(button.textContent).toContain('Copiar')
+
+    list.destroy()
+  })
+})
+
+describe('NoteList presentation hardening', () => {
+  function contaminatedSubjects() {
+    return {
+      tree: [
+        {
+          id: ADVERSARIAL_SUBJECT_ID,
+          name: 'Álgebra "A" <B> & 😀',
+          color: INVALID_CSS_COLOR,
+          children: [],
+        },
+        {
+          id: 'historic-color',
+          name: 'Color histórico',
+          color: '#38bdf8',
+          children: [],
+        },
+      ],
+    }
+  }
+
+  it('codifica IDs y texto, rechaza CSS arbitrario y conserva hex historico en badge y menu', () => {
+    const list = createList()
+    const html = list.renderCard(makeNote({
+      id: ADVERSARIAL_NOTE_ID,
+      subjectId: ADVERSARIAL_SUBJECT_ID,
+      title: 'Resumen "A" <B> & 😀',
+      content: 'Resumen "A" <B> & 😀\nCuerpo **Markdown**',
+    }), contaminatedSubjects())
+    const wrapper = document.createElement('div')
+    wrapper.innerHTML = html
+
+    const card = wrapper.querySelector('.note-card')
+    const badge = wrapper.querySelector('.note-card__subject-badge')
+    const moveButtons = [...wrapper.querySelectorAll('.js-btn-move-to')]
+    const contaminatedMove = moveButtons.find(button => button.dataset.subjectId === ADVERSARIAL_SUBJECT_ID)
+    const historicMove = moveButtons.find(button => button.dataset.subjectId === 'historic-color')
+
+    expect(wrapper.querySelector('[data-injected]')).toBeNull()
+    expect(wrapper.querySelectorAll('.note-card')).toHaveLength(1)
+    expect(card?.dataset.id).toBe(ADVERSARIAL_NOTE_ID)
+    expect(wrapper.querySelector('.note-card__implicit-title')?.textContent)
+      .toBe('Resumen "A" <B> & 😀')
+    expect(badge?.textContent).toBe('Álgebra "A" <B> & 😀')
+    expect(badge?.style.getPropertyValue('--subject-color')).toBe('')
+    expect(badge?.style.position).toBe('')
+    expect(contaminatedMove?.dataset.noteId).toBe(ADVERSARIAL_NOTE_ID)
+    expect(contaminatedMove?.querySelector('.note-card__move-color')?.style.position).toBe('')
+    expect(historicMove?.querySelector('.note-card__move-color')?.getAttribute('style'))
+      .toContain('background-color: #38bdf8')
+    expect([...wrapper.querySelectorAll('[data-id]')].every(element => (
+      element.dataset.id === ADVERSARIAL_NOTE_ID
+    ))).toBe(true)
+    expect([...wrapper.querySelectorAll('[data-note-id]')].every(element => (
+      element.dataset.noteId === ADVERSARIAL_NOTE_ID
+    ))).toBe(true)
+
+    list.destroy()
+  })
+
+  it('usa la misma defensa en feed normal y ruta virtualizada', () => {
+    const list = createList()
+    const subjects = contaminatedSubjects()
+    const contaminatedNote = makeNote({
+      id: ADVERSARIAL_NOTE_ID,
+      subjectId: ADVERSARIAL_SUBJECT_ID,
+      content: 'Título <legítimo> "citado" & 😀\nTexto **Markdown**',
+    })
+    const state = { subjects }
+
+    list.renderNotes([contaminatedNote], state)
+    expect(list.feedContainer.querySelector('.note-card')?.dataset.id).toBe(ADVERSARIAL_NOTE_ID)
+    expect(list.feedContainer.querySelector('[data-injected]')).toBeNull()
+
+    const manyNotes = [
+      contaminatedNote,
+      ...Array.from({ length: 50 }, (_, index) => makeNote({ id: `note-${index + 2}` })),
+    ]
+    list.renderNotes(manyNotes, state)
+
+    expect(list.feedContainer.classList.contains('feed--virtual')).toBe(true)
+    expect(list.feedContainer.querySelector('.feed__window')).not.toBeNull()
+    expect(list.feedContainer.querySelector('.note-card')?.dataset.id).toBe(ADVERSARIAL_NOTE_ID)
+    expect(list.feedContainer.querySelector('[data-injected]')).toBeNull()
+    expect(list.feedContainer.textContent).toContain('Título <legítimo> "citado" & 😀')
 
     list.destroy()
   })

--- a/tests/unit/components/feed/TrashView.test.js
+++ b/tests/unit/components/feed/TrashView.test.js
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as SubjectService from '../../../../src/services/SubjectService.js'
 import { renderTrashView } from '../../../../src/components/feed/TrashView.js'
 
+const ADVERSARIAL_ID = 'entity-id"] data-injected="true # [odd'
+const INVALID_CSS_COLOR = '#38bdf8; position: fixed'
+
 vi.mock('../../../../src/services/SubjectService.js', () => ({
   getTrashItems: vi.fn(),
 }))
@@ -89,5 +92,62 @@ describe('TrashView', () => {
 
     const names = [...container.querySelectorAll('.trash-item__name')].map(node => node.textContent)
     expect(names).toEqual(['Sin título', 'Sin título (1)', 'Sin título (2)'])
+  })
+
+  it('protege entidades contaminadas borradas sin inyectar DOM, atributos ni CSS', async () => {
+    SubjectService.getTrashItems.mockResolvedValue(trashData({
+      totalCount: 4,
+      subjects: [{
+        id: ADVERSARIAL_ID,
+        name: 'Materia "A" <B> & 😀',
+        color: INVALID_CSS_COLOR,
+        noteCount: 1,
+        deletedAt: '2024-01-15T09:00:00.000Z',
+        children: [{
+          id: 'child-id"] data-injected="true',
+          name: 'Sección <1> "citada" & 🧪',
+          color: '#38bdf8',
+          noteCount: 1,
+          deletedAt: '2024-01-15T09:00:00.000Z',
+        }],
+      }],
+      orphanSections: [{
+        id: 'orphan-id"] data-injected="true',
+        name: 'Huérfana <segura> & 😀',
+        color: INVALID_CSS_COLOR,
+        parentColor: '#38bdf8',
+        parentName: 'Padre "histórico" <2025>',
+        noteCount: 1,
+        deletedAt: '2024-01-15T09:00:00.000Z',
+      }],
+      notes: [{
+        id: 'note-id"] data-injected="true',
+        title: 'Nota "legítima" < > & 😀',
+        content: '# Markdown <dato> "citado" & 😀',
+        deletedAt: '2024-01-15T09:00:00.000Z',
+      }],
+    }))
+    const container = document.createElement('div')
+
+    await renderTrashView(container)
+
+    const restoreSubject = container.querySelector('.js-btn-restore-subject')
+    const colorDots = container.querySelectorAll('.drawer__subject-color')
+
+    expect(container.querySelector('[data-injected]')).toBeNull()
+    expect(restoreSubject?.dataset.id).toBe(ADVERSARIAL_ID)
+    expect(container.textContent).toContain('Materia "A" <B> & 😀')
+    expect(container.textContent).toContain('Nota "legítima" < > & 😀')
+    expect(colorDots[0].style.backgroundColor).toBe('')
+    expect(colorDots[0].style.position).toBe('')
+    expect(colorDots[1].getAttribute('style')).toContain('background-color: #38bdf8')
+    expect(colorDots[2].getAttribute('style')).toContain('background-color: #38bdf8')
+    expect([...container.querySelectorAll('[data-id]')].map(element => element.dataset.id))
+      .toEqual([
+        ADVERSARIAL_ID,
+        'orphan-id"] data-injected="true',
+        'note-id"] data-injected="true',
+        'note-id"] data-injected="true',
+      ])
   })
 })

--- a/tests/unit/components/note-editor/SubjectPicker.test.js
+++ b/tests/unit/components/note-editor/SubjectPicker.test.js
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { SubjectPicker } from '../../../../src/components/note-editor/SubjectPicker.js'
+
+const ADVERSARIAL_ID = 'subject-id"] data-injected="true # [odd'
+const INVALID_CSS_COLOR = '#38bdf8; position: fixed'
+
+function createPicker() {
+  document.body.innerHTML = `
+    <div id="composer-root">
+      <input id="composer-subject-select" type="hidden">
+      <button id="composer-subject-trigger" type="button" aria-expanded="false">
+        <span class="composer__subject-trigger-dot"></span>
+        <span id="composer-subject-label"></span>
+      </button>
+      <div id="composer-subject-menu" hidden></div>
+    </div>
+  `
+
+  return new SubjectPicker(document.getElementById('composer-root'))
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('SubjectPicker presentation hardening', () => {
+  it('preserva texto e IDs, descarta CSS arbitrario y conserva hex historico', () => {
+    const picker = createPicker()
+    const legitimateLabel = 'Materia "A" <B> & 😀'
+
+    picker.update({
+      tree: [
+        {
+          id: ADVERSARIAL_ID,
+          name: legitimateLabel,
+          color: INVALID_CSS_COLOR,
+          children: [],
+        },
+        {
+          id: 'historic-color',
+          name: 'Histórica "2025" <segura> & 🧪',
+          color: '#38bdf8',
+          children: [],
+        },
+      ],
+    })
+
+    const options = [...picker.menu.querySelectorAll('.composer__subject-option')]
+    const contaminatedOption = options.find(option => option.dataset.subjectId === ADVERSARIAL_ID)
+    const historicOption = options.find(option => option.dataset.subjectId === 'historic-color')
+
+    expect(picker.menu.querySelector('[data-injected]')).toBeNull()
+    expect(contaminatedOption?.getAttribute('aria-label')).toBe(legitimateLabel)
+    expect(contaminatedOption?.querySelector('.composer__subject-option-label')?.textContent)
+      .toBe(legitimateLabel)
+    expect(contaminatedOption?.querySelector('.composer__subject-option-dot')?.getAttribute('style'))
+      .toBeNull()
+    expect(historicOption?.querySelector('.composer__subject-option-dot')?.getAttribute('style'))
+      .toContain('--subject-color: #38bdf8')
+
+    contaminatedOption.click()
+    expect(picker.getValue()).toBe(ADVERSARIAL_ID)
+    expect(picker.label.textContent).toBe(legitimateLabel)
+    expect(picker.trigger.style.getPropertyValue('--subject-color')).toBe('')
+    expect(picker.trigger.style.position).toBe('')
+
+    picker.setValue('historic-color')
+    expect(picker.trigger.style.getPropertyValue('--subject-color')).toBe('#38bdf8')
+
+    picker.destroy()
+  })
+})

--- a/tests/unit/domain/primitiveValidation.test.js
+++ b/tests/unit/domain/primitiveValidation.test.js
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  parseBoundedOneLineText,
+  parseHexColor,
+  parseISODate,
+  parseLegacyBoolean,
+  parseOpaqueId,
+  parseRFC3339Timestamp,
+  parseUtf8ByteBoundedContent,
+  PrimitiveValidationError,
+} from '../../../src/domain/primitiveValidation.ts'
+
+describe('primitiveValidation', () => {
+  describe('parseOpaqueId', () => {
+    it('acepta IDs historicos ASCII, recorta extremos y respeta el limite exacto', () => {
+      expect(parseOpaqueId('  subj-math  ', 128)).toBe('subj-math')
+      expect(parseOpaqueId('A.b_c:d-1', 128)).toBe('A.b_c:d-1')
+      expect(parseOpaqueId(`a${'x'.repeat(127)}`, 128)).toHaveLength(128)
+    })
+
+    it.each([
+      [{ id: 'note-1' }, 128],
+      ['', 128],
+      ['-starts-with-separator', 128],
+      ['has space', 128],
+      ['nota/1', 128],
+      ['ñota-1', 128],
+      [`a${'x'.repeat(128)}`, 128],
+    ])('rechaza tipo, formato o longitud invalidos: %p', (value, limit) => {
+      expect(() => parseOpaqueId(value, limit)).toThrow(PrimitiveValidationError)
+    })
+  })
+
+  describe('parseHexColor', () => {
+    it('acepta null y colores historicos de seis digitos normalizados', () => {
+      expect(parseHexColor(null)).toBeNull()
+      expect(parseHexColor('#38bdf8')).toBe('#38bdf8')
+      expect(parseHexColor('#A78BFA')).toBe('#a78bfa')
+    })
+
+    it.each([undefined, 123, '#fff', 'red', ' #38bdf8', '#38bdf8; color:red'])
+      ('rechaza colores fuera del contrato: %p', value => {
+        expect(() => parseHexColor(value)).toThrow(PrimitiveValidationError)
+      })
+  })
+
+  describe('parseISODate', () => {
+    it.each(['2024-02-29', '2000-02-29', '2026-01-31'])
+      ('acepta fechas reales, incluidos bisiestos: %s', value => {
+        expect(parseISODate(value)).toBe(value)
+      })
+
+    it.each([
+      '0000-01-01',
+      '1900-02-29',
+      '2100-02-29',
+      '2026-02-29',
+      '2026-04-31',
+      '2026-13-01',
+      '2026-1-01',
+      '2026-01-01T00:00:00Z',
+      20260101,
+    ])('rechaza fechas mal tipadas, inexistentes o mal formadas: %p', value => {
+      expect(() => parseISODate(value)).toThrow(PrimitiveValidationError)
+    })
+  })
+
+  describe('parseRFC3339Timestamp', () => {
+    it.each([
+      ['2026-06-03T12:30:00Z', '2026-06-03T12:30:00.000Z'],
+      ['2026-06-03t12:30:00.123z', '2026-06-03T12:30:00.123Z'],
+      ['2026-06-03T09:30:00-03:00', '2026-06-03T12:30:00.000Z'],
+      ['2026-06-03T18:00:00+05:30', '2026-06-03T12:30:00.000Z'],
+      ['2024-02-29T23:59:59.999999999+00:00', '2024-02-29T23:59:59.999Z'],
+    ])('acepta una zona explicita y normaliza el instante a UTC: %s', (value, expected) => {
+      expect(parseRFC3339Timestamp(value)).toBe(expected)
+    })
+
+    it.each([
+      '2026-06-03T12:30:00',
+      '2026-02-29T12:30:00Z',
+      '2026-06-03 12:30:00Z',
+      '2026-06-03T24:00:00Z',
+      '2026-06-03T12:60:00Z',
+      '2026-06-03T12:30:60Z',
+      '2026-06-03T12:30:00+24:00',
+      '2026-06-03T12:30:00+01:60',
+      'not-a-date',
+      new Date('2026-06-03T12:30:00Z'),
+    ])('rechaza timestamps sin zona, mal tipados o con componentes invalidos: %p', value => {
+      expect(() => parseRFC3339Timestamp(value)).toThrow(PrimitiveValidationError)
+    })
+  })
+
+  describe('parseBoundedOneLineText', () => {
+    const options = { maxCodePoints: 4, trim: true, allowEmpty: false }
+
+    it('preserva markup, comillas y emoji legitimos y cuenta code points', () => {
+      expect(parseBoundedOneLineText('<😀>', options)).toBe('<😀>')
+      expect(parseBoundedOneLineText('😀😀😀😀', options)).toBe('😀😀😀😀')
+      expect(() => parseBoundedOneLineText('😀😀😀😀a', options)).toThrow('code points')
+      expect(parseBoundedOneLineText('"md"', options)).toBe('"md"')
+    })
+
+    it.each(['', '   ', 'a\0b', 'a\nb', 'a\n', '\nb', 'a\rb', 'a\u0001b', 'a\u2028b', { text: 'ok' }])
+      ('rechaza vacios, tipos incorrectos y controles: %p', value => {
+        expect(() => parseBoundedOneLineText(value, options)).toThrow(PrimitiveValidationError)
+      })
+  })
+
+  describe('parseUtf8ByteBoundedContent', () => {
+    it('preserva Markdown multilinea y aplica el limite en bytes UTF-8', () => {
+      expect(parseUtf8ByteBoundedContent('# Titulo\n\n> "<texto>"\t', 64))
+        .toBe('# Titulo\n\n> "<texto>"\t')
+      expect(parseUtf8ByteBoundedContent('😀😀', 8)).toBe('😀😀')
+      expect(() => parseUtf8ByteBoundedContent('😀😀a', 8)).toThrow('bytes UTF-8')
+    })
+
+    it.each([null, {}, 'texto\0oculto', 'texto\u0001oculto', 'texto\u007foculto'])
+      ('rechaza tipos incorrectos y controles no aptos para contenido: %p', value => {
+        expect(() => parseUtf8ByteBoundedContent(value, 64)).toThrow(PrimitiveValidationError)
+      })
+  })
+
+  describe('parseLegacyBoolean', () => {
+    it.each([
+      [true, true], [1, true], ['true', true], ['1', true],
+      [false, false], [0, false], ['false', false], ['0', false],
+    ])('acepta exclusivamente el valor legacy %p', (value, expected) => {
+      expect(parseLegacyBoolean(value)).toBe(expected)
+    })
+
+    it.each([undefined, null, 2, -1, 'True', 'FALSE', ' true ', '', {}, []])
+      ('rechaza coerciones no exactas: %p', value => {
+        expect(() => parseLegacyBoolean(value)).toThrow(PrimitiveValidationError)
+      })
+  })
+})

--- a/tests/unit/layout/drawerSubjects.test.js
+++ b/tests/unit/layout/drawerSubjects.test.js
@@ -6,6 +6,9 @@ import { initSubjects } from '../../../src/layout/drawerSubjects.js'
 import { DRAWER_SUBJECT_COLLAPSE_STORAGE_KEY } from '../../../src/layout/drawerSubjectCollapseState.js'
 
 const SUBJECT_COLORS = ['#818cf8', '#22c55e']
+const ADVERSARIAL_SUBJECT_ID = 'subject-id"] # odd[data-injected="true'
+const LEGITIMATE_SUBJECT_NAME = 'Álgebra "A" <B> & 😀'
+const INVALID_CSS_COLOR = '#38bdf8; position: fixed'
 
 function makeSubjectsData() {
   return {
@@ -199,5 +202,110 @@ describe('drawerSubjects collapse', () => {
 
     expect(NoteStore.createSubject).toHaveBeenCalledWith('Practica', '#818cf8', 'subj-1')
     expect(getStoredCollapsedIds()).toBeNull()
+  })
+})
+
+describe('drawerSubjects presentation hardening', () => {
+  it('codifica IDs y nombres, rechaza CSS arbitrario y conserva hex historico', () => {
+    const subjectsData = {
+      inboxCount: 1,
+      tree: [{
+        id: ADVERSARIAL_SUBJECT_ID,
+        name: LEGITIMATE_SUBJECT_NAME,
+        color: INVALID_CSS_COLOR,
+        noteCount: 1,
+        children: [{
+          id: 'section-id"] [data-injected="child',
+          name: 'Sección "1" <práctica> & 🧪',
+          color: '#38bdf8',
+          noteCount: 1,
+        }],
+      }],
+    }
+
+    const { subjectsList } = setupSubjectsDrawer({ subjectsData })
+    const subjectButton = subjectsList.querySelector('.js-subject-nav:not(.drawer__subject-btn--child)')
+    const colorDots = subjectsList.querySelectorAll('.drawer__subject-color')
+
+    expect(subjectsList.querySelectorAll('.drawer__subject-group')).toHaveLength(1)
+    expect(subjectsList.querySelector('[data-injected]')).toBeNull()
+    expect(subjectButton?.dataset.subject).toBe(ADVERSARIAL_SUBJECT_ID)
+    expect(subjectButton?.dataset.subjectName).toBe(LEGITIMATE_SUBJECT_NAME)
+    expect(subjectButton?.querySelector('.drawer__subject-name')?.textContent).toBe(LEGITIMATE_SUBJECT_NAME)
+    expect(colorDots[0].style.backgroundColor).toBe('')
+    expect(colorDots[0].style.position).toBe('')
+    expect(colorDots[1].getAttribute('style')).toContain('background-color: #38bdf8')
+  })
+
+  it('mantiene navegacion, formularios y renombrado con IDs adversariales sin SyntaxError', async () => {
+    const subjectsData = {
+      inboxCount: 0,
+      tree: [{
+        id: ADVERSARIAL_SUBJECT_ID,
+        name: LEGITIMATE_SUBJECT_NAME,
+        color: '#38bdf8',
+        noteCount: 0,
+        children: [],
+      }],
+    }
+    const { NoteStore, subjectsList } = setupSubjectsDrawer({ subjectsData })
+    const subjectButton = subjectsList.querySelector('.js-subject-nav')
+    const addButton = subjectsList.querySelector('.js-btn-add-section')
+
+    expect(() => addButton.click()).not.toThrow()
+    const form = subjectsList.querySelector('.drawer__section-form')
+    expect(form?.dataset.parentId).toBe(ADVERSARIAL_SUBJECT_ID)
+    expect(form?.style.display).toBe('block')
+
+    form.querySelector('.js-section-name-input').value = 'Práctica "A" & 😀'
+    expect(() => form.querySelector('.js-btn-section-save').click()).not.toThrow()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(NoteStore.createSubject).toHaveBeenCalledWith(
+      'Práctica "A" & 😀',
+      '#38bdf8',
+      ADVERSARIAL_SUBJECT_ID,
+    )
+
+    expect(() => subjectButton.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }))).not.toThrow()
+    expect(() => document.querySelector('#subject-context-menu .js-ctx-rename').click()).not.toThrow()
+    const renameInput = subjectsList.querySelector('.js-rename-input')
+    expect(renameInput?.dataset.subjectId).toBe(ADVERSARIAL_SUBJECT_ID)
+    expect(() => renameInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))).not.toThrow()
+    expect(subjectsList.querySelector('.js-rename-input')).toBeNull()
+
+    expect(() => subjectButton.click()).not.toThrow()
+    expect(NoteStore.setActiveSubject).toHaveBeenCalledWith(ADVERSARIAL_SUBJECT_ID)
+  })
+
+  it('protege materias archivadas contaminadas sin perder colores validos', () => {
+    const archivedSubjects = {
+      tree: [{
+        id: ADVERSARIAL_SUBJECT_ID,
+        name: LEGITIMATE_SUBJECT_NAME,
+        color: INVALID_CSS_COLOR,
+        archived: true,
+        noteCount: 1,
+        children: [{
+          id: 'archived-child"] data-injected="true',
+          name: 'Histórica <2025> & 😀',
+          color: '#38bdf8',
+          noteCount: 1,
+        }],
+      }],
+    }
+
+    const { subjectsList } = setupSubjectsDrawer({
+      stateOverrides: { viewMode: 'archived', archivedSubjects },
+    })
+    const restoreButtons = subjectsList.querySelectorAll('.js-btn-unarchive-subject')
+    const colorDots = subjectsList.querySelectorAll('.drawer__subject-color')
+
+    expect(subjectsList.querySelector('[data-injected]')).toBeNull()
+    expect(restoreButtons[0].dataset.subjectId).toBe(ADVERSARIAL_SUBJECT_ID)
+    expect(restoreButtons[0].dataset.subjectName).toBe(LEGITIMATE_SUBJECT_NAME)
+    expect(colorDots[0].style.backgroundColor).toBe('')
+    expect(colorDots[0].style.position).toBe('')
+    expect(colorDots[1].getAttribute('style')).toContain('background-color: #38bdf8')
   })
 })

--- a/tests/unit/services/backup/BackupImportPlanService.test.js
+++ b/tests/unit/services/backup/BackupImportPlanService.test.js
@@ -79,6 +79,32 @@ function parsedBackup(overrides = {}) {
   }
 }
 
+function subjectParentsById(plan) {
+  return Object.fromEntries(plan.data.subjects.map(item => [item.id, item.parentSubjectId]))
+}
+
+function normalizedSubjectRepairs(plan) {
+  return plan.relationshipRepairs
+    .filter(repair => repair.entity === 'subject')
+    .map(({ id, from, to, reason }) => ({ id, from, to, reason }))
+    .sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function expectValidTwoLevelHierarchy(plan, localSubjects = []) {
+  const subjectsById = new Map([
+    ...localSubjects.map(item => [item.id, item]),
+    ...plan.data.subjects.map(item => [item.id, item]),
+  ])
+
+  for (const item of plan.data.subjects) {
+    if (!item.parentSubjectId) continue
+
+    const parent = subjectsById.get(item.parentSubjectId)
+    expect(parent).toBeDefined()
+    expect(parent.parentSubjectId).toBeNull()
+  }
+}
+
 describe('BackupImportPlanService', () => {
   it('crea un plan importable completo cuando no hay datos locales', () => {
     const plan = createBackupImportPlan(parsedBackup())
@@ -107,6 +133,196 @@ describe('BackupImportPlanService', () => {
 
     expect(plan.data.subjects.map(item => item.id)).toEqual(['subj-root', 'sec-1'])
     expect(plan.data.subjects[1].parentSubjectId).toBe('subj-root')
+  })
+
+  it('repara cada nivel profundo y conserva referencias a subjects planificados', () => {
+    const plan = createBackupImportPlan(parsedBackup({
+      data: {
+        subjects: [
+          subject({ id: 'level-5', name: 'Nivel 5', parentSubjectId: 'level-4' }),
+          subject({ id: 'level-3', name: 'Nivel 3', parentSubjectId: 'level-2' }),
+          subject({ id: 'level-1', name: 'Nivel 1' }),
+          subject({ id: 'level-4', name: 'Nivel 4', parentSubjectId: 'level-3' }),
+          subject({ id: 'level-2', name: 'Nivel 2', parentSubjectId: 'level-1' }),
+        ],
+        notes: [note({ id: 'note-deep', subjectId: 'level-5' })],
+        academicEvents: [academicEvent({ id: 'event-deep', subjectId: 'level-3' })],
+      },
+    }))
+
+    expect(plan.data.subjects).toHaveLength(5)
+    expect(subjectParentsById(plan)).toEqual({
+      'level-1': null,
+      'level-2': 'level-1',
+      'level-3': null,
+      'level-4': 'level-3',
+      'level-5': null,
+    })
+    expect(normalizedSubjectRepairs(plan)).toEqual([
+      {
+        id: 'level-3',
+        from: 'level-2',
+        to: null,
+        reason: 'La materia padre ya es una seccion; no se permiten mas de 2 niveles.',
+      },
+      {
+        id: 'level-5',
+        from: 'level-4',
+        to: null,
+        reason: 'La materia padre ya es una seccion; no se permiten mas de 2 niveles.',
+      },
+    ])
+    expect(plan.counts.relationshipRepairs).toBe(2)
+    expect(plan.data.notes[0].subjectId).toBe('level-5')
+    expect(plan.data.academicEvents[0].subjectId).toBe('level-3')
+    expectValidTwoLevelHierarchy(plan)
+  })
+
+  it('repara un padre local que ya es una seccion', () => {
+    const localSubjects = [
+      subject({ id: 'local-root', name: 'Local' }),
+      subject({ id: 'local-section', name: 'Seccion local', parentSubjectId: 'local-root' }),
+    ]
+    const plan = createBackupImportPlan(parsedBackup({
+      data: {
+        subjects: [
+          subject({ id: 'imported-child', name: 'Hija', parentSubjectId: 'local-section' }),
+        ],
+        notes: [],
+        academicEvents: [],
+      },
+    }), {
+      localData: { subjects: localSubjects },
+    })
+
+    expect(plan.data.subjects[0].parentSubjectId).toBeNull()
+    expect(normalizedSubjectRepairs(plan)).toEqual([
+      {
+        id: 'imported-child',
+        from: 'local-section',
+        to: null,
+        reason: 'La materia padre ya es una seccion; no se permiten mas de 2 niveles.',
+      },
+    ])
+    expectValidTwoLevelHierarchy(plan, localSubjects)
+  })
+
+  it('repara un autociclo una sola vez sin omitir el subject', () => {
+    const plan = createBackupImportPlan(parsedBackup({
+      data: {
+        subjects: [subject({ id: 'self-cycle', name: 'Autociclo', parentSubjectId: 'self-cycle' })],
+        notes: [],
+        academicEvents: [],
+      },
+    }))
+
+    expect(subjectParentsById(plan)).toEqual({ 'self-cycle': null })
+    expect(normalizedSubjectRepairs(plan)).toEqual([
+      {
+        id: 'self-cycle',
+        from: 'self-cycle',
+        to: null,
+        reason: 'Se detecto una relacion circular entre materias/secciones.',
+      },
+    ])
+    expect(plan.counts.subjects).toEqual({ source: 1, importable: 1, skipped: 0 })
+    expect(plan.counts.relationshipRepairs).toBe(1)
+  })
+
+  it('repara ambos lados de un ciclo de dos nodos', () => {
+    const plan = createBackupImportPlan(parsedBackup({
+      data: {
+        subjects: [
+          subject({ id: 'cycle-b', name: 'B', parentSubjectId: 'cycle-a' }),
+          subject({ id: 'cycle-a', name: 'A', parentSubjectId: 'cycle-b' }),
+        ],
+        notes: [],
+        academicEvents: [],
+      },
+    }))
+
+    expect(subjectParentsById(plan)).toEqual({ 'cycle-a': null, 'cycle-b': null })
+    expect(normalizedSubjectRepairs(plan).map(repair => repair.id)).toEqual(['cycle-a', 'cycle-b'])
+    expect(plan.counts.relationshipRepairs).toBe(2)
+    expect(plan.data.subjects).toHaveLength(2)
+    expectValidTwoLevelHierarchy(plan)
+  })
+
+  it('normaliza ciclos largos con entrada de forma independiente del orden', () => {
+    const subjectsById = {
+      'cycle-a': subject({ id: 'cycle-a', name: 'A', parentSubjectId: 'cycle-b' }),
+      'cycle-b': subject({ id: 'cycle-b', name: 'B', parentSubjectId: 'cycle-c' }),
+      'cycle-c': subject({ id: 'cycle-c', name: 'C', parentSubjectId: 'cycle-a' }),
+      entry: subject({ id: 'entry', name: 'Entrada', parentSubjectId: 'cycle-a' }),
+      tail: subject({ id: 'tail', name: 'Cola', parentSubjectId: 'entry' }),
+    }
+    const planForOrder = order => createBackupImportPlan(parsedBackup({
+      data: {
+        subjects: order.map(id => subjectsById[id]),
+        notes: [],
+        academicEvents: [],
+      },
+    }))
+
+    const firstPlan = planForOrder(['tail', 'entry', 'cycle-b', 'cycle-a', 'cycle-c'])
+    const reversedPlan = planForOrder(['cycle-c', 'cycle-a', 'cycle-b', 'entry', 'tail'])
+    const expectedParents = {
+      'cycle-a': null,
+      'cycle-b': null,
+      'cycle-c': null,
+      entry: 'cycle-a',
+      tail: null,
+    }
+
+    expect(subjectParentsById(firstPlan)).toEqual(expectedParents)
+    expect(subjectParentsById(reversedPlan)).toEqual(expectedParents)
+    expect(normalizedSubjectRepairs(firstPlan)).toEqual(normalizedSubjectRepairs(reversedPlan))
+    expect(normalizedSubjectRepairs(firstPlan).map(repair => repair.id)).toEqual([
+      'cycle-a',
+      'cycle-b',
+      'cycle-c',
+      'tail',
+    ])
+    expect(firstPlan.data.subjects).toHaveLength(5)
+    expect(reversedPlan.data.subjects).toHaveLength(5)
+    expectValidTwoLevelHierarchy(firstPlan)
+    expectValidTwoLevelHierarchy(reversedPlan)
+  })
+
+  it('resuelve nombres en el nivel raiz despues de reparar el parent', () => {
+    const plan = createBackupImportPlan(parsedBackup({
+      data: {
+        subjects: [
+          subject({ id: 'deep-history', name: 'Historia', parentSubjectId: 'section-a' }),
+          subject({ id: 'root-history', name: 'Historia' }),
+          subject({ id: 'section-a', name: 'Unidad I', parentSubjectId: 'root-a' }),
+          subject({ id: 'root-a', name: 'Quimica' }),
+        ],
+        notes: [],
+        academicEvents: [],
+      },
+    }), {
+      localData: {
+        subjects: [subject({ id: 'local-history', name: 'Historia' })],
+      },
+    })
+    const namesById = Object.fromEntries(plan.data.subjects.map(item => [item.id, item.name]))
+
+    expect(subjectParentsById(plan)['deep-history']).toBeNull()
+    expect(namesById['root-history']).toBe('Historia (importada)')
+    expect(namesById['deep-history']).toBe('Historia (importada 2)')
+    expect(plan.renamedSubjects).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'root-history',
+        to: 'Historia (importada)',
+        parentSubjectId: null,
+      }),
+      expect.objectContaining({
+        id: 'deep-history',
+        to: 'Historia (importada 2)',
+        parentSubjectId: null,
+      }),
+    ]))
   })
 
   it('omite registros que ya existen por ID local sin modificarlos', () => {

--- a/tests/unit/services/backup/BackupImportRegression.test.js
+++ b/tests/unit/services/backup/BackupImportRegression.test.js
@@ -300,4 +300,25 @@ describe('Backup import regression - ZIP exportado por Lumapse', () => {
     expect(insertValues('academic_events')[0][5]).toBe(CREATED_AT_ISO)
     expect(insertValues('academic_events')[0][6]).toBe(CREATED_AT_ISO)
   })
+
+  it('rechaza JSON no confiable antes de crear el plan o iniciar persistencia SQLite', async () => {
+    const backup = await createBackup({
+      subjects: [subject({ name: { markup: '<img src=x>' } })],
+      notes: [],
+      academicEvents: [],
+    })
+    const createPlan = vi.fn()
+    const applyPlan = vi.fn()
+
+    await expect(importBackupZip({
+      content: backup.content,
+      filename: backup.filename,
+    }, { createPlan, applyPlan })).rejects.toThrow('data/subjects.json[0].name')
+
+    expect(createPlan).not.toHaveBeenCalled()
+    expect(applyPlan).not.toHaveBeenCalled()
+    expect(backupDataSourceMocks.collectBackupData).not.toHaveBeenCalled()
+    expect(sqliteMocks.runTransaction).not.toHaveBeenCalled()
+    expect(sqliteMocks.db.run).not.toHaveBeenCalled()
+  })
 })

--- a/tests/unit/services/backup/BackupImportRegression.test.js
+++ b/tests/unit/services/backup/BackupImportRegression.test.js
@@ -280,6 +280,39 @@ describe('Backup import regression - ZIP exportado por Lumapse', () => {
     expect(insertValues('academic_events')[0][4]).toBeNull()
   })
 
+  it('persiste una jerarquia de dos niveles y conserva referencias al subject reparado', async () => {
+    const backup = await createBackup({
+      subjects: [
+        subject({ id: 'deep-section', name: 'Tema', parentSubjectId: 'section-a' }),
+        subject({ id: 'root-a', name: 'Materia' }),
+        subject({ id: 'section-a', name: 'Unidad', parentSubjectId: 'root-a' }),
+      ],
+      notes: [note({ id: 'note-deep', subjectId: 'deep-section' })],
+      academicEvents: [academicEvent({ id: 'event-deep', subjectId: 'deep-section' })],
+    })
+
+    const flow = await importBackupZip({ content: backup.content, filename: backup.filename })
+    const deepSubject = flow.plan.data.subjects.find(item => item.id === 'deep-section')
+
+    expect(deepSubject.parentSubjectId).toBeNull()
+    expect(flow.plan.relationshipRepairs).toEqual([
+      expect.objectContaining({
+        entity: 'subject',
+        id: 'deep-section',
+        field: 'parentSubjectId',
+        from: 'section-a',
+        to: null,
+        reason: 'La materia padre ya es una seccion; no se permiten mas de 2 niveles.',
+      }),
+    ])
+    expect(flow.plan.counts.relationshipRepairs).toBe(1)
+    expect(flow.plan.data.notes[0].subjectId).toBe('deep-section')
+    expect(flow.plan.data.academicEvents[0].subjectId).toBe('deep-section')
+    expect(insertValues('subjects').find(values => values[0] === 'deep-section')[2]).toBeNull()
+    expect(insertValues('notes')[0][6]).toBe('deep-section')
+    expect(insertValues('academic_events')[0][4]).toBe('deep-section')
+  })
+
   it('usa la fecha del manifest como fallback si faltan timestamps opcionales', async () => {
     const backup = await createBackup({
       subjects: [subject({ createdAt: null })],

--- a/tests/unit/services/backup/BackupImportValidation.test.js
+++ b/tests/unit/services/backup/BackupImportValidation.test.js
@@ -1,0 +1,432 @@
+import { describe, expect, it } from 'vitest'
+
+import { BackupImportError } from '../../../../src/domain/backupImport.ts'
+import { buildBackupManifest } from '../../../../src/services/backup/BackupFormat.ts'
+import {
+  BACKUP_IMPORT_DATA_POLICY,
+} from '../../../../src/services/backup/BackupImportPolicy.ts'
+import {
+  validateBackupImportEntities,
+  validateBackupManifest,
+} from '../../../../src/services/backup/BackupImportValidation.ts'
+
+const CREATED_AT = '2026-06-03T12:30:00.000Z'
+
+function rawManifest(overrides = {}) {
+  const base = buildBackupManifest({
+    createdAt: CREATED_AT,
+    filename: 'lumapse-2026-06-03-12-30.zip',
+    counts: { subjects: 1, notes: 1, academicEvents: 1 },
+  })
+
+  return {
+    ...base,
+    ...overrides,
+    dataPolicy: overrides.dataPolicy === null || typeof overrides.dataPolicy !== 'object'
+      ? (overrides.dataPolicy ?? base.dataPolicy)
+      : { ...base.dataPolicy, ...overrides.dataPolicy },
+    counts: overrides.counts === null || typeof overrides.counts !== 'object'
+      ? (overrides.counts ?? base.counts)
+      : { ...base.counts, ...overrides.counts },
+  }
+}
+
+function manifest(overrides = {}) {
+  return validateBackupManifest(rawManifest(overrides))
+}
+
+function subject(overrides = {}) {
+  return {
+    id: 'subj-math',
+    name: 'Matematica',
+    parentSubjectId: null,
+    archived: false,
+    color: '#38bdf8',
+    createdAt: '2026-05-01T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function note(overrides = {}) {
+  return {
+    id: 'note-1',
+    title: 'Parcial 1',
+    content: '# Parcial 1\n\nIntegrales y matrices.',
+    pinned: false,
+    archived: false,
+    statusEmoji: null,
+    subjectId: 'subj-math',
+    createdAt: '2026-05-02T10:00:00.000Z',
+    updatedAt: '2026-05-03T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function academicEvent(overrides = {}) {
+  return {
+    id: 'event-1',
+    type: 'parcial',
+    title: 'Primer parcial',
+    date: '2026-06-20',
+    subjectId: 'subj-math',
+    createdAt: '2026-05-10T10:00:00.000Z',
+    updatedAt: '2026-05-11T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function documents(overrides = {}) {
+  return {
+    subjects: [subject()],
+    notes: [note()],
+    academicEvents: [academicEvent()],
+    ...overrides,
+  }
+}
+
+function validateDocuments(input, manifestOverrides = {}) {
+  return validateBackupImportEntities(manifest(manifestOverrides), input)
+}
+
+describe('BackupImportValidation - manifest', () => {
+  it('normaliza timestamp, filename y booleans legacy sin coercion amplia', () => {
+    const parsed = validateBackupManifest(rawManifest({
+      createdAt: '2026-06-03T09:30:00-03:00',
+      filename: ' backup <manual> 😀.zip ',
+      dataPolicy: {
+        includesDeletedItems: '0',
+        includesArchivedItems: 1,
+        includesAttachments: 'false',
+      },
+    }))
+
+    expect(parsed.createdAt).toBe(CREATED_AT)
+    expect(parsed.filename).toBe('backup <manual> 😀.zip')
+    expect(parsed.dataPolicy).toEqual({
+      includesDeletedItems: false,
+      includesArchivedItems: true,
+      includesAttachments: false,
+    })
+  })
+
+  it('acepta limites exactos de conteos y filename y rechaza limite + 1', () => {
+    const exact = rawManifest({
+      filename: '😀'.repeat(BACKUP_IMPORT_DATA_POLICY.maxManifestFilenameCodePoints),
+      counts: {
+        subjects: BACKUP_IMPORT_DATA_POLICY.maxSubjects,
+        notes: BACKUP_IMPORT_DATA_POLICY.maxNotes,
+        academicEvents: BACKUP_IMPORT_DATA_POLICY.maxAcademicEvents,
+      },
+    })
+
+    expect(validateBackupManifest(exact).counts).toMatchObject(exact.counts)
+    expect(() => validateBackupManifest({
+      ...exact,
+      filename: `${exact.filename}a`,
+    })).toThrow('manifest.json.filename')
+    expect(() => validateBackupManifest(rawManifest({
+      counts: { subjects: BACKUP_IMPORT_DATA_POLICY.maxSubjects + 1 },
+    }))).toThrow('manifest.json.counts.subjects')
+    expect(() => validateBackupManifest(rawManifest({
+      counts: { notes: BACKUP_IMPORT_DATA_POLICY.maxNotes + 1 },
+    }))).toThrow('manifest.json.counts.notes')
+    expect(() => validateBackupManifest(rawManifest({
+      counts: { academicEvents: BACKUP_IMPORT_DATA_POLICY.maxAcademicEvents + 1 },
+    }))).toThrow('manifest.json.counts.academicEvents')
+  })
+
+  it.each([
+    ['app', { app: 'OtraApp' }, 'no parece ser un backup de Lumapse'],
+    ['version', { backupFormatVersion: { version: 1 } }, 'Version de backup no soportada'],
+    ['createdAt', { createdAt: {} }, 'manifest.json.createdAt'],
+    ['filename', { filename: 123 }, 'manifest.json.filename'],
+    ['exportMode', { exportMode: 'automatic' }, 'manifest.json.exportMode'],
+    ['dataPolicy', { dataPolicy: 'all' }, 'manifest.json.dataPolicy'],
+    ['boolean', { dataPolicy: { includesDeletedItems: 'True' } }, 'includesDeletedItems'],
+    ['count string', { counts: { subjects: '1' } }, 'counts.subjects'],
+    ['count fraction', { counts: { notes: 1.5 } }, 'counts.notes'],
+    ['count negative', { counts: { academicEvents: -1 } }, 'counts.academicEvents'],
+    ['count non-finite', { counts: { attachments: Number.POSITIVE_INFINITY } }, 'counts.attachments'],
+    ['files missing', { files: undefined }, 'manifest.json.files'],
+    ['files type', { files: {} }, 'manifest.json.files'],
+  ])('rechaza manifest mal formado (%s)', (_case, overrides, expectedPath) => {
+    expect(() => validateBackupManifest(rawManifest(overrides))).toThrow(expectedPath)
+  })
+
+  it.each([
+    '../manifest.json',
+    '/manifest.json',
+    'C:/manifest.json',
+    'data\\notes.json',
+    'data//notes.json',
+    'data/./notes.json',
+    'data/../notes.json',
+    'data/',
+    'data/notes\n.json',
+  ])('rechaza rutas inseguras sin reflejar el valor: %p', file => {
+    let error
+    try {
+      validateBackupManifest(rawManifest({ files: [file] }))
+    } catch (caught) {
+      error = caught
+    }
+
+    expect(error).toBeInstanceOf(BackupImportError)
+    expect(error.message).toContain('manifest.json.files[0]')
+    expect(error.message).not.toContain(file)
+  })
+
+  it('rechaza tipos y rutas duplicadas e impone el limite de archivos antes de mapear', () => {
+    expect(() => validateBackupManifest(rawManifest({ files: [123] })))
+      .toThrow('manifest.json.files[0]')
+    expect(() => validateBackupManifest(rawManifest({
+      files: ['manifest.json', 'manifest.json'],
+    }))).toThrow('manifest.json.files[1]')
+
+    const exactFiles = Array.from(
+      { length: BACKUP_IMPORT_DATA_POLICY.maxManifestFiles },
+      (_, index) => `notes/${index}.md`,
+    )
+    expect(validateBackupManifest(rawManifest({ files: exactFiles })).files).toHaveLength(
+      BACKUP_IMPORT_DATA_POLICY.maxManifestFiles,
+    )
+    expect(() => validateBackupManifest(rawManifest({
+      files: [...exactFiles, 'notes/extra.md'],
+    }))).toThrow('supera el limite de archivos')
+  })
+})
+
+describe('BackupImportValidation - entidades', () => {
+  it('preserva compatibilidad v1 explicita y texto/Markdown legitimos', () => {
+    const parsed = validateDocuments(documents({
+      subjects: [subject({
+        id: ' historical.subject:1 ',
+        name: ' Materia <A> "😀" ',
+        archived: '1',
+        color: '#A78BFA',
+        createdAt: null,
+      })],
+      notes: [
+        note({
+          id: 'note_legacy-1',
+          title: null,
+          content: null,
+          pinned: 0,
+          archived: 'false',
+          createdAt: null,
+          updatedAt: null,
+        }),
+        note({
+          id: 'note-markdown',
+          title: ' "<Resumen>" 😀 ',
+          content: '# Markdown\n\n> <tag literal> & "comillas" 😀',
+          pinned: 'true',
+          archived: '0',
+          statusEmoji: ' ✅ ',
+          subjectId: '',
+        }),
+      ],
+      academicEvents: [academicEvent({
+        id: 'event-legacy',
+        type: 'exposicion',
+        title: ' "<Oral>" 😀 ',
+        date: '2024-02-29',
+        createdAt: null,
+        updatedAt: null,
+      })],
+    }), { counts: { subjects: 1, notes: 2, academicEvents: 1 } })
+
+    expect(parsed.data.subjects[0]).toMatchObject({
+      id: 'historical.subject:1',
+      name: 'Materia <A> "😀"',
+      archived: true,
+      color: '#a78bfa',
+      createdAt: CREATED_AT,
+    })
+    expect(parsed.data.notes[0]).toMatchObject({
+      title: 'Sin titulo', content: '', pinned: false, archived: false,
+      createdAt: CREATED_AT, updatedAt: CREATED_AT,
+    })
+    expect(parsed.data.notes[1]).toMatchObject({
+      title: '"<Resumen>" 😀',
+      content: '# Markdown\n\n> <tag literal> & "comillas" 😀',
+      statusEmoji: '✅',
+      subjectId: null,
+    })
+    expect(parsed.data.academicEvents[0]).toMatchObject({
+      type: 'exposicion', title: '"<Oral>" 😀', date: '2024-02-29',
+      createdAt: CREATED_AT, updatedAt: CREATED_AT,
+    })
+    expect(parsed.warnings).toEqual([])
+  })
+
+  it('omite papelera con avisos consolidados y conserva duplicados para el plan', () => {
+    const deletedAt = '2026-06-01T00:00:00.000Z'
+    const parsed = validateDocuments({
+      subjects: [
+        subject({ id: 'deleted-subject-1', deletedAt }),
+        subject({ id: 'deleted-subject-2', deletedAt }),
+        subject({ id: 'active-subject' }),
+        subject({ id: 'active-subject', name: 'Duplicada' }),
+      ],
+      notes: [note({ id: 'deleted-note-1', deletedAt }), note({ id: 'active-note' })],
+      academicEvents: [
+        academicEvent({ id: 'deleted-event-1', deletedAt }),
+        academicEvent({ id: 'deleted-event-2', deletedAt }),
+        academicEvent({ id: 'active-event' }),
+      ],
+    }, { counts: { subjects: 4, notes: 2, academicEvents: 3 } })
+
+    expect(parsed.data.subjects.map(item => item.id)).toEqual(['active-subject', 'active-subject'])
+    expect(parsed.data.notes.map(item => item.id)).toEqual(['active-note'])
+    expect(parsed.data.academicEvents.map(item => item.id)).toEqual(['active-event'])
+    expect(parsed.warnings.filter(warning => warning.includes('papelera'))).toEqual([
+      'Se omitieron 2 materias en papelera incluidas en el backup.',
+      'Se omitio una nota en papelera incluida en el backup.',
+      'Se omitieron 2 fechas academicas en papelera incluidas en el backup.',
+    ])
+  })
+
+  it('acepta los limites exactos de entidades antes de construir los arrays normalizados', () => {
+    const input = {
+      subjects: Array.from(
+        { length: BACKUP_IMPORT_DATA_POLICY.maxSubjects },
+        (_, index) => subject({ id: `subject-${index}` }),
+      ),
+      notes: Array.from(
+        { length: BACKUP_IMPORT_DATA_POLICY.maxNotes },
+        (_, index) => note({ id: `note-${index}`, title: null, content: null }),
+      ),
+      academicEvents: Array.from(
+        { length: BACKUP_IMPORT_DATA_POLICY.maxAcademicEvents },
+        (_, index) => academicEvent({ id: `event-${index}`, title: null }),
+      ),
+    }
+    const parsed = validateDocuments(input, {
+      counts: {
+        subjects: BACKUP_IMPORT_DATA_POLICY.maxSubjects,
+        notes: BACKUP_IMPORT_DATA_POLICY.maxNotes,
+        academicEvents: BACKUP_IMPORT_DATA_POLICY.maxAcademicEvents,
+      },
+    })
+
+    expect(parsed.counts).toEqual({
+      subjects: BACKUP_IMPORT_DATA_POLICY.maxSubjects,
+      notes: BACKUP_IMPORT_DATA_POLICY.maxNotes,
+      academicEvents: BACKUP_IMPORT_DATA_POLICY.maxAcademicEvents,
+    })
+  })
+
+  it.each([
+    ['subjects', BACKUP_IMPORT_DATA_POLICY.maxSubjects, subject],
+    ['notes', BACKUP_IMPORT_DATA_POLICY.maxNotes, note],
+    ['academicEvents', BACKUP_IMPORT_DATA_POLICY.maxAcademicEvents, academicEvent],
+  ])('rechaza %s en limite + 1 antes de normalizar items', (key, limit, factory) => {
+    const input = { subjects: [], notes: [], academicEvents: [] }
+    input[key] = Array.from({ length: limit + 1 }, (_, index) => factory({ id: `item-${index}` }))
+
+    expect(() => validateDocuments(input, {
+      counts: { subjects: 0, notes: 0, academicEvents: 0 },
+    })).toThrow('supera el limite de entidades')
+  })
+
+  it('genera una fixture practica de 500 notas sin incorporarla al repositorio', () => {
+    const input = {
+      subjects: [subject()],
+      notes: Array.from({ length: 500 }, (_, index) => note({
+        id: `fixture-note-${index}`,
+        title: `Nota ${index} 😀`,
+        content: `# Nota ${index}\n\nContenido **Markdown** <literal> 😀`,
+      })),
+      academicEvents: [],
+    }
+    const parsed = validateDocuments(input, {
+      counts: { subjects: 1, notes: 500, academicEvents: 0 },
+    })
+
+    expect(parsed.counts).toEqual({ subjects: 1, notes: 500, academicEvents: 0 })
+    expect(parsed.data.notes[499].content).toContain('**Markdown** <literal> 😀')
+  })
+
+  it('aplica limites exactos de campos y rechaza limite + 1', () => {
+    const exact = validateDocuments(documents({
+      subjects: [subject({
+        id: `s${'x'.repeat(BACKUP_IMPORT_DATA_POLICY.maxIdAsciiCharacters - 1)}`,
+        name: '😀'.repeat(BACKUP_IMPORT_DATA_POLICY.maxSubjectNameCodePoints),
+      })],
+      notes: [note({
+        title: '😀'.repeat(BACKUP_IMPORT_DATA_POLICY.maxNoteTitleCodePoints),
+        content: 'x'.repeat(BACKUP_IMPORT_DATA_POLICY.maxNoteContentBytes),
+        statusEmoji: '😀'.repeat(BACKUP_IMPORT_DATA_POLICY.maxNoteStatusCodePoints),
+      })],
+      academicEvents: [academicEvent({
+        title: '😀'.repeat(BACKUP_IMPORT_DATA_POLICY.maxAcademicEventTitleCodePoints),
+      })],
+    }))
+
+    expect(exact.data.subjects[0].name).toHaveLength(
+      BACKUP_IMPORT_DATA_POLICY.maxSubjectNameCodePoints * 2,
+    )
+    expect(exact.data.notes[0].content).toHaveLength(BACKUP_IMPORT_DATA_POLICY.maxNoteContentBytes)
+
+    const cases = [
+      documents({ subjects: [subject({ name: 'a'.repeat(BACKUP_IMPORT_DATA_POLICY.maxSubjectNameCodePoints + 1) })] }),
+      documents({ subjects: [subject({ id: `s${'x'.repeat(BACKUP_IMPORT_DATA_POLICY.maxIdAsciiCharacters)}` })] }),
+      documents({ notes: [note({ title: 'a'.repeat(BACKUP_IMPORT_DATA_POLICY.maxNoteTitleCodePoints + 1) })] }),
+      documents({ notes: [note({ content: 'a'.repeat(BACKUP_IMPORT_DATA_POLICY.maxNoteContentBytes + 1) })] }),
+      documents({ notes: [note({ statusEmoji: 'a'.repeat(BACKUP_IMPORT_DATA_POLICY.maxNoteStatusCodePoints + 1) })] }),
+      documents({ academicEvents: [academicEvent({
+        title: 'a'.repeat(BACKUP_IMPORT_DATA_POLICY.maxAcademicEventTitleCodePoints + 1),
+      })] }),
+    ]
+    for (const input of cases) {
+      expect(() => validateDocuments(input)).toThrow(BackupImportError)
+    }
+  })
+
+  it.each([
+    ['subject id', documents({ subjects: [subject({ id: {} })] }), 'data/subjects.json[0].id'],
+    ['subject name', documents({ subjects: [subject({ name: 3 })] }), 'data/subjects.json[0].name'],
+    ['subject parent', documents({ subjects: [subject({ parentSubjectId: [] })] }), 'parentSubjectId'],
+    ['subject boolean', documents({ subjects: [subject({ archived: 'yes' })] }), '.archived'],
+    ['subject color', documents({ subjects: [subject({ color: '#fff; color:red' })] }), '.color'],
+    ['subject timestamp', documents({ subjects: [subject({ createdAt: 'yesterday' })] }), '.createdAt'],
+    ['note title', documents({ notes: [note({ title: {} })] }), 'data/notes.json[0].title'],
+    ['note content', documents({ notes: [note({ content: [] })] }), '.content'],
+    ['note boolean', documents({ notes: [note({ pinned: null })] }), '.pinned'],
+    ['note status', documents({ notes: [note({ statusEmoji: 'ok\nno' })] }), '.statusEmoji'],
+    ['note subject', documents({ notes: [note({ subjectId: 1 })] }), '.subjectId'],
+    ['note timestamp', documents({ notes: [note({ updatedAt: '2026-01-01' })] }), '.updatedAt'],
+    ['event type', documents({ academicEvents: [academicEvent({ type: 'quiz' })] }), '.type'],
+    ['event title', documents({ academicEvents: [academicEvent({ title: {} })] }), '.title'],
+    ['event date', documents({ academicEvents: [academicEvent({ date: '2026-02-30' })] }), '.date'],
+    ['deletedAt', documents({ notes: [note({ deletedAt: false })] }), '.deletedAt'],
+  ])('rechaza tipo/formato invalido y señala indice/campo (%s)', (_case, input, path) => {
+    expect(() => validateDocuments(input)).toThrow(path)
+  })
+
+  it('no refleja payloads grandes o con markup en errores', () => {
+    const payload = `#123456"><img src=x>${'x'.repeat(1_000)}`
+    let error
+    try {
+      validateDocuments(documents({ subjects: [subject({ color: payload })] }))
+    } catch (caught) {
+      error = caught
+    }
+
+    expect(error).toBeInstanceOf(BackupImportError)
+    expect(error.message).toContain('data/subjects.json[0].color')
+    expect(error.message).not.toContain('<img')
+    expect(error.message.length).toBeLessThan(200)
+  })
+
+  it('rechaza un backup sin entidades importables despues de validar y omitir papelera', () => {
+    const deletedAt = '2026-06-01T00:00:00Z'
+    expect(() => validateDocuments({
+      subjects: [subject({ deletedAt })],
+      notes: [],
+      academicEvents: [],
+    }, { counts: { subjects: 1, notes: 0, academicEvents: 0 } }))
+      .toThrow('no contiene datos importables')
+  })
+})

--- a/tests/unit/services/backup/BackupImportZipService.test.js
+++ b/tests/unit/services/backup/BackupImportZipService.test.js
@@ -6,6 +6,11 @@ import {
   parseBackupImportZip,
 } from '../../../../src/services/backup/BackupImportZipService.ts'
 import { BackupImportError } from '../../../../src/domain/backupImport.ts'
+import { preflightBackupZip } from '../../../../src/services/backup/BackupZipPreflight.ts'
+import {
+  currentBackupBytes,
+  legacyBackupBytes,
+} from './BackupZipSecurityTestUtils.js'
 
 const CREATED_AT = new Date('2026-06-03T12:30:00.000Z')
 
@@ -73,14 +78,14 @@ function manifest(overrides = {}) {
   }
 }
 
-async function createZip(files) {
+async function createZip(files, options = {}) {
   const zip = new JSZip()
 
   for (const [path, content] of Object.entries(files)) {
     zip.file(path, typeof content === 'string' ? content : JSON.stringify(content, null, 2))
   }
 
-  return zip.generateAsync({ type: 'arraybuffer' })
+  return zip.generateAsync({ type: 'arraybuffer', ...options })
 }
 
 async function createValidZip(overrides = {}) {
@@ -89,7 +94,7 @@ async function createValidZip(overrides = {}) {
     'data/subjects.json': overrides.subjects || [subject()],
     'data/notes.json': overrides.notes || [note()],
     'data/academic-events.json': overrides.academicEvents || [academicEvent()],
-  })
+  }, overrides.zipOptions)
 }
 
 describe('BackupImportZipService', () => {
@@ -129,6 +134,39 @@ describe('BackupImportZipService', () => {
       type: 'parcial',
     })
     expect(parsed.warnings).toEqual([])
+  })
+
+  it('mantiene compatibilidad con backups historicos DEFLATE', async () => {
+    const content = await createValidZip({
+      zipOptions: {
+        compression: 'DEFLATE',
+        compressionOptions: { level: 9 },
+      },
+    })
+
+    const parsed = await parseBackupImportZip(content)
+
+    expect(parsed.counts).toEqual({
+      subjects: 1,
+      notes: 1,
+      academicEvents: 1,
+    })
+    expect(parsed.data.notes[0].id).toBe('note-1')
+  })
+
+  it('preserva los errores de integridad del lector acotado', async () => {
+    const content = currentBackupBytes([
+      { path: 'manifest.json', content: JSON.stringify(manifest()) },
+      { path: 'data/subjects.json', content: JSON.stringify([subject()]) },
+      { path: 'data/notes.json', content: JSON.stringify([note()]) },
+      { path: 'data/academic-events.json', content: JSON.stringify([academicEvent()]) },
+    ])
+    const archive = await preflightBackupZip(content)
+    const manifestEntry = archive.entries.find(entry => entry.path === 'manifest.json')
+    content[manifestEntry.dataOffset] ^= 0xff
+
+    await expect(parseBackupImportZip(content)).rejects
+      .toThrow('verificacion CRC32')
   })
 
   it('rechaza un ZIP que no contiene manifest.json', async () => {

--- a/tests/unit/services/backup/BackupZipEntryReader.test.js
+++ b/tests/unit/services/backup/BackupZipEntryReader.test.js
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  BACKUP_IMPORT_ZIP_POLICY,
+} from '../../../../src/services/backup/BackupImportPolicy.ts'
+import { readBackupZipText } from '../../../../src/services/backup/BackupZipEntryReader.ts'
+import { preflightBackupZip } from '../../../../src/services/backup/BackupZipPreflight.ts'
+import {
+  CANONICAL_BACKUP_FILES,
+  currentBackupBytes,
+  legacyBackupBytes,
+  setDeclaredEntrySize,
+} from './BackupZipSecurityTestUtils.js'
+
+function policy(overrides = {}) {
+  return {
+    ...BACKUP_IMPORT_ZIP_POLICY,
+    ...overrides,
+    jsonBytes: {
+      ...BACKUP_IMPORT_ZIP_POLICY.jsonBytes,
+      ...overrides.jsonBytes,
+    },
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('BackupZipEntryReader', () => {
+  it('lee texto STORE y valida su CRC32', async () => {
+    const archive = await preflightBackupZip(currentBackupBytes())
+
+    await expect(readBackupZipText(archive, 'manifest.json'))
+      .resolves.toBe('{"app":"Lumapse"}')
+  })
+
+  it('lee texto DEFLATE de backups historicos', async () => {
+    const archive = await preflightBackupZip(await legacyBackupBytes())
+
+    await expect(readBackupZipText(archive, 'manifest.json'))
+      .resolves.toBe('{"app":"Lumapse"}')
+  })
+
+  it('mantiene STORE disponible y falla cerrado si el runtime no soporta DEFLATE', async () => {
+    const stored = await preflightBackupZip(currentBackupBytes())
+    const deflated = await preflightBackupZip(await legacyBackupBytes())
+    vi.stubGlobal('DecompressionStream', undefined)
+
+    await expect(readBackupZipText(stored, 'manifest.json'))
+      .resolves.toBe('{"app":"Lumapse"}')
+    await expect(readBackupZipText(deflated, 'manifest.json'))
+      .rejects.toThrow('WebView debe actualizarse')
+  })
+
+  it('rechaza contenido STORE alterado aunque su metadata sea valida', async () => {
+    const bytes = currentBackupBytes()
+    const initial = await preflightBackupZip(bytes)
+    const manifest = initial.entries.find(entry => entry.path === 'manifest.json')
+    bytes[manifest.dataOffset] ^= 0xff
+    const corrupted = await preflightBackupZip(bytes)
+
+    await expect(readBackupZipText(corrupted, 'manifest.json'))
+      .rejects.toThrow('verificacion CRC32')
+  })
+
+  it('rechaza contenido que no sea UTF-8 valido', async () => {
+    const files = CANONICAL_BACKUP_FILES.map(file => (
+      file.path === 'manifest.json'
+        ? { ...file, content: new Uint8Array([0xff]) }
+        : file
+    ))
+    const archive = await preflightBackupZip(currentBackupBytes(files))
+
+    await expect(readBackupZipText(archive, 'manifest.json'))
+      .rejects.toThrow('no contiene UTF-8 valido')
+  })
+
+  it('cancela DEFLATE cuando el contenido real supera el limite por entrada', async () => {
+    const files = CANONICAL_BACKUP_FILES.map(file => (
+      file.path === 'manifest.json'
+        ? { ...file, content: 'A'.repeat(200_000) }
+        : file
+    ))
+    const bytes = await legacyBackupBytes(files)
+    setDeclaredEntrySize(bytes, 'manifest.json', 16)
+    const archive = await preflightBackupZip(bytes, policy({
+      jsonBytes: { 'manifest.json': 1_024 },
+    }))
+
+    await expect(readBackupZipText(archive, 'manifest.json'))
+      .rejects.toThrow('limite real descomprimido')
+  })
+
+  it('rechaza tamanos descomprimidos que no coinciden con lo declarado', async () => {
+    const bytes = await legacyBackupBytes()
+    setDeclaredEntrySize(bytes, 'manifest.json', 1)
+    const archive = await preflightBackupZip(bytes)
+
+    await expect(readBackupZipText(archive, 'manifest.json'))
+      .rejects.toThrow('no coincide con el tamano declarado')
+  })
+
+  it('rechaza rutas ausentes y carpetas como contenido de texto', async () => {
+    const archive = await preflightBackupZip(await legacyBackupBytes())
+
+    await expect(readBackupZipText(archive, 'missing.json')).rejects.toThrow('falta missing.json')
+    await expect(readBackupZipText(archive, 'data/')).rejects.toThrow('falta data/')
+  })
+})

--- a/tests/unit/services/backup/BackupZipPreflight.test.js
+++ b/tests/unit/services/backup/BackupZipPreflight.test.js
@@ -50,7 +50,7 @@ describe('BackupZipPreflight', () => {
   it('acepta ZIPs DEFLATE historicos con carpetas y rutas UTF-8', async () => {
     const bytes = await legacyBackupBytes([
       ...CANONICAL_BACKUP_FILES,
-      { path: 'notes/álgebra.md', content: '# Álgebra\n' },
+      { path: 'notes/matematica/álgebra.md', content: '# Álgebra\n' },
     ])
 
     const archive = await preflightBackupZip(bytes)
@@ -60,7 +60,8 @@ describe('BackupZipPreflight', () => {
     expect(archive.entries.map(entry => entry.path)).toEqual(expect.arrayContaining([
       'data/',
       'notes/',
-      'notes/álgebra.md',
+      'notes/matematica/',
+      'notes/matematica/álgebra.md',
     ]))
   })
 

--- a/tests/unit/services/backup/BackupZipPreflight.test.js
+++ b/tests/unit/services/backup/BackupZipPreflight.test.js
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+
+import { BackupImportError } from '../../../../src/domain/backupImport.ts'
+import {
+  BACKUP_IMPORT_ZIP_POLICY,
+} from '../../../../src/services/backup/BackupImportPolicy.ts'
+import {
+  preflightBackupZip,
+  ZIP_METHOD_DEFLATE,
+  ZIP_METHOD_STORE,
+} from '../../../../src/services/backup/BackupZipPreflight.ts'
+import {
+  bytesToBase64,
+  CANONICAL_BACKUP_FILES,
+  centralRecord,
+  currentBackupBytes,
+  endOfCentralDirectoryOffset,
+  legacyBackupBytes,
+  renameEntry,
+  setDeclaredEntrySize,
+  setEntryFlags,
+  setEntryMethod,
+  setUint16,
+  setUint32,
+} from './BackupZipSecurityTestUtils.js'
+
+function policy(overrides = {}) {
+  return {
+    ...BACKUP_IMPORT_ZIP_POLICY,
+    ...overrides,
+    jsonBytes: {
+      ...BACKUP_IMPORT_ZIP_POLICY.jsonBytes,
+      ...overrides.jsonBytes,
+    },
+  }
+}
+
+describe('BackupZipPreflight', () => {
+  it('acepta el ZIP STORE actual y conserva metadata acotada', async () => {
+    const archive = await preflightBackupZip(currentBackupBytes())
+
+    expect(archive.entries).toHaveLength(4)
+    expect(archive.entries.map(entry => entry.path)).toEqual(
+      CANONICAL_BACKUP_FILES.map(file => file.path),
+    )
+    expect(archive.entries.every(entry => entry.method === ZIP_METHOD_STORE)).toBe(true)
+    expect(archive.entries.every(entry => entry.maxOutputBytes > 0)).toBe(true)
+  })
+
+  it('acepta ZIPs DEFLATE historicos con carpetas y rutas UTF-8', async () => {
+    const bytes = await legacyBackupBytes([
+      ...CANONICAL_BACKUP_FILES,
+      { path: 'notes/álgebra.md', content: '# Álgebra\n' },
+    ])
+
+    const archive = await preflightBackupZip(bytes)
+    const manifest = archive.entries.find(entry => entry.path === 'manifest.json')
+
+    expect(manifest.method).toBe(ZIP_METHOD_DEFLATE)
+    expect(archive.entries.map(entry => entry.path)).toEqual(expect.arrayContaining([
+      'data/',
+      'notes/',
+      'notes/álgebra.md',
+    ]))
+  })
+
+  it('normaliza las fuentes soportadas y conserva un snapshot propio', async () => {
+    const bytes = currentBackupBytes()
+    const base64 = bytesToBase64(bytes)
+    const sources = [
+      bytes,
+      bytes.slice().buffer,
+      new Blob([bytes], { type: 'application/zip' }),
+      base64,
+      `data:application/zip;base64,${base64}`,
+      { content: bytes, filename: 'backup.zip' },
+    ]
+
+    for (const source of sources) {
+      await expect(preflightBackupZip(source)).resolves.toMatchObject({
+        entries: expect.any(Array),
+      })
+    }
+
+    const mutable = currentBackupBytes()
+    const expected = mutable.slice()
+    const pending = preflightBackupZip(mutable)
+    mutable.fill(0)
+    const archive = await pending
+
+    expect(archive.bytes).toEqual(expected)
+  })
+
+  it('rechaza fuentes vacias, sobredimensionadas y base64 invalido', async () => {
+    const bytes = currentBackupBytes()
+
+    await expect(preflightBackupZip(new Uint8Array())).rejects.toThrow('esta vacio')
+    await expect(preflightBackupZip(bytes, policy({
+      maxSourceBytes: bytes.byteLength - 1,
+    }))).rejects.toThrow('supera el limite permitido')
+    await expect(preflightBackupZip('%%%no-base64%%%')).rejects.toThrow('base64')
+  })
+
+  it('aplica limites de entradas, directorio central, entrada y total declarado', async () => {
+    const bytes = currentBackupBytes()
+
+    await expect(preflightBackupZip(bytes, policy({ maxEntries: 3 })))
+      .rejects.toThrow('cantidad de entradas ZIP')
+    await expect(preflightBackupZip(bytes, policy({ maxCentralDirectoryBytes: 1 })))
+      .rejects.toThrow('directorio central supera')
+    await expect(preflightBackupZip(bytes, policy({
+      jsonBytes: { 'manifest.json': 1 },
+    }))).rejects.toThrow('limite descomprimido declarado')
+    await expect(preflightBackupZip(bytes, policy({ maxDeclaredUncompressedBytes: 1 })))
+      .rejects.toThrow('limite total')
+  })
+
+  it('rechaza traversal, rutas no soportadas y duplicados', async () => {
+    const files = [...CANONICAL_BACKUP_FILES, { path: 'notes/a.md', content: '# A' }]
+    const traversal = currentBackupBytes(files)
+    const unexpected = currentBackupBytes(files)
+    const inheritedKey = currentBackupBytes([
+      ...CANONICAL_BACKUP_FILES,
+      { path: 'toString', content: 'unexpected' },
+    ])
+    const duplicate = currentBackupBytes([
+      ...CANONICAL_BACKUP_FILES,
+      { path: 'manifest.json', content: '{}' },
+    ])
+    renameEntry(traversal, 'notes/a.md', '../evil.md')
+    renameEntry(unexpected, 'notes/a.md', 'other/a.md')
+
+    await expect(preflightBackupZip(traversal)).rejects.toThrow('ruta')
+    await expect(preflightBackupZip(unexpected)).rejects.toThrow('entrada no soportada')
+    await expect(preflightBackupZip(inheritedKey)).rejects.toThrow('entrada no soportada')
+    await expect(preflightBackupZip(duplicate)).rejects.toThrow('rutas duplicadas')
+  })
+
+  it('rechaza flags peligrosos, metodos desconocidos, ZIP64 y multidisk', async () => {
+    const descriptor = currentBackupBytes()
+    const encrypted = currentBackupBytes()
+    const unknownMethod = currentBackupBytes()
+    const zip64 = currentBackupBytes()
+    const multidisk = currentBackupBytes()
+    setEntryFlags(descriptor, 'manifest.json', 0x0808)
+    setEntryFlags(encrypted, 'manifest.json', 0x0801)
+    setEntryMethod(unknownMethod, 'manifest.json', 99)
+    setUint16(zip64, endOfCentralDirectoryOffset(zip64) + 8, 0xffff)
+    setUint16(zip64, endOfCentralDirectoryOffset(zip64) + 10, 0xffff)
+    setUint16(multidisk, endOfCentralDirectoryOffset(multidisk) + 4, 1)
+
+    await expect(preflightBackupZip(descriptor)).rejects.toThrow('flags o version ZIP')
+    await expect(preflightBackupZip(encrypted)).rejects.toThrow('flags o version ZIP')
+    await expect(preflightBackupZip(unknownMethod)).rejects.toThrow('metodo de compresion')
+    await expect(preflightBackupZip(zip64)).rejects.toThrow('ZIP64')
+    await expect(preflightBackupZip(multidisk)).rejects.toThrow('multidisk')
+  })
+
+  it('rechaza discrepancias entre headers locales y el directorio central', async () => {
+    const bytes = currentBackupBytes()
+    const record = centralRecord(bytes, 'manifest.json')
+    setUint32(bytes, record.localOffset + 14, 0)
+
+    await expect(preflightBackupZip(bytes)).rejects.toThrow('header local no coincide')
+  })
+
+  it('rechaza tamanos STORE incompatibles y archivos canonicos faltantes', async () => {
+    const invalidStore = currentBackupBytes()
+    setDeclaredEntrySize(invalidStore, 'manifest.json', 1)
+    const missing = currentBackupBytes(CANONICAL_BACKUP_FILES.slice(0, -1))
+
+    await expect(preflightBackupZip(invalidStore)).rejects.toThrow('STORE declara tamanos')
+    await expect(preflightBackupZip(missing)).rejects.toThrow('falta data/academic-events.json')
+    await expect(preflightBackupZip(missing)).rejects.toBeInstanceOf(BackupImportError)
+  })
+})

--- a/tests/unit/services/backup/BackupZipSecurityTestUtils.js
+++ b/tests/unit/services/backup/BackupZipSecurityTestUtils.js
@@ -1,0 +1,107 @@
+import JSZip from 'jszip'
+
+import { createZipContent } from '../../../../src/services/backup/BackupZipArchive.ts'
+
+export const CANONICAL_BACKUP_FILES = Object.freeze([
+  { path: 'manifest.json', content: '{"app":"Lumapse"}' },
+  { path: 'data/subjects.json', content: '[]' },
+  { path: 'data/notes.json', content: '[]' },
+  { path: 'data/academic-events.json', content: '[]' },
+])
+
+export function currentBackupBytes(files = CANONICAL_BACKUP_FILES) {
+  return new Uint8Array(createZipContent(files, {
+    createdAt: new Date('2026-06-03T12:30:00.000Z'),
+    type: 'arraybuffer',
+  }))
+}
+
+export async function legacyBackupBytes(files = CANONICAL_BACKUP_FILES) {
+  const zip = new JSZip()
+  for (const file of files) zip.file(file.path, file.content)
+  return zip.generateAsync({
+    type: 'uint8array',
+    compression: 'DEFLATE',
+    compressionOptions: { level: 9 },
+    streamFiles: false,
+  })
+}
+
+function findSignature(bytes, signature, from = 0) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  for (let offset = from; offset <= bytes.byteLength - 4; offset += 1) {
+    if (view.getUint32(offset, true) === signature) return offset
+  }
+  throw new Error(`ZIP signature ${signature.toString(16)} not found`)
+}
+
+export function endOfCentralDirectoryOffset(bytes) {
+  return findSignature(bytes, 0x06054b50, Math.max(0, bytes.byteLength - 65_557))
+}
+
+export function centralRecord(bytes, expectedPath) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  const eocdOffset = endOfCentralDirectoryOffset(bytes)
+  const count = view.getUint16(eocdOffset + 10, true)
+  let offset = view.getUint32(eocdOffset + 16, true)
+
+  for (let index = 0; index < count; index += 1) {
+    if (view.getUint32(offset, true) !== 0x02014b50) throw new Error('Invalid central directory')
+    const nameLength = view.getUint16(offset + 28, true)
+    const extraLength = view.getUint16(offset + 30, true)
+    const commentLength = view.getUint16(offset + 32, true)
+    const name = new TextDecoder().decode(bytes.subarray(offset + 46, offset + 46 + nameLength))
+
+    if (name === expectedPath) {
+      return {
+        offset,
+        localOffset: view.getUint32(offset + 42, true),
+        nameLength,
+      }
+    }
+    offset += 46 + nameLength + extraLength + commentLength
+  }
+
+  throw new Error(`ZIP entry ${expectedPath} not found`)
+}
+
+export function setUint16(bytes, offset, value) {
+  new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).setUint16(offset, value, true)
+}
+
+export function setUint32(bytes, offset, value) {
+  new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).setUint32(offset, value, true)
+}
+
+export function setEntryFlags(bytes, path, flags) {
+  const record = centralRecord(bytes, path)
+  setUint16(bytes, record.offset + 8, flags)
+  setUint16(bytes, record.localOffset + 6, flags)
+}
+
+export function setEntryMethod(bytes, path, method) {
+  const record = centralRecord(bytes, path)
+  setUint16(bytes, record.offset + 10, method)
+  setUint16(bytes, record.localOffset + 8, method)
+}
+
+export function setDeclaredEntrySize(bytes, path, size) {
+  const record = centralRecord(bytes, path)
+  setUint32(bytes, record.offset + 24, size)
+  setUint32(bytes, record.localOffset + 22, size)
+}
+
+export function renameEntry(bytes, path, replacement) {
+  const record = centralRecord(bytes, path)
+  const encoded = new TextEncoder().encode(replacement)
+  if (encoded.byteLength !== record.nameLength) throw new Error('Replacement path length differs')
+
+  bytes.set(encoded, record.offset + 46)
+  bytes.set(encoded, record.localOffset + 30)
+}
+
+export function bytesToBase64(bytes) {
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return globalThis.btoa(binary)
+}


### PR DESCRIPTION
## Summary

- add a bounded ZIP32 reader with source, entry, document, entity, and decompression limits
- validate manifest and imported entities at runtime before planning or SQLite persistence
- enforce the two-level imported subject hierarchy and report relationship repairs
- harden HTML text/attribute, CSS color, selector, and date rendering contexts
- update the AUD-003 analysis and prioritized technical review with final validation evidence

## Validation

- 60 test files and 955 tests passed with `NODE_OPTIONS=--no-experimental-webstorage` on the remote Node 26 environment
- typecheck, ESLint, build, bundle budgets, SQLite smoke, accessibility, documentation, traceability, and `git diff --check` passed
- manual Android validation passed on Samsung SM_G965F:
  - current STORE backup
  - historical DEFLATE backup
  - 500-note fixture and virtualized feed
  - invalid `pinned` rejection without partial writes
  - final drawer, feed, trash, picker, academic-event, and Heatmap smoke test

## Known baseline limitations

- Node 26 requires the documented Web Storage workaround
- the aggregate fallback offline gate still flags the two intentional `http://localhost` CSP entries
- these are tracked outside AUD-003; this branch introduces no new failures

## Scope

- no dependency, lockfile, schema, or SQLite connection changes
- AUD-004, AUD-006, AUD-008, and AUD-009 remain out of scope
