### PR TITLE
docs(project): reconcile post-v0.4.8 release tracking

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -37,12 +37,11 @@ La trazabilidad de `v0.4.8` queda distribuida entre `docs/gestion/lineas-base.md
 
 | Orden | Tarea | Criterio de cierre |
 |---|---|---|
-| 1 | Sincronización documental de cierre | Reconciliar `CHANGELOG.md`, backlog, `TODO` e Hito 06 con la evidencia integrada hasta `ba16777`, sin declarar todavía una nueva release |
-| 2 | Seguridad previa al próximo corte | Resolver AUD-004 en un PR separado, revisar advisories/changelogs y repetir sanitización, tests, build y auditoría de dependencias |
-| 3 | Congelamiento editorial y visual | Consolidar evidencia, verificar bibliografía y confirmar legibilidad de gráficos DB en PDF y diapositivas |
-| 4 | Validación final | Ejecutar el gate sobre el corte candidato, completar las mediciones RNF y repetir Android sobre el artefacto versionado; resolver o aceptar `Mover a` y rendimiento |
-| 5 | Presentación y defensa | Preparar guion, demo, cheatsheet, material visual y contingencias |
-| 6 | Corte final | Decidir entre beta patch y entrega final; alinear versión web/Android, firmar, calcular hash, etiquetar y registrar la línea base |
+| 1 | Seguridad previa al próximo corte | Resolver AUD-004 en un PR separado, revisar advisories/changelogs y repetir sanitización, tests, build y auditoría de dependencias |
+| 2 | Congelamiento editorial y visual | Consolidar evidencia, verificar bibliografía y confirmar legibilidad de gráficos DB en PDF y diapositivas |
+| 3 | Validación final | Ejecutar el gate sobre el corte candidato, completar las mediciones RNF y repetir Android sobre el artefacto versionado; resolver o aceptar `Mover a` y rendimiento |
+| 4 | Presentación y defensa | Preparar guion, demo, cheatsheet, material visual y contingencias |
+| 5 | Corte final | Decidir entre beta patch y entrega final; alinear versión web/Android, firmar, calcular hash, etiquetar y registrar la línea base |
 
 ---
 
@@ -95,7 +94,7 @@ Estas tareas no bloquean el MVP. Se conservan como decisiones trazables para rea
 | Tipado gradual | Aplicar estrategia JS/TS por fases | Media | Plan definido en [`docs/gestion/plan-mantenibilidad-tipado-gradual-2026-06-12.md`](docs/gestion/plan-mantenibilidad-tipado-gradual-2026-06-12.md): typecheck, contratos, primera tanda de modulos puros, `AcademicEventTypes`, registro de comandos del editor, `AcademicEventService`, capa de backup —incluidos adaptadores nativos—, `ExportService`, `SubjectService.crud`, `SubjectService.trash` y auditorias `.ts` completadas |
 | Tipado gradual | Continuar servicios de dominio/backup archivo por archivo | Baja/Media | No avanzar en bloque; proximos candidatos requieren evaluar bordes nativos/share/storage o store con contratos mas claros |
 | Framework UI | No incorporar Svelte por ahora | Baja | Costo de migracion alto vs beneficio actual; reabrir solo si DOM manual se vuelve una carga clara |
-| Documentación | Congelar documentos antes del corte final | Alta | La reconciliación posterior a AUD-001/002/003 está en curso; restan `TODO`, Hito 06, evidencia final, revisión de maquetación y el corte elegido |
+| Documentación | Congelar documentos antes del corte final | Alta | La reconciliación posterior a AUD-001/002/003 se completó el 2026-09-02; restan evidencia final, revisión de maquetación y el corte elegido |
 | Dependencias | Resolver AUD-004 sin mezclar otros hallazgos | Alta | Actualizar dependencias con advisories en una rama propia y validar especialmente sanitización, lockfile, suite, build y APK antes del próximo corte |
 | Persistencia y asincronía | Planificar AUD-005–AUD-007 | Alta/Media | Mantener ramas separadas para propiedad transaccional/migraciones, resultados async obsoletos y contratos de error; priorizar solo lo que bloquee el gate acordado |
 | Tooling | Resolver portabilidad de gate y Node 26 (AUD-008/AUD-009) | Media | Distinguir falsos positivos CSP del fallback offline y eliminar la dependencia del workaround de Web Storage sin relajar controles |

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,7 +4,7 @@ Este documento funciona como bandeja viva de tareas, deuda y decisiones pendient
 
 > **Hito activo:** 06 — Entrega Final
 > **Hito 05:** Cerrado documentalmente el 2026-07-15 sobre la beta operativa `v0.4.8`
-> **Última actualización:** 2026-07-15 — reconciliación documental transversal e incorporación de los diagramas finales de base de datos
+> **Última actualización:** 2026-09-02 — cierre de AUD-001, AUD-002 y AUD-003, y revisión del próximo corte Android
 > **Snapshot histórico:** [`docs/gestion/historico/backlog-historico-hito-04-2026-06-01.md`](docs/gestion/historico/backlog-historico-hito-04-2026-06-01.md)
 
 ---
@@ -15,7 +15,9 @@ Hito 04 quedó cerrado formalmente como bloque de Organización y UX. El cierre 
 
 Hito 05 quedó cerrado documentalmente el 2026-07-15. Entregó el quality gate, APK firmada, validación inicial en Android real y publicación de la beta controlada [`v0.4.8`](https://github.com/jdfesa/lumapse/releases/tag/v0.4.8), junto con mejoras funcionales acotadas: borradores persistentes (`RF-005`), backup manual (`RF-017`), importación ZIP (`RF-018`), Acerca de (`RF-023`), fechas académicas discretas (`RF-027`) y editor enriquecido (`RF-028`). Las observaciones sobre `Mover a` y rendimiento con más notas no bloquearon ese cierre.
 
-Hito 06 queda activo para completar la documentación final, verificar la maquetación de los gráficos de base de datos ya actualizados, repetir la validación sobre un corte congelado y preparar la presentación. La versión operativa continúa siendo `v0.4.8`: el trabajo posterior al tag permanece no publicado y no se denominará `0.4.9` antes de decidir el artefacto final. El checkpoint previo a esta revisión comprendía 12 commits; ese número es histórico y no se usa como contador permanente de `main`.
+Hito 06 queda activo para completar la documentación final, verificar la maquetación de los gráficos de base de datos ya actualizados, repetir la validación sobre un corte congelado y preparar la presentación. La única versión publicada continúa siendo `v0.4.8`; el rango auditado posterior al tag comprende 38 commits hasta `ba16777`, pero todavía no constituye una release ni un APK distribuible nuevo. La decisión pendiente debe distinguir entre una beta de corrección `v0.4.9` y el artefacto final de Hito 06, sin renombrar preventivamente el estado actual de `main`.
+
+La revisión técnica priorizada del 2026-09-01 abrió trece hallazgos trazables. AUD-001 y AUD-002 quedaron resueltos mediante PR #2; AUD-003 quedó implementado, validado en Android e integrado mediante PR #3. La validación incluyó backups `STORE` y `DEFLATE`, rechazo previo a persistencia de datos inválidos y una fixture funcional de 500 notas. Esta última evidencia no sustituye las mediciones de latencia y rendimiento exigidas por `RNF-002` y `RNF-004`. AUD-004 conserva prioridad P0 y debe tratarse en un frente separado antes de publicar otro artefacto; los hallazgos restantes mantienen sus prioridades y no se incorporan automáticamente al alcance de Hito 06.
 
 La revisión de exportación/importación corrige una sobrepromesa documental del Hito 03: los servicios base de Markdown no equivalían a un flujo de usuario validado. La opción "Compartir" para una nota individual (`RF-016`) solo tendría sentido si abre el share sheet nativo de Android y ofrece apps como WhatsApp; si termina copiando contenido, duplica una acción existente y agrega ruido. La portabilidad de workspace sí quedó resuelta de forma acotada con exportación e importación de backup `.zip` desde la vista Backup.
 
@@ -25,7 +27,7 @@ El benchmark visual contra Notion mobile derivó en `RF-028`: controles opcional
 
 La revisión de `RF-005` reemplazó el auto-guardado final silencioso por borradores persistentes del editor. Lumapse conserva localmente el trabajo en curso al crear o editar, lo restaura al volver de otra app o vista, y lo limpia solo al guardar/actualizar con éxito o al descartar explícitamente. El plan cerrado queda archivado en [`docs/gestion/historico/plan-borradores-persistentes-2026-06-06.md`](docs/gestion/historico/plan-borradores-persistentes-2026-06-06.md).
 
-La estrategia de mantenibilidad y tipado gradual queda documentada en [`docs/gestion/plan-mantenibilidad-tipado-gradual-2026-06-12.md`](docs/gestion/plan-mantenibilidad-tipado-gradual-2026-06-12.md). Las primeras fases operativas ya quedaron aplicadas: `tests/unit/components/` espeja la organizacion por feature de `src/components/`, `NoteStore.*` dejo de importar feedback visual, el proyecto ya tiene `typecheck` y contratos de dominio iniciales en `src/domain/`, los primeros modulos puros migrados son `AcademicEventRules`, `NoteTitleService`, `SubjectService.validation`, `BackupFormat`, `noteFilters`, `AcademicEventTypes`, `editorTextTransforms`, `MarkdownService` y el registro de comandos del editor, el primer servicio de dominio migrado es `AcademicEventService`, la capa de backup ya tipa decisiones, datos, transformacion ZIP, escritura ZIP, persistencia liviana, orquestacion y adaptadores nativos de red/share, `ExportService` ya quedo tipado como fachada web/legada del backup canonico, y `SubjectService.crud`/`SubjectService.trash` ya declaran contratos sobre materias, arbol activo y papelera avanzada manteniendo el barrel publico. Las auditorias auxiliares y el binario Rust tambien escanean `.ts`. El siguiente paso recomendado es seguir archivo por archivo con servicios donde el contrato aporte seguridad real, dejando store y componentes DOM grandes para fases posteriores.
+La estrategia de mantenibilidad y tipado gradual queda documentada en [`docs/gestion/plan-mantenibilidad-tipado-gradual-2026-06-12.md`](docs/gestion/plan-mantenibilidad-tipado-gradual-2026-06-12.md). Las primeras fases operativas ya quedaron aplicadas: `tests/unit/components/` espeja la organización por feature de `src/components/`, `NoteStore.*` dejó de importar feedback visual, el proyecto ya tiene `typecheck` y contratos de dominio iniciales en `src/domain/`, los primeros módulos puros migrados son `AcademicEventRules`, `NoteTitleService`, `SubjectService.validation`, `BackupFormat`, `noteFilters`, `AcademicEventTypes`, `editorTextTransforms`, `MarkdownService` y el registro de comandos del editor, el primer servicio de dominio migrado es `AcademicEventService`, la capa de backup ya tipa decisiones, datos, transformación ZIP, escritura ZIP, persistencia liviana, orquestación y adaptadores nativos de red/share, `ExportService` ya quedó tipado como fachada web/legada del backup canónico, y `SubjectService.crud`/`SubjectService.trash` ya declaran contratos sobre materias, árbol activo y papelera avanzada manteniendo el barrel público. Las auditorías auxiliares y el binario Rust también escanean `.ts`. Las migraciones futuras permanecen subordinadas a riesgos o cambios concretos: no se abre una conversión masiva durante el cierre.
 
 La trazabilidad de `v0.4.8` queda distribuida entre `docs/gestion/lineas-base.md`, `docs/gestion/cheatsheet-defensa.md`, el cierre de Hito 05 y `CHANGELOG.md`. El trabajo final de informe, defensa, diagramas y evidencia adicional se concentra desde ahora en Hito 06.
 
@@ -35,11 +37,27 @@ La trazabilidad de `v0.4.8` queda distribuida entre `docs/gestion/lineas-base.md
 
 | Orden | Tarea | Criterio de cierre |
 |---|---|---|
-| 1 | Congelamiento editorial final | La reconciliación transversal y la incorporación de gráficos DB quedaron completadas; consolidar evidencia y revisar la maquetación antes de congelar el contenido |
-| 2 | Diagramas de base de datos | Fuentes e imágenes conceptual/lógica verificadas e incorporadas; confirmar legibilidad en PDF y diapositivas |
-| 3 | Validación final | Repetir gate y Android, ejecutar el plan RNF pendiente y emitir una matriz por artefacto; resolver o aceptar `Mover a` y rendimiento |
-| 4 | Presentación y defensa | Preparar guion, demo, cheatsheet, material visual y contingencias |
-| 5 | Corte final | Decidir artefacto, versión y línea base solo después de cerrar documentación y validación |
+| 1 | Sincronización documental de cierre | Reconciliar `CHANGELOG.md`, backlog, `TODO` e Hito 06 con la evidencia integrada hasta `ba16777`, sin declarar todavía una nueva release |
+| 2 | Seguridad previa al próximo corte | Resolver AUD-004 en un PR separado, revisar advisories/changelogs y repetir sanitización, tests, build y auditoría de dependencias |
+| 3 | Congelamiento editorial y visual | Consolidar evidencia, verificar bibliografía y confirmar legibilidad de gráficos DB en PDF y diapositivas |
+| 4 | Validación final | Ejecutar el gate sobre el corte candidato, completar las mediciones RNF y repetir Android sobre el artefacto versionado; resolver o aceptar `Mover a` y rendimiento |
+| 5 | Presentación y defensa | Preparar guion, demo, cheatsheet, material visual y contingencias |
+| 6 | Corte final | Decidir entre beta patch y entrega final; alinear versión web/Android, firmar, calcular hash, etiquetar y registrar la línea base |
+
+---
+
+## Revisión técnica priorizada — estado vivo
+
+El análisis detallado permanece en [`docs/gestion/revision-tecnica-priorizada-2026-09-01.md`](docs/gestion/revision-tecnica-priorizada-2026-09-01.md). Esta tabla solo fija el estado operativo del backlog después de integrar los PR #2 y #3.
+
+| ID | Prioridad | Frente | Estado operativo |
+|---|---|---|---|
+| AUD-001 | P0 | Pérdida de borrador ante error SQLite | Cerrado en PR #2; regresiones aprobadas |
+| AUD-002 | P0 | Guardados duplicados por taps concurrentes | Cerrado en PR #2; single-flight y estado visual validados |
+| AUD-003 | P0 | Frontera y presentación de backups no confiables | Cerrado en PR #3; suite acumulativa y checkpoints Android aprobados |
+| AUD-004 | P0 | Dependencias con advisories de seguridad | Pendiente; próximo frente técnico previo a una nueva APK |
+| AUD-005–AUD-009 | P1 | Persistencia, asincronía, contratos y tooling | Pendientes; abordar en ramas separadas según riesgo y gate de release |
+| AUD-010–AUD-013 | P2 | Escalabilidad, rendimiento, cohesión y margen de bundle/coverage | Monitorear o medir; no bloquean por sí solos el cierre actual |
 
 ---
 
@@ -77,13 +95,17 @@ Estas tareas no bloquean el MVP. Se conservan como decisiones trazables para rea
 | Tipado gradual | Aplicar estrategia JS/TS por fases | Media | Plan definido en [`docs/gestion/plan-mantenibilidad-tipado-gradual-2026-06-12.md`](docs/gestion/plan-mantenibilidad-tipado-gradual-2026-06-12.md): typecheck, contratos, primera tanda de modulos puros, `AcademicEventTypes`, registro de comandos del editor, `AcademicEventService`, capa de backup —incluidos adaptadores nativos—, `ExportService`, `SubjectService.crud`, `SubjectService.trash` y auditorias `.ts` completadas |
 | Tipado gradual | Continuar servicios de dominio/backup archivo por archivo | Baja/Media | No avanzar en bloque; proximos candidatos requieren evaluar bordes nativos/share/storage o store con contratos mas claros |
 | Framework UI | No incorporar Svelte por ahora | Baja | Costo de migracion alto vs beneficio actual; reabrir solo si DOM manual se vuelve una carga clara |
-| Documentación | Congelar documentos antes del corte final | Alta | El checkpoint 2026-07-15 ya distingue la beta publicada de `main` e incorpora los gráficos DB; resta evidencia final, revisión de maquetación y el corte elegido |
+| Documentación | Congelar documentos antes del corte final | Alta | La reconciliación posterior a AUD-001/002/003 está en curso; restan `TODO`, Hito 06, evidencia final, revisión de maquetación y el corte elegido |
+| Dependencias | Resolver AUD-004 sin mezclar otros hallazgos | Alta | Actualizar dependencias con advisories en una rama propia y validar especialmente sanitización, lockfile, suite, build y APK antes del próximo corte |
+| Persistencia y asincronía | Planificar AUD-005–AUD-007 | Alta/Media | Mantener ramas separadas para propiedad transaccional/migraciones, resultados async obsoletos y contratos de error; priorizar solo lo que bloquee el gate acordado |
+| Tooling | Resolver portabilidad de gate y Node 26 (AUD-008/AUD-009) | Media | Distinguir falsos positivos CSP del fallback offline y eliminar la dependencia del workaround de Web Storage sin relajar controles |
 | Tooling DB | Ampliar el smoke test a `academic_events` y constraints relevantes | Media | El DDL completo se ejecuta, pero las aserciones explícitas de tablas/columnas/relaciones se concentran en materias, notas y metadata; decidir su ampliación antes de presentar cobertura exhaustiva |
+| Tooling de release | Sincronizar versión Android desde el helper | Alta | `scripts/release-helper.py` actualiza package/changelog, pero no `versionName` ni `versionCode`; corregirlo o agregar un gate explícito antes de generar otra APK |
 | Diagramas | Revisar Mermaid de casos de uso, secuencia y dominio | Baja | Completado el 2026-07-03 contra `v0.4.8`; reabrir solo si cambia el alcance o durante la exportacion final a PDF/LaTeX |
 | Informe final | Preparar conversion LaTeX/PDF | Media | Consideraciones registradas en `docs/informe-final/README.md`; mantener Markdown como fuente de verdad y abrir pipeline LaTeX solo cuando el contenido este congelado |
-| Release | Definir el corte final | Alta | `v0.4.8` sigue como beta operativa; no crear `0.4.9` antes de la validación y de decidir si habrá un artefacto distinto |
+| Release | Definir el próximo corte | Alta | `v0.4.8` sigue como única beta publicada y no contiene AUD-001/002/003; evaluar `v0.4.9` como beta patch o reservar el artefacto para el cierre final, siempre después de los gates acordados |
 | UX menor | Revisar interacción de `Mover a` | Baja | En S20 FE se observó que puede requerir pulsación prolongada; no bloquea beta porque la acción se completa |
-| Rendimiento | Monitorear crecimiento real de notas | Media | Validación inicial con pocas notas fue correcta; observar comportamiento con mayor volumen post-release |
+| Rendimiento | Medir crecimiento real de notas | Media | La importación funcional de una fixture de 500 notas fue aprobada; todavía deben medirse latencia CRUD y rendimiento percibido para cerrar `RNF-002`/`RNF-004` |
 | Adjuntos | Planificar adjuntos de imagen post-release | Media | Valor alto para fotos de pizarrón; debe implementarse sin cargar SQLite ni saturar el feed |
 | Backup | Restauracion avanzada y Drive API directa | Alta | Exportacion e importacion ZIP manual ya estan integradas; quedan reemplazo/merge avanzado de workspace y subida directa a Drive como fases futuras |
 
@@ -107,6 +129,7 @@ Hito 06 es un hito de cierre. No incorporar salvo que un bloqueo de entrega lo e
 - Mantener un máximo de dos frentes en curso.
 - No abrir refactors ni migraciones amplias; una corrección estructural debe estar ligada a un bloqueo o a una validación concreta.
 - No denominar `0.4.9` al estado actual de `main` ni generar un APK con esa versión sin una decisión formal de corte.
+- No publicar un nuevo artefacto mientras AUD-004 o cualquier otro bloqueo de seguridad confirmado para ese corte permanezca abierto.
 - Todo cambio de comportamiento debe cerrar con tests focalizados, `npm run verify`, trazabilidad y nueva validación Android proporcional al riesgo.
 - Preservar `v0.4.8` y su SHA-256 como evidencia inmutable de la beta publicada.
 - Las ideas postergadas permanecen en este backlog; no vuelven al `TODO` operativo hasta que Hito 06 haya terminado.
@@ -145,6 +168,10 @@ Los ítems marcados como completados fueron planes que originalmente estaban en 
 - [x] Adaptadores nativos de backup migrados a TypeScript: `BackupNativeNetworkService.ts` y `BackupShareService.ts` fijan contratos pequenos para Network, Filesystem y Share sin acoplar el dominio a los plugins de Capacitor.
 - [x] Coverage ampliado a JavaScript y TypeScript: `npm run test:coverage` mide `src/**/*.{js,ts}` y la linea base del 2026-08-21 registra 92,43% de statements en `src/services/**`, por encima del 70% exigido por `RNF-024`.
 - [x] Imports dinamicos redundantes retirados del store y la restauracion de papelera: Vite ya no advierte sobre modulos que eran importados de forma estatica y dinamica a la vez.
+- [x] AUD-001 y AUD-002 cerrados en PR #2: el editor conserva el borrador ante fallos, serializa guardados concurrentes y diferencia visualmente el descarte.
+- [x] AUD-003 cerrado en PR #3: importación ZIP acotada, validación runtime, jerarquía consistente, presentación defensiva y validación Android acumulativa.
+- [ ] AUD-004: actualizar dependencias con advisories en un frente separado y repetir los controles de sanitización, lockfile, suite y build antes de otra APK.
+- [ ] Corregir o reforzar `scripts/release-helper.py` para que `versionName` y `versionCode` Android no puedan quedar desalineados del corte declarado.
 - [ ] Aplicar mejoras pequenas y verificables que aumenten cohesion, reduzcan acoplamiento y faciliten revisiones humanas/IA, evitando reescrituras grandes.
 - [ ] Restauracion avanzada desde backup `.zip` con estrategia explicita de reemplazo/merge, solo despues de validar la importacion no destructiva actual con usuarios reales.
 - [ ] Sincronización real multi-dispositivo, solo después de validar backup/restauración y con feedback fuerte de adopción.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,23 @@ y este proyecto adhiere a [Conventional Commits](https://www.conventionalcommits
 
 ## [Unreleased] — Trabajo posterior a `v0.4.8`
 
-> `main` conserva la versión declarada `0.4.8`, pero contiene trabajo posterior al tag. No existe una release `0.4.9` ni un APK posterior publicado. El corte auditado previo al cierre documental de Hito 05 comprende exactamente 12 commits.
+> `main` conserva la versión declarada `0.4.8`, pero contiene trabajo posterior al tag. No existe una release `0.4.9` ni un APK posterior publicado. Este corte resume el rango Git completo desde `v0.4.8` (exclusivo) hasta `ba16777` (inclusivo). Las ejecuciones Android sobre código posterior al tag son evidencia de validación y no constituyen un artefacto publicado.
+
+### Added
+
+- **Regresiones de integridad de guardado:** Se incorporaron pruebas unitarias para creación y actualización fallidas, conservación del borrador y serialización de solicitudes concurrentes.
+- **Cobertura de AUD-003:** Se agregaron regresiones para preflight y lectura ZIP, CRC32, límites, validación de primitivas y entidades, jerarquía de materias y presentación por contexto. El cierre documenta 11 archivos y 75 tests focalizados de presentación, además de 60 archivos y 955 tests en la suite completa con el workaround registrado para Node 26.
+- **Evidencia Android posterior al tag:** Se registró la validación manual de backups `STORE` y `DEFLATE`, una fixture de 500 notas, el rechazo de `pinned` inválido antes de persistir y el checkpoint final de la implementación completa instalada en un Samsung `SM_G965F`; estas ejecuciones no representan una nueva release ni un APK publicado.
 
 ### Changed
 
 - **Marco metodológico reforzado:** ADR-003, el informe final y el material de defensa distinguen Scrum, RUP y Kanban con fuentes oficiales; se corrige la mezcla entre Scrum Guide 2017/2020, se elimina la equivalencia hito–Sprint y se formaliza una Definition of Workflow para Hito 06 sin inventar métricas históricas.
 - **Frontera de backend explicitada:** El informe diferencia la ausencia de backend remoto de las capas locales de aplicación, dominio y datos; SQLite, Capacitor y el servidor de desarrollo Vite quedan clasificados según su función real.
-- **Trazabilidad de la beta:** Se documentaron la publicación, la línea base operativa, el material de defensa y la sincronización parcial del informe final (`59e7011`, `8306765`, `8cc658a`, `c65d8b3`).
-- **Registro de comandos del editor tipado:** `editorCommandRegistry` y `editorInlineCommands` pasan a TypeScript sin alterar la interfaz ni el comportamiento publicado (`ced74c7`, `27d6f84`).
-- **Diagramas Mermaid sincronizados:** Se definió el alcance y se actualizaron casos de uso, modelo de dominio y secuencia de creación/edición contra `v0.4.8` (`25a675c`, `2cb7218`, `3904641`).
-- **Preparación editorial:** Se registraron consideraciones para la conversión final Markdown → LaTeX/PDF (`4a84b03`).
-- **Render Markdown seguro tipado:** `MarkdownService` pasa a TypeScript conservando sanitización, callouts y salida renderizada (`30e2dce`, `5db64de`).
+- **Trazabilidad de la beta:** Se documentaron la publicación, la línea base operativa, el material de defensa y la sincronización inicial del informe final con `v0.4.8`.
+- **Registro de comandos del editor tipado:** `editorCommandRegistry` y `editorInlineCommands` pasan a TypeScript sin alterar la interfaz ni el comportamiento publicado.
+- **Diagramas Mermaid sincronizados:** Se definió el alcance y se actualizaron casos de uso, modelo de dominio y secuencia de creación/edición contra `v0.4.8`.
+- **Preparación editorial:** Se registraron consideraciones para la conversión final Markdown → LaTeX/PDF.
+- **Render Markdown seguro tipado:** `MarkdownService` pasa a TypeScript conservando sanitización, callouts y salida renderizada.
 - **Reconciliación documental de Hito 06:** README, backlog, TODO, hitos, requisitos, investigación e informe adoptan una narrativa única para `v0.4.8`, el trabajo posterior no publicado y el alcance real de la evidencia.
 - **Arquitectura y patrones formalizados:** ADR-008 y el diagrama de componentes clasifican Lumapse como monolito modular cliente offline-first, con capas pragmáticas y patrones respaldados por puntos concretos del código.
 - **Modelos de datos sincronizados:** Las fuentes conceptual DOT, lógica DBML y física DDL reflejan el schema vigente; las exportaciones conceptual y lógica fueron reemplazadas, revisadas e incorporadas al informe el 2026-07-15.
@@ -28,21 +34,20 @@ y este proyecto adhiere a [Conventional Commits](https://www.conventionalcommits
 - **Adaptadores nativos de backup tipados:** `BackupNativeNetworkService` y `BackupShareService` pasan a TypeScript con contratos locales para Network, Filesystem y Share, y cobertura directa del fallback web de conectividad.
 - **Coverage JS/TS medible:** Vitest incorpora `src/**/*.{js,ts}` y genera un resumen JSON; la nueva línea base registra 92,43% de statements en `src/services/**`, cerrando la medición pendiente de `RNF-024` sin fijar todavía umbrales bloqueantes.
 - **Dependencias estáticas explícitas:** Se retiraron cinco imports dinámicos que Vite no podía separar en chunks porque los mismos módulos ya formaban parte del grafo estático; el comportamiento y las APIs públicas permanecen sin cambios.
+- **Auditoría técnica trazable:** La revisión priorizada separa hallazgos de integridad, seguridad, confiabilidad, tooling y mantenibilidad; el análisis de AUD-003 registra riesgos confirmados y refutados, alcance, fases, evidencia y limitaciones sin mezclar la actualización de dependencias de AUD-004.
 
-### Commits posteriores al tag
+### Fixed
 
-- `59e7011` docs(release): document published v0.4.8 beta
-- `8306765` docs(project): update backlog and task tracking for v0.4.8 beta
-- `8cc658a` docs(release): document baseline and defense cheatsheet for v0.4.8
-- `c65d8b3` docs(report): synchronize final report with v0.4.8 beta updates
-- `ced74c7` refactor(editor): migrate editorCommandRegistry and editorInlineCommands to TypeScript
-- `27d6f84` docs(project): update task tracking and plan for editor commands TS migration
-- `25a675c` docs(project): define explicit scope and tools for diagram updates
-- `2cb7218` docs(diagrams): update Mermaid diagrams to align with current app features
-- `3904641` docs(project): update backlog, changelog, and todo for diagram updates
-- `4a84b03` docs(report): add LaTeX conversion considerations to final report guidelines
-- `30e2dce` refactor(markdown): migrate MarkdownService to TypeScript
-- `5db64de` docs: update backlog, changelog and TODO for MarkdownService migration
+- **Integridad del guardado (AUD-001):** El editor solo limpia los campos y descarta el borrador tras confirmar la persistencia; ante un fallo conserva contenido, borrador, contexto de edición y modo foco para permitir el reintento.
+- **Guardados concurrentes (AUD-002):** Una protección single-flight serializa el guardado y mantiene un estado visual mientras la operación está pendiente, evitando mutaciones duplicadas o fuera de orden por taps repetidos.
+- **Descarte de borrador distinguible:** La acción destructiva de descartar quedó diferenciada visualmente del guardado y cubierta por una regresión de presentación.
+
+### Security
+
+- **Importación ZIP acotada (AUD-003):** Un lector ZIP32 con preflight estructural aplica límites a la fuente, las entradas, los documentos y la salida real, verifica CRC32 y admite los formatos legítimos `STORE` y `DEFLATE`; rechaza estructuras ZIP64, multidisco o cifradas, rutas inseguras, nombres canónicos duplicados y métodos no admitidos antes de persistir.
+- **Validación runtime de backups:** El manifiesto, las entidades y sus primitivas se validan sin coerciones permisivas antes del plan de importación, con contratos y límites explícitos para conteos, booleanos, IDs, colores, fechas, timestamps y textos.
+- **Jerarquía importada consistente:** El plan impone un máximo de dos niveles, detecta ciclos y padres inexistentes o que ya son secciones, y registra en el preview las reparaciones de relaciones antes de escribir.
+- **Presentación defensiva de contenido importado:** Textos y atributos se codifican según su contexto, los colores pasan por una allowlist y los selectores evitan interpolar IDs importados; los renderizadores también toleran datos antiguos inválidos.
 
 ---
 

--- a/TODO
+++ b/TODO
@@ -4,11 +4,11 @@
 
 ## Hito actual: 06 — Entrega Final
 
-**Estado:** activo desde el cierre documental de Hito 05, realizado el 2026-07-15.
+**Estado:** activo; AUD-001, AUD-002 y AUD-003 quedaron integrados y validados al 2026-09-02.
 
 **Corte operativo vigente:** beta/candidata [`v0.4.8`](https://github.com/jdfesa/lumapse/releases/tag/v0.4.8), publicada y validada inicialmente en Android real.
 
-**Versión:** `v0.4.8`; el trabajo posterior al tag permanece no publicado y no existe una release `0.4.9`. El número exacto de commits se registrará al congelar el próximo corte, no como dato vivo de este tablero.
+**Versión:** `v0.4.8`; el trabajo posterior al tag permanece no publicado y no existe una release `0.4.9`. El rango técnico auditado llega hasta `ba16777`, pero la versión del próximo artefacto solo se decidirá después de cerrar sus bloqueos y validaciones.
 
 **Objetivo:** cerrar documentación, gráficos de base de datos, validación final y materiales de presentación sin ampliar el producto.
 
@@ -16,11 +16,12 @@
 
 | Orden | Frente | Criterio de cierre |
 |---|---|---|
-| 1 | Congelamiento editorial final | La reconciliación transversal y la incorporación de los gráficos DB quedaron completadas el 2026-07-15; resta consolidar evidencia y revisar la maquetación final antes de congelar |
-| 2 | Gráficos de base de datos | Fuentes e imágenes conceptual/lógica sincronizadas e incorporadas; resta confirmar su legibilidad en la salida PDF y las diapositivas |
-| 3 | Validación final | Quality gate, checklist Android y matriz RNF cerrados sobre el mismo artefacto, con evidencia y observaciones clasificadas |
-| 4 | Defensa y presentación | Guion, cheatsheet, demo y material visual preparados y ensayados |
-| 5 | Línea base final | Decisión explícita sobre artefacto, versión y tag final solo después de completar los puntos anteriores |
+| 1 | Sincronización documental | `CHANGELOG.md`, backlog, este tablero e Hito 06 reflejan el cierre de AUD-001/002/003 y la frontera no publicada posterior a `v0.4.8` |
+| 2 | Seguridad del próximo corte | AUD-004 resuelto en un PR independiente, con dependencias, sanitización, lockfile, suite y build verificados |
+| 3 | Congelamiento editorial y visual | Evidencia y bibliografía consolidadas; gráficos DB legibles en PDF y diapositivas |
+| 4 | Validación final | Quality gate, checklist Android y matriz RNF cerrados sobre el mismo artefacto versionado, con observaciones clasificadas |
+| 5 | Defensa y presentación | Guion, cheatsheet, demo y material visual preparados y ensayados |
+| 6 | Línea base final | Decisión explícita entre beta patch y entrega final; versión web/Android, firma, hash y tag inequívocos |
 
 ## Checklist de trabajo
 
@@ -29,12 +30,16 @@
 - [x] Ensamblar un checkpoint coherente de `INFORME-FINAL-COMPLETO.md` desde los capítulos fuente.
 - [x] Exportar externamente, reemplazar, revisar visualmente e incorporar los gráficos de base de datos (2026-07-15).
 - [x] Revisar el marco metodológico y la defensa: corregir Scrum 2017/2020, distinguir RUP y formalizar el flujo Kanban (2026-08-11).
+- [x] Corregir AUD-001 y AUD-002: conservar borradores ante fallos, serializar guardados concurrentes y diferenciar el descarte (PR #2, 2026-09-01).
+- [x] Corregir AUD-003: acotar y validar la importación ZIP, proteger jerarquías/renderizado y aprobar los checkpoints Android acumulativos (PR #3, 2026-09-02).
+- [ ] Completar la sincronización documental posterior a las auditorías: `CHANGELOG.md`, backlog y `TODO` actualizados; resta Hito 06.
 - [ ] Alinear el tablero de GitHub Projects con la Definition of Workflow: WIP global 2, bloqueos y fechas `startedAt`/`finishedAt`; recalibrar la SLE al completar cinco elementos confiables.
 - [ ] Contrastar los metadatos bibliográficos de Gómez (2014) y Parada (2026) contra los originales de cátedra y cerrar la sección de referencias.
-- [ ] Ejecutar el gate final sobre el commit candidato y guardar la evidencia.
-- [ ] Repetir la validación Android con un conjunto de datos más representativo.
+- [ ] Resolver AUD-004 en un PR separado antes de otra APK publicada: revisar advisories/changelogs y validar dependencias, sanitización, lockfile, suite y build.
+- [ ] Ejecutar el gate final sobre el commit y artefacto candidatos y guardar la evidencia; el gate acumulativo de AUD-003 y los pre-push documentales no sustituyen este cierre.
+- [ ] Repetir la validación Android sobre el artefacto versionado con un conjunto de datos representativo; el checkpoint de AUD-003 ya cubrió `STORE`, `DEFLATE`, datos inválidos y una fixture de 500 notas.
 - [ ] Verificar específicamente la interacción `Mover a` y clasificar su fricción como corregida, aceptada o bloqueante.
-- [ ] Medir el comportamiento con un volumen mayor de notas y registrar el resultado.
+- [ ] Medir latencia CRUD y rendimiento percibido con al menos 500 notas y registrar el resultado; importar correctamente esa cantidad no constituye por sí solo una medición de `RNF-002`/`RNF-004`.
 - [ ] Ejecutar pruebas de uso con estudiantes y verificar profundidad de navegación (`RNF-005`, `RNF-006`).
 - [ ] Completar la auditoría manual de tipografía, touch targets, contraste y navegación accesible (`RNF-007`, `RNF-008`, `RNF-019` a `RNF-022`).
 - [ ] Repetir flujos principales en modo avión y comprobar recuperación ante cierre/terminación inesperada (`RNF-009`, `RNF-010`).
@@ -43,8 +48,9 @@
 - [ ] Emitir la matriz RNF final con requisito, método, comando, dispositivo, fecha, artefacto, resultado y evidencia.
 - [ ] Preparar presentación, guion de demo, respuestas de defensa y checklist de contingencia.
 - [ ] Medir el factor de ajuste real y redactar recomendaciones para futuros equipos.
+- [ ] Corregir o reforzar `scripts/release-helper.py` para sincronizar y verificar `versionName`/`versionCode` Android con la versión declarada.
 - [ ] Sincronizar README, CHANGELOG, informe de Hito 06, líneas base, velocidad y cheatsheet en el corte final.
-- [ ] Decidir si `v0.4.8` alcanza como artefacto de entrega o si corresponde crear una versión final distinta.
+- [ ] Decidir si corresponde publicar una beta patch `v0.4.9` o reservar el siguiente artefacto para la entrega final de Hito 06.
 
 ## Criterios de salida de Hito 06
 
@@ -59,6 +65,6 @@
 ## Observaciones heredadas no bloqueantes
 
 - `Mover a`: en la validación inicial del S20 FE algunas interacciones parecieron requerir pulsación prolongada.
-- Rendimiento: la beta respondió correctamente con pocos datos; falta evidencia con un volumen mayor de notas.
+- Rendimiento: la importación funcional de 500 notas fue aprobada, pero todavía faltan mediciones de latencia CRUD y rendimiento percibido con ese volumen.
 
 Estas observaciones forman parte de la validación final; las reglas de alcance que las gobiernan están centralizadas en [`BACKLOG.md`](BACKLOG.md#política-de-alcance--hito-06).

--- a/TODO
+++ b/TODO
@@ -16,12 +16,11 @@
 
 | Orden | Frente | Criterio de cierre |
 |---|---|---|
-| 1 | Sincronización documental | `CHANGELOG.md`, backlog, este tablero e Hito 06 reflejan el cierre de AUD-001/002/003 y la frontera no publicada posterior a `v0.4.8` |
-| 2 | Seguridad del próximo corte | AUD-004 resuelto en un PR independiente, con dependencias, sanitización, lockfile, suite y build verificados |
-| 3 | Congelamiento editorial y visual | Evidencia y bibliografía consolidadas; gráficos DB legibles en PDF y diapositivas |
-| 4 | Validación final | Quality gate, checklist Android y matriz RNF cerrados sobre el mismo artefacto versionado, con observaciones clasificadas |
-| 5 | Defensa y presentación | Guion, cheatsheet, demo y material visual preparados y ensayados |
-| 6 | Línea base final | Decisión explícita entre beta patch y entrega final; versión web/Android, firma, hash y tag inequívocos |
+| 1 | Seguridad del próximo corte | AUD-004 resuelto en un PR independiente, con dependencias, sanitización, lockfile, suite y build verificados |
+| 2 | Congelamiento editorial y visual | Evidencia y bibliografía consolidadas; gráficos DB legibles en PDF y diapositivas |
+| 3 | Validación final | Quality gate, checklist Android y matriz RNF cerrados sobre el mismo artefacto versionado, con observaciones clasificadas |
+| 4 | Defensa y presentación | Guion, cheatsheet, demo y material visual preparados y ensayados |
+| 5 | Línea base final | Decisión explícita entre beta patch y entrega final; versión web/Android, firma, hash y tag inequívocos |
 
 ## Checklist de trabajo
 
@@ -32,7 +31,7 @@
 - [x] Revisar el marco metodológico y la defensa: corregir Scrum 2017/2020, distinguir RUP y formalizar el flujo Kanban (2026-08-11).
 - [x] Corregir AUD-001 y AUD-002: conservar borradores ante fallos, serializar guardados concurrentes y diferenciar el descarte (PR #2, 2026-09-01).
 - [x] Corregir AUD-003: acotar y validar la importación ZIP, proteger jerarquías/renderizado y aprobar los checkpoints Android acumulativos (PR #3, 2026-09-02).
-- [ ] Completar la sincronización documental posterior a las auditorías: `CHANGELOG.md`, backlog y `TODO` actualizados; resta Hito 06.
+- [x] Completar la sincronización documental posterior a las auditorías en `CHANGELOG.md`, backlog, `TODO` e Hito 06 (2026-09-02).
 - [ ] Alinear el tablero de GitHub Projects con la Definition of Workflow: WIP global 2, bloqueos y fechas `startedAt`/`finishedAt`; recalibrar la SLE al completar cinco elementos confiables.
 - [ ] Contrastar los metadatos bibliográficos de Gómez (2014) y Parada (2026) contra los originales de cátedra y cerrar la sección de referencias.
 - [ ] Resolver AUD-004 en un PR separado antes de otra APK publicada: revisar advisories/changelogs y validar dependencias, sanitización, lockfile, suite y build.

--- a/docs/hitos/hito-06-octubre.md
+++ b/docs/hitos/hito-06-octubre.md
@@ -1,4 +1,4 @@
-# Informe inicial de Hito 06 — Entrega Final
+# Informe de avance de Hito 06 — Entrega Final
 
 **Período planificado:** Octubre 2026
 
@@ -8,9 +8,9 @@
 
 **Proyecto:** Lumapse
 
-**Estado:** Activo
+**Estado:** Activo — endurecimiento técnico integrado; cierre editorial, RNF y artefacto pendientes
 
-**Última actualización:** 2026-08-11
+**Última actualización:** 2026-09-02
 
 ---
 
@@ -25,7 +25,8 @@ Cerrar Lumapse con documentación coherente, evidencia técnica reproducible, di
 - Tag `v0.4.8` asociado al commit `a808de7`.
 - SHA-256 del APK: `cad122d0329e1761816ac7ad07938673389c859a252d9cc63504359355db3d10`.
 - Validación inicial aprobada en Samsung Galaxy S20 FE con Android 13.
-- Al iniciar esta revisión, `main` contenía 12 commits posteriores al tag, concentrados en documentación y refactors de TypeScript. Ese dato describe el checkpoint previo y puede crecer; no existe una release `0.4.9`.
+- El rango técnico auditado posterior al tag comprende 38 commits hasta `ba16777`: documentación, refactors TypeScript, correcciones de integridad de guardado y endurecimiento de la importación de backups. Este rango no constituye una release ni un APK publicado nuevo.
+- AUD-001 y AUD-002 quedaron integrados mediante PR #2; AUD-003 quedó integrado mediante PR #3 después de completar la suite acumulativa y los checkpoints Android acordados.
 - Diagramas Mermaid revisados contra el alcance de la beta; fuentes DOT, DBML y DDL sincronizadas; exportaciones gráficas de base de datos reemplazadas, revisadas e incorporadas el 2026-07-15.
 
 ## Alcance del Hito
@@ -37,6 +38,7 @@ Cerrar Lumapse con documentación coherente, evidencia técnica reproducible, di
 - [x] Mantener Markdown como fuente de verdad y documentar la salida LaTeX/PDF para después del congelamiento.
 - [x] Incorporar una sección de referencias y metadatos de portada reproducibles, sin leer información desde el artefacto generado.
 - [x] Revisar el marco metodológico: corregir la comparación con Scrum, distinguir RUP de sus artefactos y formalizar el flujo Kanban sin inventar métricas históricas.
+- [x] Reconciliar `CHANGELOG.md`, backlog, `TODO` y este informe con la evidencia integrada hasta `ba16777`, manteniendo explícita la frontera publicada de `v0.4.8`.
 - [ ] Alinear el tablero con la Definition of Workflow y registrar fechas de inicio/fin de los elementos restantes para recalibrar la SLE con evidencia.
 - [ ] Verificar contra los originales los datos bibliográficos incompletos de los materiales de cátedra.
 - [ ] Consolidar la evidencia final; luego verificar referencias, tablas, terminología, legibilidad de las figuras y congelar el contenido. Las exportaciones gráficas DB ya fueron incorporadas.
@@ -51,9 +53,13 @@ Cerrar Lumapse con documentación coherente, evidencia técnica reproducible, di
 
 ### 3. Validación final
 
-- [ ] Ejecutar el quality gate sobre el commit candidato.
-- [ ] Repetir la checklist Android sobre el artefacto elegido.
-- [ ] Medir latencia CRUD y rendimiento con un volumen reproducible de notas (`RNF-002`, `RNF-004`).
+- [x] Cerrar AUD-001 y AUD-002 con regresiones de error y concurrencia, integración mediante PR #2 y comportamiento de descarte distinguible.
+- [x] Cerrar AUD-003 con importación ZIP acotada, validación runtime, jerarquía consistente, presentación defensiva, suite acumulativa e integración mediante PR #3.
+- [x] Aprobar los checkpoints Android de AUD-003 con backups `STORE`/`DEFLATE`, rechazo de datos inválidos antes de persistir, fixture de 500 notas y build completo instalado. Esta evidencia no equivale a validar un artefacto publicado nuevo.
+- [ ] Resolver AUD-004 en un PR separado antes del próximo APK publicado y repetir auditoría de dependencias, sanitización, lockfile, suite y build.
+- [ ] Ejecutar el quality gate sobre el commit candidato y guardar la evidencia; los gates acumulativos y pre-push ya aprobados no sustituyen el cierre del corte.
+- [ ] Repetir la checklist Android sobre el artefacto versionado y firmado elegido.
+- [ ] Medir latencia CRUD y rendimiento con al menos 500 notas (`RNF-002`, `RNF-004`); la importación funcional de esa cantidad no constituye una medición de rendimiento.
 - [ ] Ejecutar pruebas con estudiantes y revisar profundidad de navegación, incluyendo la interacción `Mover a` (`RNF-005`, `RNF-006`).
 - [ ] Auditar tipografía, touch targets, contraste y navegación accesible (`RNF-007`, `RNF-008`, `RNF-019` a `RNF-022`).
 - [ ] Repetir los flujos principales en modo avión y cubrir cierre o terminación inesperada del editor (`RNF-009`, `RNF-010`).
@@ -72,8 +78,10 @@ Cerrar Lumapse con documentación coherente, evidencia técnica reproducible, di
 
 ### 5. Corte y línea base final
 
-- Decidir si `v0.4.8` es suficiente como artefacto de entrega o si la evidencia exige una versión final distinta.
+- `v0.4.8` permanece como evidencia inmutable de la beta, pero no contiene las correcciones AUD-001/002/003 ya integradas; el próximo artefacto distribuido deberá partir de un corte posterior.
+- Decidir si ese corte se publica como beta patch `v0.4.9` para una nueva ronda de validación o se reserva para la versión final de Hito 06.
 - No crear `0.4.9` de forma preventiva ni reutilizar `versionCode 408` para un binario diferente.
+- Corregir o reforzar `scripts/release-helper.py`: actualmente actualiza package/changelog, pero no garantiza la alineación de `versionName` y `versionCode` Android.
 - Si se genera un nuevo APK, actualizar versión, código Android, hash, changelog, README, línea base y material de defensa en un único corte.
 - Crear `LB-PROD-v1.0.0` o un tag final equivalente solo cuando documentación, validación y artefacto sean definitivos.
 
@@ -93,11 +101,12 @@ Las ideas conservadas siguen en [`../../BACKLOG.md`](../../BACKLOG.md) y no comp
 
 | Orden | Frente | Salida esperada |
 |---|---|---|
-| 1 | Revisión editorial | Contenido congelado y consistente |
-| 2 | Diagramas DB | Fuentes y exportaciones finales verificadas |
-| 3 | Validación | Gate y checklist sin bloqueantes |
-| 4 | Presentación | Deck, demo, guion y contingencia listos |
-| 5 | Línea base | Artefacto, versión, hash y tag inequívocos |
+| 1 | Sincronización documental | Evidencia post-auditoría reflejada sin confundir `main` con una release |
+| 2 | Seguridad de release | AUD-004 resuelto y dependencias verificadas en un frente independiente |
+| 3 | Revisión editorial y diagramas DB | Contenido congelado; fuentes y exportaciones finales verificadas |
+| 4 | Validación | Gate, matriz RNF y checklist Android sin bloqueantes sobre el mismo artefacto |
+| 5 | Presentación | Deck, demo, guion y contingencia listos |
+| 6 | Línea base | Artefacto, versión web/Android, firma, hash y tag inequívocos |
 
 Se mantiene WIP máximo de dos elementos activos en total entre `En Curso` y `En Revisión`, según la [`Definition of Workflow`](../gestion/definicion-flujo-kanban.md), para evitar que documentación, validación y presentación queden abiertas al mismo tiempo.
 
@@ -105,22 +114,27 @@ Se mantiene WIP máximo de dos elementos activos en total entre `En Curso` y `En
 
 | Observación | Severidad actual | Evidencia requerida |
 |---|---|---|
+| AUD-004 — dependencias con advisories | P0 / bloqueante para nueva publicación | PR separado, auditoría de dependencias y regresiones de sanitización/build |
+| El helper no alinea automáticamente la versión Android | Riesgo alto de release | Test o gate que compare versión declarada, `versionName` y `versionCode` antes del build |
 | `Mover a` puede requerir pulsación prolongada | Menor / no bloqueante | Reproducción repetible en validación final y decisión explícita |
-| Rendimiento con mayor volumen de notas | Riesgo medio de evidencia | Prueba con dataset representativo y registro del resultado |
+| Rendimiento con mayor volumen de notas | Riesgo medio de evidencia | Medición de latencia y percepción con al menos 500 notas; no solo importación funcional |
+| `npm run verify` depende del entorno vigente | Riesgo medio de tooling | Resolver por separado falsos positivos CSP de AUD-008 y colisión Web Storage de Node 26 de AUD-009 |
 
 ## Criterios de Cierre
 
 - [x] Narrativa canónica, capítulos fuente y checkpoint ensamblado reconciliados al 2026-07-15.
 - [x] Fuentes de base de datos sincronizadas con el schema ejecutable.
+- [x] AUD-001, AUD-002 y AUD-003 corregidos, validados e integrados.
 - [ ] Informe final revisado, referenciado y exportable.
 - [x] Gráficos de base de datos actualizados y consistentes con el schema.
+- [ ] AUD-004 resuelto y auditoría de dependencias sin bloqueantes aceptados para el corte.
 - [ ] Quality gate final sin fallos.
 - [ ] Validación Android final documentada y sin bloqueantes.
 - [ ] Matriz RNF final emitida con evidencia reproducible y límites explícitos.
 - [ ] Observaciones de `Mover a` y rendimiento resueltas o aceptadas explícitamente.
 - [ ] Presentación, demo y contingencia ensayadas.
 - [ ] Factor de ajuste y recomendaciones finales registrados.
-- [ ] Artefacto, versión, hash y mecanismo de distribución decididos.
+- [ ] Nuevo artefacto posterior a `v0.4.8`, versión web/Android, firma, hash y mecanismo de distribución decididos.
 - [ ] Línea base final creada y documentada.
 
 ## Documentos de Control
@@ -131,4 +145,6 @@ Se mantiene WIP máximo de dos elementos activos en total entre `En Curso` y `En
 - [`../gestion/seguimiento-velocidad.md`](../gestion/seguimiento-velocidad.md) — SP entregados por hito.
 - [`../gestion/definicion-flujo-kanban.md`](../gestion/definicion-flujo-kanban.md) — estados, políticas, WIP y métricas de flujo.
 - [`../gestion/cheatsheet-defensa.md`](../gestion/cheatsheet-defensa.md) — argumentos y métricas de defensa.
+- [`../gestion/revision-tecnica-priorizada-2026-09-01.md`](../gestion/revision-tecnica-priorizada-2026-09-01.md) — hallazgos AUD-001 a AUD-013 y prioridades vigentes.
+- [`../gestion/analisis-aud-003-seguridad-importacion-backups-2026-09-01.md`](../gestion/analisis-aud-003-seguridad-importacion-backups-2026-09-01.md) — evidencia, implementación y validación acumulativa de AUD-003.
 - [`hito-05-septiembre.md`](hito-05-septiembre.md) — cierre del hito anterior.


### PR DESCRIPTION
## Summary

- reconcile the complete post-`v0.4.8` Unreleased changelog through the audited `ba16777` checkpoint
- update the live backlog and TODO with the merged AUD-001, AUD-002, and AUD-003 work
- record AUD-004 and Android version alignment as gates before another published APK
- update Hito 06 with current validation evidence while preserving the boundary between post-tag code and published artifacts

## Phased commits

1. `docs(changelog): reconcile post-v0.4.8 changes`
2. `docs(backlog): update post-audit priorities`
3. `docs(todo): reconcile final-delivery work`
4. `docs(milestone): update hito 06 release status`
5. `docs(project): close release tracking sync`

## Validation

- `git diff --check`
- `npm run check:docs`
- `npm run check:traceability`
- pre-push quality gate after every local phase
- 60 test files / 955 tests passed
- production build passed
- bundle budget passed

## Release boundary

This PR does not bump a version, build or publish an APK, create a tag, or choose between `v0.4.9` and the final Hito 06 release. The only published artifact remains `v0.4.8`.
