### PR TITLE
fix(deps): remediate AUD-004 vulnerabilities

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,7 +4,7 @@ Este documento funciona como bandeja viva de tareas, deuda y decisiones pendient
 
 > **Hito activo:** 06 — Entrega Final
 > **Hito 05:** Cerrado documentalmente el 2026-07-15 sobre la beta operativa `v0.4.8`
-> **Última actualización:** 2026-09-02 — cierre de AUD-001, AUD-002 y AUD-003, y revisión del próximo corte Android
+> **Última actualización:** 2026-09-02 — AUD-001 a AUD-004 cerrados técnicamente; próximo foco editorial y de validación final
 > **Snapshot histórico:** [`docs/gestion/historico/backlog-historico-hito-04-2026-06-01.md`](docs/gestion/historico/backlog-historico-hito-04-2026-06-01.md)
 
 ---
@@ -15,9 +15,9 @@ Hito 04 quedó cerrado formalmente como bloque de Organización y UX. El cierre 
 
 Hito 05 quedó cerrado documentalmente el 2026-07-15. Entregó el quality gate, APK firmada, validación inicial en Android real y publicación de la beta controlada [`v0.4.8`](https://github.com/jdfesa/lumapse/releases/tag/v0.4.8), junto con mejoras funcionales acotadas: borradores persistentes (`RF-005`), backup manual (`RF-017`), importación ZIP (`RF-018`), Acerca de (`RF-023`), fechas académicas discretas (`RF-027`) y editor enriquecido (`RF-028`). Las observaciones sobre `Mover a` y rendimiento con más notas no bloquearon ese cierre.
 
-Hito 06 queda activo para completar la documentación final, verificar la maquetación de los gráficos de base de datos ya actualizados, repetir la validación sobre un corte congelado y preparar la presentación. La única versión publicada continúa siendo `v0.4.8`; el rango auditado posterior al tag comprende 38 commits hasta `ba16777`, pero todavía no constituye una release ni un APK distribuible nuevo. La decisión pendiente debe distinguir entre una beta de corrección `v0.4.9` y el artefacto final de Hito 06, sin renombrar preventivamente el estado actual de `main`.
+Hito 06 queda activo para completar la documentación final, verificar la maquetación de los gráficos de base de datos ya actualizados, repetir la validación sobre un corte congelado y preparar la presentación. La única versión publicada continúa siendo `v0.4.8`; el trabajo posterior al tag ya incluye los cierres técnicos AUD-001 a AUD-004, pero todavía no constituye una release ni un APK distribuible nuevo. La decisión pendiente debe distinguir entre una beta de corrección `v0.4.9` y el artefacto final de Hito 06, sin renombrar preventivamente el estado actual de `main`.
 
-La revisión técnica priorizada del 2026-09-01 abrió trece hallazgos trazables. AUD-001 y AUD-002 quedaron resueltos mediante PR #2; AUD-003 quedó implementado, validado en Android e integrado mediante PR #3. La validación incluyó backups `STORE` y `DEFLATE`, rechazo previo a persistencia de datos inválidos y una fixture funcional de 500 notas. Esta última evidencia no sustituye las mediciones de latencia y rendimiento exigidas por `RNF-002` y `RNF-004`. AUD-004 conserva prioridad P0 y debe tratarse en un frente separado antes de publicar otro artefacto; los hallazgos restantes mantienen sus prioridades y no se incorporan automáticamente al alcance de Hito 06.
+La revisión técnica priorizada del 2026-09-01 abrió trece hallazgos trazables. AUD-001 y AUD-002 quedaron resueltos mediante PR #2; AUD-003 quedó validado en Android e integrado mediante PR #3. AUD-004 actualizó de forma mínima DOMPurify y siete dependencias de tooling, dejó las auditorías completa y productiva en cero y aprobó suites, build, quality gate y Android 0.4.8/408; su integración fue autorizada. La validación funcional de 500 notas de AUD-003 no sustituye las mediciones de latencia y rendimiento exigidas por `RNF-002` y `RNF-004`. Los hallazgos restantes mantienen sus prioridades y no se incorporan automáticamente al alcance de Hito 06.
 
 La revisión de exportación/importación corrige una sobrepromesa documental del Hito 03: los servicios base de Markdown no equivalían a un flujo de usuario validado. La opción "Compartir" para una nota individual (`RF-016`) solo tendría sentido si abre el share sheet nativo de Android y ofrece apps como WhatsApp; si termina copiando contenido, duplica una acción existente y agrega ruido. La portabilidad de workspace sí quedó resuelta de forma acotada con exportación e importación de backup `.zip` desde la vista Backup.
 
@@ -37,24 +37,23 @@ La trazabilidad de `v0.4.8` queda distribuida entre `docs/gestion/lineas-base.md
 
 | Orden | Tarea | Criterio de cierre |
 |---|---|---|
-| 1 | Seguridad previa al próximo corte | Resolver AUD-004 en un PR separado, revisar advisories/changelogs y repetir sanitización, tests, build y auditoría de dependencias |
-| 2 | Congelamiento editorial y visual | Consolidar evidencia, verificar bibliografía y confirmar legibilidad de gráficos DB en PDF y diapositivas |
-| 3 | Validación final | Ejecutar el gate sobre el corte candidato, completar las mediciones RNF y repetir Android sobre el artefacto versionado; resolver o aceptar `Mover a` y rendimiento |
-| 4 | Presentación y defensa | Preparar guion, demo, cheatsheet, material visual y contingencias |
-| 5 | Corte final | Decidir entre beta patch y entrega final; alinear versión web/Android, firmar, calcular hash, etiquetar y registrar la línea base |
+| 1 | Congelamiento editorial y visual | Consolidar evidencia, verificar bibliografía y confirmar legibilidad de gráficos DB en PDF y diapositivas |
+| 2 | Validación final | Ejecutar el gate sobre el corte candidato, completar las mediciones RNF y repetir Android sobre el artefacto versionado; resolver o aceptar `Mover a` y rendimiento |
+| 3 | Presentación y defensa | Preparar guion, demo, cheatsheet, material visual y contingencias |
+| 4 | Corte final | Decidir entre beta patch y entrega final; alinear versión web/Android, firmar, calcular hash, etiquetar y registrar la línea base |
 
 ---
 
 ## Revisión técnica priorizada — estado vivo
 
-El análisis detallado permanece en [`docs/gestion/revision-tecnica-priorizada-2026-09-01.md`](docs/gestion/revision-tecnica-priorizada-2026-09-01.md). Esta tabla solo fija el estado operativo del backlog después de integrar los PR #2 y #3.
+El análisis detallado permanece en [`docs/gestion/revision-tecnica-priorizada-2026-09-01.md`](docs/gestion/revision-tecnica-priorizada-2026-09-01.md). Esta tabla fija el estado operativo después de integrar los PR #2 y #3 y completar la validación de AUD-004.
 
 | ID | Prioridad | Frente | Estado operativo |
 |---|---|---|---|
 | AUD-001 | P0 | Pérdida de borrador ante error SQLite | Cerrado en PR #2; regresiones aprobadas |
 | AUD-002 | P0 | Guardados duplicados por taps concurrentes | Cerrado en PR #2; single-flight y estado visual validados |
 | AUD-003 | P0 | Frontera y presentación de backups no confiables | Cerrado en PR #3; suite acumulativa y checkpoints Android aprobados |
-| AUD-004 | P0 | Dependencias con advisories de seguridad | Pendiente; próximo frente técnico previo a una nueva APK |
+| AUD-004 | P0 | Dependencias con advisories de seguridad | Cerrado técnicamente; auditorías 0/0 y Android aprobados; integración autorizada |
 | AUD-005–AUD-009 | P1 | Persistencia, asincronía, contratos y tooling | Pendientes; abordar en ramas separadas según riesgo y gate de release |
 | AUD-010–AUD-013 | P2 | Escalabilidad, rendimiento, cohesión y margen de bundle/coverage | Monitorear o medir; no bloquean por sí solos el cierre actual |
 
@@ -95,14 +94,14 @@ Estas tareas no bloquean el MVP. Se conservan como decisiones trazables para rea
 | Tipado gradual | Continuar servicios de dominio/backup archivo por archivo | Baja/Media | No avanzar en bloque; proximos candidatos requieren evaluar bordes nativos/share/storage o store con contratos mas claros |
 | Framework UI | No incorporar Svelte por ahora | Baja | Costo de migracion alto vs beneficio actual; reabrir solo si DOM manual se vuelve una carga clara |
 | Documentación | Congelar documentos antes del corte final | Alta | La reconciliación posterior a AUD-001/002/003 se completó el 2026-09-02; restan evidencia final, revisión de maquetación y el corte elegido |
-| Dependencias | Resolver AUD-004 sin mezclar otros hallazgos | Alta | Actualizar dependencias con advisories en una rama propia y validar especialmente sanitización, lockfile, suite, build y APK antes del próximo corte |
+| Dependencias | Repetir auditorías en cada corte candidato | Recurrente | AUD-004 quedó cerrado con grafo mínimo, auditorías 0/0 y Android aprobado; revalidar porque los advisories evolucionan |
 | Persistencia y asincronía | Planificar AUD-005–AUD-007 | Alta/Media | Mantener ramas separadas para propiedad transaccional/migraciones, resultados async obsoletos y contratos de error; priorizar solo lo que bloquee el gate acordado |
 | Tooling | Resolver portabilidad de gate y Node 26 (AUD-008/AUD-009) | Media | Distinguir falsos positivos CSP del fallback offline y eliminar la dependencia del workaround de Web Storage sin relajar controles |
 | Tooling DB | Ampliar el smoke test a `academic_events` y constraints relevantes | Media | El DDL completo se ejecuta, pero las aserciones explícitas de tablas/columnas/relaciones se concentran en materias, notas y metadata; decidir su ampliación antes de presentar cobertura exhaustiva |
 | Tooling de release | Sincronizar versión Android desde el helper | Alta | `scripts/release-helper.py` actualiza package/changelog, pero no `versionName` ni `versionCode`; corregirlo o agregar un gate explícito antes de generar otra APK |
 | Diagramas | Revisar Mermaid de casos de uso, secuencia y dominio | Baja | Completado el 2026-07-03 contra `v0.4.8`; reabrir solo si cambia el alcance o durante la exportacion final a PDF/LaTeX |
 | Informe final | Preparar conversion LaTeX/PDF | Media | Consideraciones registradas en `docs/informe-final/README.md`; mantener Markdown como fuente de verdad y abrir pipeline LaTeX solo cuando el contenido este congelado |
-| Release | Definir el próximo corte | Alta | `v0.4.8` sigue como única beta publicada y no contiene AUD-001/002/003; evaluar `v0.4.9` como beta patch o reservar el artefacto para el cierre final, siempre después de los gates acordados |
+| Release | Definir el próximo corte | Alta | `v0.4.8` sigue como única beta publicada y no contiene AUD-001/002/003/004; evaluar `v0.4.9` como beta patch o reservar el artefacto para el cierre final, siempre después de los gates acordados |
 | UX menor | Revisar interacción de `Mover a` | Baja | En S20 FE se observó que puede requerir pulsación prolongada; no bloquea beta porque la acción se completa |
 | Rendimiento | Medir crecimiento real de notas | Media | La importación funcional de una fixture de 500 notas fue aprobada; todavía deben medirse latencia CRUD y rendimiento percibido para cerrar `RNF-002`/`RNF-004` |
 | Adjuntos | Planificar adjuntos de imagen post-release | Media | Valor alto para fotos de pizarrón; debe implementarse sin cargar SQLite ni saturar el feed |
@@ -128,7 +127,7 @@ Hito 06 es un hito de cierre. No incorporar salvo que un bloqueo de entrega lo e
 - Mantener un máximo de dos frentes en curso.
 - No abrir refactors ni migraciones amplias; una corrección estructural debe estar ligada a un bloqueo o a una validación concreta.
 - No denominar `0.4.9` al estado actual de `main` ni generar un APK con esa versión sin una decisión formal de corte.
-- No publicar un nuevo artefacto mientras AUD-004 o cualquier otro bloqueo de seguridad confirmado para ese corte permanezca abierto.
+- No publicar un nuevo artefacto sin repetir auditorías sobre el corte candidato ni mientras exista cualquier bloqueo de seguridad confirmado.
 - Todo cambio de comportamiento debe cerrar con tests focalizados, `npm run verify`, trazabilidad y nueva validación Android proporcional al riesgo.
 - Preservar `v0.4.8` y su SHA-256 como evidencia inmutable de la beta publicada.
 - Las ideas postergadas permanecen en este backlog; no vuelven al `TODO` operativo hasta que Hito 06 haya terminado.
@@ -169,7 +168,7 @@ Los ítems marcados como completados fueron planes que originalmente estaban en 
 - [x] Imports dinamicos redundantes retirados del store y la restauracion de papelera: Vite ya no advierte sobre modulos que eran importados de forma estatica y dinamica a la vez.
 - [x] AUD-001 y AUD-002 cerrados en PR #2: el editor conserva el borrador ante fallos, serializa guardados concurrentes y diferencia visualmente el descarte.
 - [x] AUD-003 cerrado en PR #3: importación ZIP acotada, validación runtime, jerarquía consistente, presentación defensiva y validación Android acumulativa.
-- [ ] AUD-004: actualizar dependencias con advisories en un frente separado y repetir los controles de sanitización, lockfile, suite y build antes de otra APK.
+- [x] AUD-004 cerrado técnicamente: dependencias parcheadas en un frente separado, auditorías 0/0, sanitización, lockfile, suite, build y Android aprobados el 2026-09-02.
 - [ ] Corregir o reforzar `scripts/release-helper.py` para que `versionName` y `versionCode` Android no puedan quedar desalineados del corte declarado.
 - [ ] Aplicar mejoras pequenas y verificables que aumenten cohesion, reduzcan acoplamiento y faciliten revisiones humanas/IA, evitando reescrituras grandes.
 - [ ] Restauracion avanzada desde backup `.zip` con estrategia explicita de reemplazo/merge, solo despues de validar la importacion no destructiva actual con usuarios reales.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ y este proyecto adhiere a [Conventional Commits](https://www.conventionalcommits
 
 ## [Unreleased] — Trabajo posterior a `v0.4.8`
 
-> `main` conserva la versión declarada `0.4.8`, pero contiene trabajo posterior al tag. No existe una release `0.4.9` ni un APK posterior publicado. Este corte resume el rango Git completo desde `v0.4.8` (exclusivo) hasta `ba16777` (inclusivo). Las ejecuciones Android sobre código posterior al tag son evidencia de validación y no constituyen un artefacto publicado.
+> `main` conserva la versión declarada `0.4.8`, pero contiene trabajo posterior al tag. No existe una release `0.4.9` ni un APK posterior publicado. Este bloque resume el trabajo desde `v0.4.8`, incluidos los cierres técnicos AUD-001 a AUD-004. Las ejecuciones Android sobre código posterior al tag son evidencia de validación y no constituyen un artefacto publicado.
 
 ### Added
 
@@ -35,6 +35,7 @@ y este proyecto adhiere a [Conventional Commits](https://www.conventionalcommits
 - **Coverage JS/TS medible:** Vitest incorpora `src/**/*.{js,ts}` y genera un resumen JSON; la nueva línea base registra 92,43% de statements en `src/services/**`, cerrando la medición pendiente de `RNF-024` sin fijar todavía umbrales bloqueantes.
 - **Dependencias estáticas explícitas:** Se retiraron cinco imports dinámicos que Vite no podía separar en chunks porque los mismos módulos ya formaban parte del grafo estático; el comportamiento y las APIs públicas permanecen sin cambios.
 - **Auditoría técnica trazable:** La revisión priorizada separa hallazgos de integridad, seguridad, confiabilidad, tooling y mantenibilidad; el análisis de AUD-003 registra riesgos confirmados y refutados, alcance, fases, evidencia y limitaciones sin mezclar la actualización de dependencias de AUD-004.
+- **Dependencias parcheadas dentro de sus majors:** DOMPurify sube a 3.4.14 y Vite a 6.4.3; el lockfile resuelve también `tar` 7.5.22, PostCSS 8.5.26, nanoid 3.3.18, undici 7.29.0, `brace-expansion` 5.0.9 y `@xmldom/xmldom` 0.9.12 sin overrides ni transitivas directas.
 
 ### Fixed
 
@@ -48,6 +49,7 @@ y este proyecto adhiere a [Conventional Commits](https://www.conventionalcommits
 - **Validación runtime de backups:** El manifiesto, las entidades y sus primitivas se validan sin coerciones permisivas antes del plan de importación, con contratos y límites explícitos para conteos, booleanos, IDs, colores, fechas, timestamps y textos.
 - **Jerarquía importada consistente:** El plan impone un máximo de dos niveles, detecta ciclos y padres inexistentes o que ya son secciones, y registra en el preview las reparaciones de relaciones antes de escribir.
 - **Presentación defensiva de contenido importado:** Textos y atributos se codifican según su contexto, los colores pasan por una allowlist y los selectores evitan interpolar IDs importados; los renderizadores también toleran datos antiguos inválidos.
+- **Dependencias sin advisories conocidos (AUD-004):** Las auditorías completa y productiva pasan de ocho y una vulnerabilidades respectivamente a cero; `npm ci`, el árbol completo, 56 regresiones de Markdown, 955 tests, build, quality gate y Android 0.4.8/408 fueron aprobados sin publicar una release.
 
 ---
 

--- a/TODO
+++ b/TODO
@@ -4,11 +4,11 @@
 
 ## Hito actual: 06 — Entrega Final
 
-**Estado:** activo; AUD-001, AUD-002 y AUD-003 quedaron integrados y validados al 2026-09-02.
+**Estado:** activo; AUD-001 a AUD-003 quedaron integrados y AUD-004 completó implementación y validación con integración autorizada al 2026-09-02.
 
 **Corte operativo vigente:** beta/candidata [`v0.4.8`](https://github.com/jdfesa/lumapse/releases/tag/v0.4.8), publicada y validada inicialmente en Android real.
 
-**Versión:** `v0.4.8`; el trabajo posterior al tag permanece no publicado y no existe una release `0.4.9`. El rango técnico auditado llega hasta `ba16777`, pero la versión del próximo artefacto solo se decidirá después de cerrar sus bloqueos y validaciones.
+**Versión:** `v0.4.8`; el trabajo posterior al tag —incluido AUD-004— permanece no publicado y no existe una release `0.4.9`. La versión del próximo artefacto solo se decidirá después de cerrar sus bloqueos y validaciones.
 
 **Objetivo:** cerrar documentación, gráficos de base de datos, validación final y materiales de presentación sin ampliar el producto.
 
@@ -16,11 +16,10 @@
 
 | Orden | Frente | Criterio de cierre |
 |---|---|---|
-| 1 | Seguridad del próximo corte | AUD-004 resuelto en un PR independiente, con dependencias, sanitización, lockfile, suite y build verificados |
-| 2 | Congelamiento editorial y visual | Evidencia y bibliografía consolidadas; gráficos DB legibles en PDF y diapositivas |
-| 3 | Validación final | Quality gate, checklist Android y matriz RNF cerrados sobre el mismo artefacto versionado, con observaciones clasificadas |
-| 4 | Defensa y presentación | Guion, cheatsheet, demo y material visual preparados y ensayados |
-| 5 | Línea base final | Decisión explícita entre beta patch y entrega final; versión web/Android, firma, hash y tag inequívocos |
+| 1 | Congelamiento editorial y visual | Evidencia y bibliografía consolidadas; gráficos DB legibles en PDF y diapositivas |
+| 2 | Validación final | Quality gate, checklist Android y matriz RNF cerrados sobre el mismo artefacto versionado, con observaciones clasificadas |
+| 3 | Defensa y presentación | Guion, cheatsheet, demo y material visual preparados y ensayados |
+| 4 | Línea base final | Decisión explícita entre beta patch y entrega final; versión web/Android, firma, hash y tag inequívocos |
 
 ## Checklist de trabajo
 
@@ -34,7 +33,7 @@
 - [x] Completar la sincronización documental posterior a las auditorías en `CHANGELOG.md`, backlog, `TODO` e Hito 06 (2026-09-02).
 - [ ] Alinear el tablero de GitHub Projects con la Definition of Workflow: WIP global 2, bloqueos y fechas `startedAt`/`finishedAt`; recalibrar la SLE al completar cinco elementos confiables.
 - [ ] Contrastar los metadatos bibliográficos de Gómez (2014) y Parada (2026) contra los originales de cátedra y cerrar la sección de referencias.
-- [ ] Resolver AUD-004 en un PR separado antes de otra APK publicada: revisar advisories/changelogs y validar dependencias, sanitización, lockfile, suite y build.
+- [x] Resolver AUD-004 en un PR separado: DOMPurify y siete dependencias de tooling parcheadas, auditorías 0/0, 955 tests, build, quality gate y Android 0.4.8/408 aprobados (2026-09-02).
 - [ ] Ejecutar el gate final sobre el commit y artefacto candidatos y guardar la evidencia; el gate acumulativo de AUD-003 y los pre-push documentales no sustituyen este cierre.
 - [ ] Repetir la validación Android sobre el artefacto versionado con un conjunto de datos representativo; el checkpoint de AUD-003 ya cubrió `STORE`, `DEFLATE`, datos inválidos y una fixture de 500 notas.
 - [ ] Verificar específicamente la interacción `Mover a` y clasificar su fricción como corregida, aceptada o bloqueante.

--- a/docs/gestion/README.md
+++ b/docs/gestion/README.md
@@ -20,8 +20,9 @@ de Gómez (2014).
 | [`cheatsheet-defensa.md`](./cheatsheet-defensa.md) | Métricas, decisiones y respuestas breves para la defensa | 🔄 Revisión final pendiente |
 | [`firma-apk-android.md`](./firma-apk-android.md) | Política de firma, secretos y resguardo del artefacto Android | ✅ Completado |
 | [`plan-mantenibilidad-tipado-gradual-2026-06-12.md`](./plan-mantenibilidad-tipado-gradual-2026-06-12.md) | Estrategia incremental de modularidad y tipado; no habilita refactors amplios durante el cierre | 📌 Referencia |
-| [`revision-tecnica-priorizada-2026-09-01.md`](./revision-tecnica-priorizada-2026-09-01.md) | Auditoría vigente de arquitectura, seguridad, persistencia, escalabilidad y tooling con backlog priorizado | 🔄 Remediación activa |
-| [`analisis-aud-003-seguridad-importacion-backups-2026-09-01.md`](./analisis-aud-003-seguridad-importacion-backups-2026-09-01.md) | Revalidación e implementación de AUD-003: frontera ZIP/JSON, integridad y defensa de presentación | ✅ Implementación y validación completas; integración autorizada |
+| [`revision-tecnica-priorizada-2026-09-01.md`](./revision-tecnica-priorizada-2026-09-01.md) | Auditoría vigente de arquitectura, seguridad, persistencia, escalabilidad y tooling con backlog priorizado | 🔄 AUD-001 a AUD-004 remediados; seguimiento activo |
+| [`analisis-aud-003-seguridad-importacion-backups-2026-09-01.md`](./analisis-aud-003-seguridad-importacion-backups-2026-09-01.md) | Revalidación e implementación de AUD-003: frontera ZIP/JSON, integridad y defensa de presentación | ✅ Cerrado en PR #3 |
+| [`analisis-aud-004-seguridad-dependencias-2026-09-02.md`](./analisis-aud-004-seguridad-dependencias-2026-09-02.md) | Revalidación y cierre de AUD-004: advisories, grafo mínimo, auditorías, gates y Android | ✅ Implementación y validación completas; integración autorizada |
 | [`historico/`](./historico/) | Snapshots operativos cerrados preservados como evidencia de proceso | 📦 Archivo |
 
 ---

--- a/docs/gestion/analisis-aud-004-seguridad-dependencias-2026-09-02.md
+++ b/docs/gestion/analisis-aud-004-seguridad-dependencias-2026-09-02.md
@@ -1,0 +1,156 @@
+# Análisis AUD-004 — Seguridad de dependencias
+
+**Fecha de revalidación:** 2026-09-02  
+**Base Git:** `45b2b1ea162ec94b993e9b959c2435d6e4dcd191` (`main` y `origin/main`)  
+**Entorno:** Node.js `v22.20.0`, npm `10.9.3`  
+**Rama:** `fix/aud-004-dependency-security`  
+**Estado:** plan de remediación aprobado técnicamente; implementación y gates pendientes
+
+## 1. Alcance
+
+AUD-004 cubre exclusivamente la dependencia productiva DOMPurify y las vulnerabilidades del
+toolchain informadas por `npm audit`. Este frente no incluye otros hallazgos de la revisión
+técnica, refactors, cambios funcionales, modificaciones al release helper, incremento de versión,
+publicación de APK, tags ni líneas base.
+
+La versión debe permanecer en `0.4.8`; Android debe conservar `versionName 0.4.8` y
+`versionCode 408`.
+
+## 2. Baseline reproducible
+
+Comandos ejecutados desde la raíz del repositorio:
+
+```bash
+node --version
+npm --version
+npm audit --json
+npm audit --omit=dev --json
+npm explain <paquete>
+npm audit fix --dry-run --json
+```
+
+Resultados frescos:
+
+| Auditoría | Critical | High | Moderate | Total |
+|---|---:|---:|---:|---:|
+| Completa | 1 | 5 | 2 | 8 |
+| Producción (`--omit=dev`) | 0 | 0 | 1 | 1 |
+
+La única exposición del bundle productivo es `dompurify@3.4.2`, dependencia directa. Las otras
+siete entradas pertenecen exclusivamente al entorno de desarrollo, build, tests o CLI nativa.
+
+## 3. Grafo, advisories y selección de versiones
+
+| Paquete | Alcance y cadena introductora | Versión actual | Último rango vulnerable decisivo | Versión elegida |
+|---|---|---:|---:|---:|
+| `dompurify` | Producción; dependencia directa | 3.4.2 | `<=3.4.12` | 3.4.14 |
+| `vite` | Desarrollo; dependencia directa y peer de Vitest | 6.4.2 | `<=6.4.2` | 6.4.3 |
+| `tar` | Desarrollo; `@capacitor/cli@8.3.4 -> tar` | 7.5.15 | `<=7.5.20` | 7.5.22 |
+| `postcss` | Desarrollo; `vite -> postcss` | 8.5.10 | `<=8.5.22` | 8.5.26 |
+| `nanoid` | Desarrollo; `vite -> postcss -> nanoid` | 3.3.11 | `<=3.3.17` | 3.3.18 |
+| `undici` | Desarrollo/tests; `jsdom@29.1.1 -> undici` | 7.25.0 | `<7.29.0` | 7.29.0 |
+| `brace-expansion` | Desarrollo; toolchain ESLint/Capacitor mediante `minimatch` | 5.0.5 | `<5.0.9` | 5.0.9 |
+| `@xmldom/xmldom` | Desarrollo/CLI; `@capacitor/cli -> plist -> @xmldom/xmldom` | 0.9.10 | `<=0.9.11` | 0.9.12 |
+
+Advisories determinantes y fuentes primarias de versión:
+
+- DOMPurify: [GHSA-55q2-fjhq-7xh7](https://github.com/advisories/GHSA-55q2-fjhq-7xh7)
+  fija el mayor límite afectado actual (`<=3.4.12`). También aplican los advisories de `IN_PLACE`,
+  configuración y hooks incluidos en la auditoría; la
+  [release 3.4.14](https://github.com/cure53/DOMPurify/releases/tag/3.4.14) agrega hardening
+  posterior dentro de la misma línea 3.x.
+- Vite: [GHSA-v6wh-96g9-6wx3](https://github.com/advisories/GHSA-v6wh-96g9-6wx3) y
+  [GHSA-fx2h-pf6j-xcff](https://github.com/advisories/GHSA-fx2h-pf6j-xcff); ambos dejan de
+  afectar a partir de 6.4.3.
+- `tar`: [GHSA-23hp-3jrh-7fpw](https://github.com/advisories/GHSA-23hp-3jrh-7fpw) es el
+  hallazgo crítico y [GHSA-r292-9mhp-454m](https://github.com/advisories/GHSA-r292-9mhp-454m)
+  eleva el límite afectado hasta 7.5.20.
+- PostCSS: [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) cubre la
+  corrección incompleta hasta 8.5.22; el
+  [changelog oficial](https://github.com/postcss/postcss/blob/main/CHANGELOG.md) registra el
+  endurecimiento de source maps en 8.5.23.
+- nanoid: [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) requiere
+  3.3.18 o posterior dentro de 3.x.
+- undici: [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524) y
+  [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272) mantienen afectada
+  la rama 7.x anterior a 7.29.0.
+- `brace-expansion`: [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895)
+  requiere 5.0.9 o posterior.
+- `@xmldom/xmldom`: [GHSA-6gmq-8vp8-gcm6](https://github.com/advisories/GHSA-6gmq-8vp8-gcm6)
+  afecta 0.9.0–0.9.11; 0.9.12 es la primera versión fuera del rango.
+
+Las versiones seleccionadas fueron verificadas además contra sus manifests publicados en el
+registro npm. No se requiere ningún salto de major: DOMPurify permanece en 3.x, Vite en 6.x y
+Capacitor en 8.x.
+
+## 4. Compatibilidad y estrategia de lockfile
+
+Los rangos declarados por los padres admiten todos los parches seleccionados:
+
+- `@capacitor/cli@8.3.4` declara `tar ^7.5.3`;
+- `vite@6.4.3` declara `postcss ^8.5.3`;
+- `postcss@8.5.26` declara `nanoid ^3.3.17`;
+- `jsdom@29.1.1` declara `undici ^7.25.0`;
+- `minimatch@10.2.5` declara `brace-expansion ^5.0.5`;
+- `plist@3.1.1` declara `@xmldom/xmldom ^0.9.10`.
+
+El único cambio de plataforma observable es que `brace-expansion@5.0.9` declara Node.js 20 o
+22 en adelante. Es compatible con el entorno local Node 22 y el CI Node 22; sigue siendo una
+dependencia exclusiva del toolchain.
+
+`npm audit fix --dry-run` propone los ocho parches, pero también intenta agregar 56 paquetes
+opcionales de plataforma de Rollup/esbuild que ya están representados en el lockfile. No se usará
+esa operación amplia. Una simulación aislada con instalación dirigida y actualización explícita
+de las seis transitivas produjo solamente 28 inserciones y 28 eliminaciones en `package-lock.json`,
+sin variar sus 356 nodos. La implementación seguirá ese camino y rechazará cualquier diff más
+amplio sin una causa nueva comprobable.
+
+No se agregarán transitivas como dependencias directas y no se introducirán `overrides`.
+
+## 5. Alcanzabilidad en MarkdownService
+
+`src/services/MarkdownService.ts` pasa un string generado por Marked a `DOMPurify.sanitize()` y
+recibe un string limpio. No usa:
+
+- `IN_PLACE`;
+- `setConfig()` ni `clearConfig()`;
+- `CUSTOM_ELEMENT_HANDLING`;
+- `SAFE_FOR_TEMPLATES`;
+- modos de salida DOM o Trusted Types;
+- mutación de `data.allowedTags` o `data.allowedAttributes` desde hooks.
+
+El único hook persistente es `afterSanitizeAttributes`; elimina atributos o URLs no permitidos y
+agrega `rel`/`target` seguros, pero no elimina nodos ni modifica allow-lists. Por lo tanto, las rutas
+más específicas de los advisories de DOMPurify no son alcanzables con la configuración actual.
+Eso reduce la explotabilidad inmediata, pero no justifica conservar una dependencia productiva
+vulnerable.
+
+La suite existente ya cubre Markdown válido, headings, listas, checkboxes, callouts, eliminación
+de `script` y handlers `on*`, protocolos peligrosos, política de imágenes locales/remotas, tablas y
+los efectos esperados del hook. Solo se agregarán casos si el upgrade revela una regresión o una
+ruta relevante sin cobertura.
+
+## 6. Plan de implementación y pruebas
+
+1. Elevar los pisos directos a `dompurify ^3.4.14` y `vite ^6.4.3`.
+2. Actualizar en el lockfile únicamente `tar`, `postcss`, `nanoid`, `undici`,
+   `brace-expansion` y `@xmldom/xmldom` a los parches indicados.
+3. Confirmar que no cambien la versión de la aplicación ni las versiones Android y que no aparezcan
+   dependencias directas u overrides nuevos.
+4. Ejecutar `npm ci`, ambas auditorías, `npm ls --all`, la suite focalizada de Markdown y todos los
+   gates solicitados (`test`, `lint`, `typecheck`, `build`, tamaño, diálogos nativos, a11y,
+   documentación, trazabilidad y `verify`).
+5. Preparar e instalar el build Android conservando datos y completar el gate manual antes del
+   cierre documental.
+
+## 7. Criterios de cierre
+
+AUD-004 solo podrá marcarse como cerrado cuando:
+
+- `npm audit --omit=dev` informe 0 vulnerabilidades;
+- `npm audit` informe 0 vulnerabilidades o exista una excepción aceptada explícitamente;
+- la instalación reproducible, tests, lint, typecheck, build y gates auxiliares pasen sin relajarse;
+- el diff del lockfile quede limitado y explicado;
+- el build Android preserve `0.4.8`/`408`, datos SQLite y comportamiento de sanitización;
+- el usuario apruebe explícitamente la checklist Android.
+

--- a/docs/gestion/analisis-aud-004-seguridad-dependencias-2026-09-02.md
+++ b/docs/gestion/analisis-aud-004-seguridad-dependencias-2026-09-02.md
@@ -4,7 +4,7 @@
 **Base Git:** `45b2b1ea162ec94b993e9b959c2435d6e4dcd191` (`main` y `origin/main`)  
 **Entorno:** Node.js `v22.20.0`, npm `10.9.3`  
 **Rama:** `fix/aud-004-dependency-security`  
-**Estado:** plan de remediación aprobado técnicamente; implementación y gates pendientes
+**Estado:** implementación y validaciones completas; integración autorizada
 
 ## 1. Alcance
 
@@ -154,3 +154,42 @@ AUD-004 solo podrá marcarse como cerrado cuando:
 - el build Android preserve `0.4.8`/`408`, datos SQLite y comportamiento de sanitización;
 - el usuario apruebe explícitamente la checklist Android.
 
+## 8. Resultado final — 2026-09-02
+
+La implementación quedó registrada en `efb621b` (`fix(deps): remediate AUD-004
+vulnerabilities`) con los ocho parches previstos. `package-lock.json` conserva 356 nodos y su diff
+se limita a 28 inserciones y 28 eliminaciones; no se agregaron dependencias directas transitivas,
+`overrides` ni paquetes opcionales de plataforma.
+
+| Verificación | Resultado |
+|---|---|
+| `npm ci` | 299 paquetes instalados; 300 auditados; 0 vulnerabilidades |
+| `npm audit --omit=dev` | 0 vulnerabilidades |
+| `npm audit` | 0 vulnerabilidades |
+| `npm ls --all` | Árbol válido, sin dependencias inválidas o faltantes |
+| Suite focalizada Markdown | 1 archivo, 56 tests aprobados |
+| Suite completa | 60 archivos, 955 tests aprobados |
+| ESLint | 0 errores; 3 warnings basales fuera de AUD-004 |
+| TypeScript | `tsc --noEmit` aprobado |
+| Build | Vite 6.4.3; 117 módulos transformados |
+| Bundle budget | 181,48 kB JS gzip; 192,72 kB total; dentro de presupuesto |
+| Checks auxiliares | Tamaño, diálogos nativos, a11y, links y trazabilidad aprobados |
+| Gate agregado | `npm run verify` aprobado sin relajar controles |
+
+El build Android debug se generó desde `efb621b`. El primer intento mediante
+`scripts/deploy-android.sh` llegó hasta la sincronización de Capacitor, pero el JDK 21.0.10 sufrió
+un `SIGSEGV` interno del compilador C2 durante Gradle. El mismo código compiló correctamente en un
+proceso Gradle aislado con `-XX:TieredStopAtLevel=1`; luego se instaló con `adb install -r`, sin
+desinstalar la aplicación ni borrar datos.
+
+- Dispositivo: Samsung `SM_G965F` (`ad071603088c2172aa`).
+- APK de validación: SHA-256
+  `4cd9273a10de7e652601c0c0ce18d6d491d7ed8084f496649a46c3059358e1cb`.
+- Paquete instalado: `versionName 0.4.8`, `versionCode 408`.
+- SQLite antes/después: `lumapse-dbSQLite.db`, 53.248 bytes, preservada.
+- Validación manual: funcionamiento correcto confirmado explícitamente por el usuario el
+  2026-09-02.
+
+El APK fue únicamente un artefacto debug de validación: no se publicó una release, no se creó un
+tag y no se modificó la versión. Con auditorías, suites, build y Android aprobados, AUD-004 queda
+cerrado técnicamente y habilitado para integración.

--- a/docs/gestion/revision-tecnica-priorizada-2026-09-01.md
+++ b/docs/gestion/revision-tecnica-priorizada-2026-09-01.md
@@ -1,6 +1,6 @@
 # Revisión Técnica Priorizada — 2026-09-01
 
-**Estado:** Vigente — AUD-003 con implementación y validación completas; integración autorizada
+**Estado:** Vigente — AUD-001 a AUD-003 integrados; AUD-004 implementado y validado, con integración autorizada
 **Rama original de auditoría:** `fix/note-save-integrity`
 **Commit base original revisado:** `cd60c0e` (`main`)
 **Versión de producto documentada:** `0.4.8` (Beta)  
@@ -72,7 +72,7 @@ está en reforzar los límites ya existentes de forma incremental.
 | Build | Pasa con Vite 6.4.2 |
 | Bundle JS gzip | 203,77 kB de 220 kB permitidos (93%) |
 | Auditoría offline fallback | Falla por dos falsos positivos de `http://localhost` en el CSP |
-| Dependencias | 7 vulnerabilidades reportadas por `npm audit` |
+| Dependencias | 7 vulnerabilidades en la revisión inicial; 0 tras el cierre de AUD-004 el 2026-09-02 |
 
 ### 5.1 Advertencias ESLint vigentes
 
@@ -94,8 +94,8 @@ store, no como métrica integral de toda la aplicación.
 |---|---|---|---|---|
 | AUD-001 | P0 | Pérdida de borrador ante error SQLite | Bug confirmado | Resuelto en PR #2 |
 | AUD-002 | P0 | Guardados duplicados por taps concurrentes | Bug confirmado | Resuelto en PR #2 |
-| AUD-003 | P0 | Inyección HTML persistente desde campos de backup | Seguridad confirmada | Implementación y validación completas; integración autorizada |
-| AUD-004 | P0 | Dependencias vulnerables, incluida DOMPurify en producción | Seguridad/tooling | Pendiente |
+| AUD-003 | P0 | Inyección HTML persistente desde campos de backup | Seguridad confirmada | Cerrado en PR #3 |
+| AUD-004 | P0 | Dependencias vulnerables, incluida DOMPurify en producción | Seguridad/tooling | Implementación y validación completas; integración autorizada |
 | AUD-005 | P1 | Propiedad global de transacciones y migraciones permisivas | Confiabilidad | Pendiente |
 | AUD-006 | P1 | Resultados async obsoletos sobrescriben vista/cache reciente | Bug de concurrencia | Pendiente |
 | AUD-007 | P1 | Contratos incompatibles para errores de mutaciones | Diseño/confiabilidad | Pendiente |
@@ -201,15 +201,20 @@ preparados.
 
 ### AUD-004 — Dependencias vulnerables
 
-La auditoría encontró:
+El análisis reproducible y los criterios de cierre quedan en
+[`analisis-aud-004-seguridad-dependencias-2026-09-02.md`](analisis-aud-004-seguridad-dependencias-2026-09-02.md).
+La revalidación inicial encontró ocho paquetes vulnerables: DOMPurify como única dependencia
+productiva afectada y siete entradas exclusivas de tooling.
 
-- `dompurify@3.4.2`: dependencia directa de producción con advisories de sanitización/XSS.
-- `vite@6.4.2`: dependencia directa de desarrollo.
-- `tar@7.5.15`, `postcss@8.5.10`, `nanoid@3.3.11`, `undici@7.25.0` y
-  `brace-expansion@5.0.5`: dependencias transitivas.
+La remediación mantuvo los majors actuales y actualizó `dompurify` a 3.4.14, Vite a 6.4.3,
+`tar` a 7.5.22, PostCSS a 8.5.26, nanoid a 3.3.18, undici a 7.29.0,
+`brace-expansion` a 5.0.9 y `@xmldom/xmldom` a 0.9.12. El lockfile no incorporó overrides,
+transitivas directas ni expansión de paquetes opcionales.
 
-Todas reportaron una corrección disponible al momento del análisis. La actualización debe hacerse
-en un PR separado, revisando changelogs, lockfile, build y tests de sanitización.
+`npm ci`, ambas auditorías en cero, `npm ls --all`, 56 tests focalizados de Markdown, 955 tests
+totales, lint, typecheck, build y `npm run verify` pasaron. El build Android 0.4.8/408 preservó
+SQLite y su funcionamiento fue aprobado explícitamente en Samsung SM_G965F. No se publicó una
+release ni se cambió la versión; la integración quedó autorizada.
 
 ### AUD-005 — Coordinación SQLite y arranque
 
@@ -403,8 +408,8 @@ test(editor): cover failed and concurrent note saves
 | Orden | Rama sugerida | Resultado esperado |
 |---:|---|---|
 | 1 | `fix/note-save-integrity` | Cerrado en PR #2: AUD-001 y AUD-002 |
-| 2 | `fix/backup-import-security` | Implementación y validación completas; integración autorizada |
-| 3 | `fix/dependency-security` | Actualizar DOMPurify y dependencias auditadas |
+| 2 | `fix/backup-import-security` | Cerrado en PR #3: AUD-003 |
+| 3 | `fix/aud-004-dependency-security` | Implementación y validación completas; integración autorizada |
 | 4 | `fix/store-action-contract` | Unificar semántica de errores de mutaciones |
 | 5 | `fix/sqlite-write-coordination` | Aislar transacciones y endurecer migraciones/arranque |
 | 6 | `fix/async-request-ownership` | Evitar resultados obsoletos en trash y Heatmap |
@@ -460,6 +465,16 @@ Resultado consolidado:
   checkpoint final fue aprobado el 2026-09-02 sobre la implementación completa instalada en
   Samsung SM_G965F.
 
+### Cierre automático y manual de AUD-004 — 2026-09-02
+
+- `npm ci`, `npm ls --all` y auditorías completa/productiva aprobados; ambas auditorías informan
+  **0 vulnerabilidades**.
+- Suite focalizada de Markdown: **1 archivo/56 tests**; suite completa: **60 archivos/955 tests**.
+- Lint (**0 errores/3 warnings basales**), typecheck, build con Vite 6.4.3 y `npm run verify`
+  aprobados. Bundle gzip total: **192,72 kB / 250 kB**.
+- Android 0.4.8/408 instalado preservando SQLite en Samsung SM_G965F; comportamiento aprobado
+  explícitamente. No se publicó APK, release ni tag.
+
 ## 11. Limitaciones de la revisión
 
 - Se aprobó el escenario funcional Android con 500 notas; no se ejecutó benchmark instrumentado ni
@@ -468,8 +483,8 @@ Resultado consolidado:
 - La prueba de inyección fue un caso jsdom focalizado, no una explotación end-to-end en WebView.
 - Las carreras async y transaccionales se derivaron del flujo de control y necesitan regresiones
   deterministas al abordar cada fix.
-- Los advisories de dependencias reflejan el lockfile y la auditoría del 2026-09-01; deben repetirse
-  antes de cada actualización o release.
+- AUD-004 cerró los advisories conocidos al 2026-09-02; las auditorías deben repetirse antes de
+  cada actualización o release porque el resultado depende del lockfile y del momento de consulta.
 
 ## 12. Decisión de cierre del análisis
 
@@ -479,7 +494,7 @@ cohesión de features con cambios pequeños y medidos.
 
 La revisión inicial quedó vinculada al primer fix porque AUD-001 y AUD-002 afectaban el flujo
 central del producto y presentaban la mejor relación entre impacto, riesgo y tamaño de cambio.
-Ambos hallazgos se cerraron posteriormente en la PR #2. AUD-003 quedó implementado y validado en
-`fix/backup-import-security`; el checkpoint Android final fue aprobado el 2026-09-02 y su
-integración quedó autorizada. Al momento de este commit el coordinador aún no había creado el PR ni
-ejecutado el merge. AUD-004 y los demás hallazgos conservan alcance y seguimiento independientes.
+Ambos hallazgos se cerraron posteriormente en la PR #2 y AUD-003 en la PR #3. AUD-004 quedó
+implementado y validado en `fix/aud-004-dependency-security`; las auditorías completa y productiva
+quedaron en cero, el checkpoint Android fue aprobado el 2026-09-02 y su integración quedó
+autorizada. AUD-005 y los demás hallazgos conservan alcance y seguimiento independientes.

--- a/docs/hitos/hito-06-octubre.md
+++ b/docs/hitos/hito-06-octubre.md
@@ -8,7 +8,7 @@
 
 **Proyecto:** Lumapse
 
-**Estado:** Activo — endurecimiento técnico integrado; cierre editorial, RNF y artefacto pendientes
+**Estado:** Activo — AUD-001 a AUD-004 cerrados técnicamente; cierre editorial, RNF y artefacto pendientes
 
 **Última actualización:** 2026-09-02
 
@@ -56,7 +56,7 @@ Cerrar Lumapse con documentación coherente, evidencia técnica reproducible, di
 - [x] Cerrar AUD-001 y AUD-002 con regresiones de error y concurrencia, integración mediante PR #2 y comportamiento de descarte distinguible.
 - [x] Cerrar AUD-003 con importación ZIP acotada, validación runtime, jerarquía consistente, presentación defensiva, suite acumulativa e integración mediante PR #3.
 - [x] Aprobar los checkpoints Android de AUD-003 con backups `STORE`/`DEFLATE`, rechazo de datos inválidos antes de persistir, fixture de 500 notas y build completo instalado. Esta evidencia no equivale a validar un artefacto publicado nuevo.
-- [ ] Resolver AUD-004 en un PR separado antes del próximo APK publicado y repetir auditoría de dependencias, sanitización, lockfile, suite y build.
+- [x] Resolver AUD-004 en un PR separado: grafo mínimo actualizado, auditorías completa/productiva en cero, sanitización, 955 tests, build, quality gate y Android 0.4.8/408 aprobados el 2026-09-02.
 - [ ] Ejecutar el quality gate sobre el commit candidato y guardar la evidencia; los gates acumulativos y pre-push ya aprobados no sustituyen el cierre del corte.
 - [ ] Repetir la checklist Android sobre el artefacto versionado y firmado elegido.
 - [ ] Medir latencia CRUD y rendimiento con al menos 500 notas (`RNF-002`, `RNF-004`); la importación funcional de esa cantidad no constituye una medición de rendimiento.
@@ -78,7 +78,7 @@ Cerrar Lumapse con documentación coherente, evidencia técnica reproducible, di
 
 ### 5. Corte y línea base final
 
-- `v0.4.8` permanece como evidencia inmutable de la beta, pero no contiene las correcciones AUD-001/002/003 ya integradas; el próximo artefacto distribuido deberá partir de un corte posterior.
+- `v0.4.8` permanece como evidencia inmutable de la beta y no contiene las correcciones AUD-001/002/003/004; el próximo artefacto distribuido deberá partir de un corte posterior.
 - Decidir si ese corte se publica como beta patch `v0.4.9` para una nueva ronda de validación o se reserva para la versión final de Hito 06.
 - No crear `0.4.9` de forma preventiva ni reutilizar `versionCode 408` para un binario diferente.
 - Corregir o reforzar `scripts/release-helper.py`: actualmente actualiza package/changelog, pero no garantiza la alineación de `versionName` y `versionCode` Android.
@@ -102,7 +102,7 @@ Las ideas conservadas siguen en [`../../BACKLOG.md`](../../BACKLOG.md) y no comp
 | Orden | Frente | Salida esperada |
 |---|---|---|
 | 1 | Sincronización documental | Evidencia post-auditoría reflejada sin confundir `main` con una release |
-| 2 | Seguridad de release | AUD-004 resuelto y dependencias verificadas en un frente independiente |
+| 2 | Seguridad de release | Completado: AUD-004 validado con auditorías 0/0 y Android aprobado |
 | 3 | Revisión editorial y diagramas DB | Contenido congelado; fuentes y exportaciones finales verificadas |
 | 4 | Validación | Gate, matriz RNF y checklist Android sin bloqueantes sobre el mismo artefacto |
 | 5 | Presentación | Deck, demo, guion y contingencia listos |
@@ -114,7 +114,7 @@ Se mantiene WIP máximo de dos elementos activos en total entre `En Curso` y `En
 
 | Observación | Severidad actual | Evidencia requerida |
 |---|---|---|
-| AUD-004 — dependencias con advisories | P0 / bloqueante para nueva publicación | PR separado, auditoría de dependencias y regresiones de sanitización/build |
+| AUD-004 — dependencias con advisories | Cerrado técnicamente / sin bloqueantes | Grafo mínimo, auditorías 0/0, sanitización, build y Android aprobados el 2026-09-02 |
 | El helper no alinea automáticamente la versión Android | Riesgo alto de release | Test o gate que compare versión declarada, `versionName` y `versionCode` antes del build |
 | `Mover a` puede requerir pulsación prolongada | Menor / no bloqueante | Reproducción repetible en validación final y decisión explícita |
 | Rendimiento con mayor volumen de notas | Riesgo medio de evidencia | Medición de latencia y percepción con al menos 500 notas; no solo importación funcional |
@@ -127,7 +127,7 @@ Se mantiene WIP máximo de dos elementos activos en total entre `En Curso` y `En
 - [x] AUD-001, AUD-002 y AUD-003 corregidos, validados e integrados.
 - [ ] Informe final revisado, referenciado y exportable.
 - [x] Gráficos de base de datos actualizados y consistentes con el schema.
-- [ ] AUD-004 resuelto y auditoría de dependencias sin bloqueantes aceptados para el corte.
+- [x] AUD-004 resuelto y auditorías completa/productiva sin vulnerabilidades al 2026-09-02.
 - [ ] Quality gate final sin fallos.
 - [ ] Validación Android final documentada y sin bloqueantes.
 - [ ] Matriz RNF final emitida con evidencia reproducible y límites explícitos.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@capacitor/filesystem": "^8.1.2",
         "@capacitor/network": "^8.0.1",
         "@capacitor/share": "^8.0.1",
-        "dompurify": "^3.4.2",
+        "dompurify": "^3.4.14",
         "jeep-sqlite": "^2.8.0",
         "jszip": "^3.10.1",
         "marked": "^18.0.3",
@@ -31,7 +31,7 @@
         "jsdom": "^29.1.1",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.62.0",
-        "vite": "^6.3.3",
+        "vite": "^6.4.3",
         "vitest": "^4.1.7"
       }
     },
@@ -2242,9 +2242,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2407,16 +2407,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browser-fs-access": {
@@ -2602,9 +2602,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
-      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -3574,9 +3574,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -3830,9 +3830,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -3850,7 +3850,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4239,9 +4239,9 @@
       "license": "MIT"
     },
     "node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -4482,9 +4482,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4535,9 +4535,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "jsdom": "^29.1.1",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.0",
-    "vite": "^6.3.3",
+    "vite": "^6.4.3",
     "vitest": "^4.1.7"
   },
   "keywords": [
@@ -65,7 +65,7 @@
     "@capacitor/filesystem": "^8.1.2",
     "@capacitor/network": "^8.0.1",
     "@capacitor/share": "^8.0.1",
-    "dompurify": "^3.4.2",
+    "dompurify": "^3.4.14",
     "jeep-sqlite": "^2.8.0",
     "jszip": "^3.10.1",
     "marked": "^18.0.3",


### PR DESCRIPTION
## Summary

- closes AUD-004 with a minimal dependency-only remediation
- documents the fresh advisory baseline, parent chains, compatibility review, lockfile strategy, automated evidence, and Android gate
- keeps package/Android version `0.4.8` and Android `versionCode 408`
- does not publish an APK, create a release/tag, modify the release helper, or mix later audit findings

## Audit results

| Scope | Baseline | Final |
|---|---:|---:|
| Full dependency graph | 8 vulnerabilities (1 critical, 5 high, 2 moderate) | 0 |
| Production (`--omit=dev`) | 1 moderate (`dompurify`) | 0 |

## Dependency updates

- production direct: `dompurify` 3.4.2 -> 3.4.14
- development direct: `vite` 6.4.2 -> 6.4.3
- `@capacitor/cli -> tar`: 7.5.15 -> 7.5.22
- `vite -> postcss`: 8.5.10 -> 8.5.26
- `vite -> postcss -> nanoid`: 3.3.11 -> 3.3.18
- `jsdom -> undici`: 7.25.0 -> 7.29.0
- `minimatch -> brace-expansion`: 5.0.5 -> 5.0.9
- `@capacitor/cli -> plist -> @xmldom/xmldom`: 0.9.10 -> 0.9.12

All updates stay within the existing major lines. The lockfile remains at 356 nodes and changes only 28 lines in/28 lines out. No overrides, direct pins of transitives, or optional-platform expansion were introduced.

## Validation

- `npm ci`
- `npm audit --omit=dev`
- `npm audit`
- `npm ls --all`
- `npx vitest run tests/unit/services/MarkdownService.test.js` — 56/56
- `npm test` — 60 files, 955/955
- `npm run lint` — 0 errors, 3 pre-existing warnings
- `npm run typecheck`
- `npm run build` — Vite 6.4.3, 117 modules
- `npm run check:size` — 181.48 kB JS gzip / 192.72 kB total
- `npm run check:native-dialogs`
- `npm run check:a11y`
- `npm run check:docs`
- `npm run check:traceability`
- `npm run verify`

## Android

- installed non-destructively on the connected Android test device with existing SQLite data preserved
- confirmed `versionName 0.4.8` and `versionCode 408`
- user explicitly approved application startup, Markdown/sanitizer behavior, existing data, and absence of crashes

The first scripted deploy encountered a local JDK compiler crash during Gradle. A single-use Gradle build with C2 disabled succeeded, followed by a non-destructive reinstall. This was a debug validation artifact only; no APK was published.

## Limitations

- the three existing lint warnings remain outside AUD-004
- AUD-008/AUD-009, release-helper changes, version selection, and final release artifact work remain separate
