### PR TITLE
fix(store): unify mutation error handling

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,7 +4,7 @@ Este documento funciona como bandeja viva de tareas, deuda y decisiones pendient
 
 > **Hito activo:** 06 — Entrega Final
 > **Hito 05:** Cerrado documentalmente el 2026-07-15 sobre la beta operativa `v0.4.8`
-> **Última actualización:** 2026-09-02 — AUD-001 a AUD-004 cerrados técnicamente; próximo foco editorial y de validación final
+> **Última actualización:** 2026-09-03 — AUD-001 a AUD-004 y AUD-007 cerrados técnicamente; AUD-005 es el próximo frente técnico independiente
 > **Snapshot histórico:** [`docs/gestion/historico/backlog-historico-hito-04-2026-06-01.md`](docs/gestion/historico/backlog-historico-hito-04-2026-06-01.md)
 
 ---
@@ -15,9 +15,9 @@ Hito 04 quedó cerrado formalmente como bloque de Organización y UX. El cierre 
 
 Hito 05 quedó cerrado documentalmente el 2026-07-15. Entregó el quality gate, APK firmada, validación inicial en Android real y publicación de la beta controlada [`v0.4.8`](https://github.com/jdfesa/lumapse/releases/tag/v0.4.8), junto con mejoras funcionales acotadas: borradores persistentes (`RF-005`), backup manual (`RF-017`), importación ZIP (`RF-018`), Acerca de (`RF-023`), fechas académicas discretas (`RF-027`) y editor enriquecido (`RF-028`). Las observaciones sobre `Mover a` y rendimiento con más notas no bloquearon ese cierre.
 
-Hito 06 queda activo para completar la documentación final, verificar la maquetación de los gráficos de base de datos ya actualizados, repetir la validación sobre un corte congelado y preparar la presentación. La única versión publicada continúa siendo `v0.4.8`; el trabajo posterior al tag ya incluye los cierres técnicos AUD-001 a AUD-004, pero todavía no constituye una release ni un APK distribuible nuevo. La decisión pendiente debe distinguir entre una beta de corrección `v0.4.9` y el artefacto final de Hito 06, sin renombrar preventivamente el estado actual de `main`.
+Hito 06 queda activo para completar la documentación final, verificar la maquetación de los gráficos de base de datos ya actualizados, repetir la validación sobre un corte congelado y preparar la presentación. La única versión publicada continúa siendo `v0.4.8`; el trabajo posterior al tag ya incluye los cierres técnicos AUD-001 a AUD-004 y AUD-007, pero todavía no constituye una release ni un APK distribuible nuevo. La decisión pendiente debe distinguir entre una beta de corrección `v0.4.9` y el artefacto final de Hito 06, sin renombrar preventivamente el estado actual de `main`.
 
-La revisión técnica priorizada del 2026-09-01 abrió trece hallazgos trazables. AUD-001 y AUD-002 quedaron resueltos mediante PR #2; AUD-003 quedó validado en Android e integrado mediante PR #3. AUD-004 actualizó de forma mínima DOMPurify y siete dependencias de tooling, dejó las auditorías completa y productiva en cero y aprobó suites, build, quality gate y Android 0.4.8/408; su integración fue autorizada. La validación funcional de 500 notas de AUD-003 no sustituye las mediciones de latencia y rendimiento exigidas por `RNF-002` y `RNF-004`. Los hallazgos restantes mantienen sus prioridades y no se incorporan automáticamente al alcance de Hito 06.
+La revisión técnica priorizada del 2026-09-01 abrió trece hallazgos trazables. AUD-001 y AUD-002 quedaron resueltos mediante PR #2; AUD-003 quedó validado en Android e integrado mediante PR #3; AUD-004 cerró dependencias vulnerables en PR #5. AUD-007 unificó el contrato emit-and-rethrow del store, adaptó los límites UI, aprobó 989 tests, quality gate y Android 0.4.8/408, y se integra mediante PR #6. La validación funcional de 500 notas de AUD-003 no sustituye las mediciones de latencia y rendimiento exigidas por `RNF-002` y `RNF-004`. Los hallazgos restantes mantienen sus prioridades y no se incorporan automáticamente al alcance de Hito 06.
 
 La revisión de exportación/importación corrige una sobrepromesa documental del Hito 03: los servicios base de Markdown no equivalían a un flujo de usuario validado. La opción "Compartir" para una nota individual (`RF-016`) solo tendría sentido si abre el share sheet nativo de Android y ofrece apps como WhatsApp; si termina copiando contenido, duplica una acción existente y agrega ruido. La portabilidad de workspace sí quedó resuelta de forma acotada con exportación e importación de backup `.zip` desde la vista Backup.
 
@@ -46,15 +46,17 @@ La trazabilidad de `v0.4.8` queda distribuida entre `docs/gestion/lineas-base.md
 
 ## Revisión técnica priorizada — estado vivo
 
-El análisis detallado permanece en [`docs/gestion/revision-tecnica-priorizada-2026-09-01.md`](docs/gestion/revision-tecnica-priorizada-2026-09-01.md). Esta tabla fija el estado operativo después de integrar los PR #2 y #3 y completar la validación de AUD-004.
+El análisis detallado permanece en [`docs/gestion/revision-tecnica-priorizada-2026-09-01.md`](docs/gestion/revision-tecnica-priorizada-2026-09-01.md). Esta tabla fija el estado operativo después de cerrar AUD-001 a AUD-004 y AUD-007.
 
 | ID | Prioridad | Frente | Estado operativo |
 |---|---|---|---|
 | AUD-001 | P0 | Pérdida de borrador ante error SQLite | Cerrado en PR #2; regresiones aprobadas |
 | AUD-002 | P0 | Guardados duplicados por taps concurrentes | Cerrado en PR #2; single-flight y estado visual validados |
 | AUD-003 | P0 | Frontera y presentación de backups no confiables | Cerrado en PR #3; suite acumulativa y checkpoints Android aprobados |
-| AUD-004 | P0 | Dependencias con advisories de seguridad | Cerrado técnicamente; auditorías 0/0 y Android aprobados; integración autorizada |
-| AUD-005–AUD-009 | P1 | Persistencia, asincronía, contratos y tooling | Pendientes; abordar en ramas separadas según riesgo y gate de release |
+| AUD-004 | P0 | Dependencias con advisories de seguridad | Cerrado en PR #5; auditorías 0/0 y Android aprobados |
+| AUD-005–AUD-006 | P1 | Coordinación de persistencia y resultados async obsoletos | Pendientes; AUD-005 es el próximo frente técnico independiente |
+| AUD-007 | P1 | Contratos incompatibles para errores de mutaciones | Cerrado en PR #6; contrato único, consumidores y Android aprobados |
+| AUD-008–AUD-009 | P1 | Portabilidad del gate y Node 26 | Pendientes; abordar sin relajar controles |
 | AUD-010–AUD-013 | P2 | Escalabilidad, rendimiento, cohesión y margen de bundle/coverage | Monitorear o medir; no bloquean por sí solos el cierre actual |
 
 ---
@@ -95,7 +97,7 @@ Estas tareas no bloquean el MVP. Se conservan como decisiones trazables para rea
 | Framework UI | No incorporar Svelte por ahora | Baja | Costo de migracion alto vs beneficio actual; reabrir solo si DOM manual se vuelve una carga clara |
 | Documentación | Congelar documentos antes del corte final | Alta | La reconciliación posterior a AUD-001/002/003 se completó el 2026-09-02; restan evidencia final, revisión de maquetación y el corte elegido |
 | Dependencias | Repetir auditorías en cada corte candidato | Recurrente | AUD-004 quedó cerrado con grafo mínimo, auditorías 0/0 y Android aprobado; revalidar porque los advisories evolucionan |
-| Persistencia y asincronía | Planificar AUD-005–AUD-007 | Alta/Media | Mantener ramas separadas para propiedad transaccional/migraciones, resultados async obsoletos y contratos de error; priorizar solo lo que bloquee el gate acordado |
+| Persistencia y asincronía | Planificar AUD-005–AUD-006 | Alta/Media | AUD-007 quedó cerrado en PR #6; mantener ramas separadas para propiedad transaccional/migraciones y resultados async obsoletos |
 | Tooling | Resolver portabilidad de gate y Node 26 (AUD-008/AUD-009) | Media | Distinguir falsos positivos CSP del fallback offline y eliminar la dependencia del workaround de Web Storage sin relajar controles |
 | Tooling DB | Ampliar el smoke test a `academic_events` y constraints relevantes | Media | El DDL completo se ejecuta, pero las aserciones explícitas de tablas/columnas/relaciones se concentran en materias, notas y metadata; decidir su ampliación antes de presentar cobertura exhaustiva |
 | Tooling de release | Sincronizar versión Android desde el helper | Alta | `scripts/release-helper.py` actualiza package/changelog, pero no `versionName` ni `versionCode`; corregirlo o agregar un gate explícito antes de generar otra APK |
@@ -168,7 +170,8 @@ Los ítems marcados como completados fueron planes que originalmente estaban en 
 - [x] Imports dinamicos redundantes retirados del store y la restauracion de papelera: Vite ya no advierte sobre modulos que eran importados de forma estatica y dinamica a la vez.
 - [x] AUD-001 y AUD-002 cerrados en PR #2: el editor conserva el borrador ante fallos, serializa guardados concurrentes y diferencia visualmente el descarte.
 - [x] AUD-003 cerrado en PR #3: importación ZIP acotada, validación runtime, jerarquía consistente, presentación defensiva y validación Android acumulativa.
-- [x] AUD-004 cerrado técnicamente: dependencias parcheadas en un frente separado, auditorías 0/0, sanitización, lockfile, suite, build y Android aprobados el 2026-09-02.
+- [x] AUD-004 cerrado en PR #5: dependencias parcheadas, auditorías 0/0, sanitización, lockfile, suite, build y Android aprobados el 2026-09-02.
+- [x] AUD-007 cerrado en PR #6: contrato emit-and-rethrow unificado, consumidores adaptados, 989 tests, quality gate y Android 0.4.8/408 aprobados el 2026-09-03.
 - [ ] Corregir o reforzar `scripts/release-helper.py` para que `versionName` y `versionCode` Android no puedan quedar desalineados del corte declarado.
 - [ ] Aplicar mejoras pequenas y verificables que aumenten cohesion, reduzcan acoplamiento y faciliten revisiones humanas/IA, evitando reescrituras grandes.
 - [ ] Restauracion avanzada desde backup `.zip` con estrategia explicita de reemplazo/merge, solo despues de validar la importacion no destructiva actual con usuarios reales.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ y este proyecto adhiere a [Conventional Commits](https://www.conventionalcommits
 
 ## [Unreleased] — Trabajo posterior a `v0.4.8`
 
-> `main` conserva la versión declarada `0.4.8`, pero contiene trabajo posterior al tag. No existe una release `0.4.9` ni un APK posterior publicado. Este bloque resume el trabajo desde `v0.4.8`, incluidos los cierres técnicos AUD-001 a AUD-004. Las ejecuciones Android sobre código posterior al tag son evidencia de validación y no constituyen un artefacto publicado.
+> `main` conserva la versión declarada `0.4.8`, pero contiene trabajo posterior al tag. No existe una release `0.4.9` ni un APK posterior publicado. Este bloque resume el trabajo desde `v0.4.8`, incluidos los cierres técnicos AUD-001 a AUD-004 y AUD-007. Las ejecuciones Android sobre código posterior al tag son evidencia de validación y no constituyen un artefacto publicado.
 
 ### Added
 
 - **Regresiones de integridad de guardado:** Se incorporaron pruebas unitarias para creación y actualización fallidas, conservación del borrador y serialización de solicitudes concurrentes.
 - **Cobertura de AUD-003:** Se agregaron regresiones para preflight y lectura ZIP, CRC32, límites, validación de primitivas y entidades, jerarquía de materias y presentación por contexto. El cierre documenta 11 archivos y 75 tests focalizados de presentación, además de 60 archivos y 955 tests en la suite completa con el workaround registrado para Node 26.
 - **Evidencia Android posterior al tag:** Se registró la validación manual de backups `STORE` y `DEFLATE`, una fixture de 500 notas, el rechazo de `pinned` inválido antes de persistir y el checkpoint final de la implementación completa instalada en un Samsung `SM_G965F`; estas ejecuciones no representan una nueva release ni un APK publicado.
+- **Regresiones de contratos de error (AUD-007):** Se cubrieron retornos exitosos, emisión única de `DatabaseError`, propagación de errores inesperados, ausencia de mutaciones de éxito ante fallo y restauración de los límites UI.
 
 ### Changed
 
@@ -34,6 +35,7 @@ y este proyecto adhiere a [Conventional Commits](https://www.conventionalcommits
 - **Adaptadores nativos de backup tipados:** `BackupNativeNetworkService` y `BackupShareService` pasan a TypeScript con contratos locales para Network, Filesystem y Share, y cobertura directa del fallback web de conectividad.
 - **Coverage JS/TS medible:** Vitest incorpora `src/**/*.{js,ts}` y genera un resumen JSON; la nueva línea base registra 92,43% de statements en `src/services/**`, cerrando la medición pendiente de `RNF-024` sin fijar todavía umbrales bloqueantes.
 - **Dependencias estáticas explícitas:** Se retiraron cinco imports dinámicos que Vite no podía separar en chunks porque los mismos módulos ya formaban parte del grafo estático; el comportamiento y las APIs públicas permanecen sin cambios.
+- **Contrato único de mutaciones (AUD-007):** Las escrituras persistentes del store emiten una vez los fallos SQLite y propagan la misma excepción; los no-op legítimos y retornos exitosos conservan su semántica.
 - **Auditoría técnica trazable:** La revisión priorizada separa hallazgos de integridad, seguridad, confiabilidad, tooling y mantenibilidad; el análisis de AUD-003 registra riesgos confirmados y refutados, alcance, fases, evidencia y limitaciones sin mezclar la actualización de dependencias de AUD-004.
 - **Dependencias parcheadas dentro de sus majors:** DOMPurify sube a 3.4.14 y Vite a 6.4.3; el lockfile resuelve también `tar` 7.5.22, PostCSS 8.5.26, nanoid 3.3.18, undici 7.29.0, `brace-expansion` 5.0.9 y `@xmldom/xmldom` 0.9.12 sin overrides ni transitivas directas.
 
@@ -42,6 +44,7 @@ y este proyecto adhiere a [Conventional Commits](https://www.conventionalcommits
 - **Integridad del guardado (AUD-001):** El editor solo limpia los campos y descarta el borrador tras confirmar la persistencia; ante un fallo conserva contenido, borrador, contexto de edición y modo foco para permitir el reintento.
 - **Guardados concurrentes (AUD-002):** Una protección single-flight serializa el guardado y mantiene un estado visual mientras la operación está pendiente, evitando mutaciones duplicadas o fuera de orden por taps repetidos.
 - **Descarte de borrador distinguible:** La acción destructiva de descartar quedó diferenciada visualmente del guardado y cubierta por una regresión de presentación.
+- **Límites UI ante fallos de mutación (AUD-007):** Editor, feed, drawer, eventos académicos, papelera y acciones relacionadas consumen rechazos sin cerrar interfaces, refrescar como éxito ni duplicar feedback; `NoteEditor.js` volvió al umbral no bloqueante de 400 LOC.
 
 ### Security
 

--- a/TODO
+++ b/TODO
@@ -4,11 +4,11 @@
 
 ## Hito actual: 06 — Entrega Final
 
-**Estado:** activo; AUD-001 a AUD-003 quedaron integrados y AUD-004 completó implementación y validación con integración autorizada al 2026-09-02.
+**Estado:** activo; AUD-001 a AUD-004 y AUD-007 quedaron cerrados técnicamente mediante PR #2, #3, #5 y #6.
 
 **Corte operativo vigente:** beta/candidata [`v0.4.8`](https://github.com/jdfesa/lumapse/releases/tag/v0.4.8), publicada y validada inicialmente en Android real.
 
-**Versión:** `v0.4.8`; el trabajo posterior al tag —incluido AUD-004— permanece no publicado y no existe una release `0.4.9`. La versión del próximo artefacto solo se decidirá después de cerrar sus bloqueos y validaciones.
+**Versión:** `v0.4.8`; el trabajo posterior al tag —incluidos AUD-001 a AUD-004 y AUD-007— permanece no publicado y no existe una release `0.4.9`. La versión del próximo artefacto solo se decidirá después de cerrar sus bloqueos y validaciones.
 
 **Objetivo:** cerrar documentación, gráficos de base de datos, validación final y materiales de presentación sin ampliar el producto.
 
@@ -34,6 +34,7 @@
 - [ ] Alinear el tablero de GitHub Projects con la Definition of Workflow: WIP global 2, bloqueos y fechas `startedAt`/`finishedAt`; recalibrar la SLE al completar cinco elementos confiables.
 - [ ] Contrastar los metadatos bibliográficos de Gómez (2014) y Parada (2026) contra los originales de cátedra y cerrar la sección de referencias.
 - [x] Resolver AUD-004 en un PR separado: DOMPurify y siete dependencias de tooling parcheadas, auditorías 0/0, 955 tests, build, quality gate y Android 0.4.8/408 aprobados (2026-09-02).
+- [x] Resolver AUD-007 en PR #6: contrato de errores de mutaciones unificado, límites UI adaptados, 989 tests, quality gate y prueba manual Android aprobados (2026-09-03).
 - [ ] Ejecutar el gate final sobre el commit y artefacto candidatos y guardar la evidencia; el gate acumulativo de AUD-003 y los pre-push documentales no sustituyen este cierre.
 - [ ] Repetir la validación Android sobre el artefacto versionado con un conjunto de datos representativo; el checkpoint de AUD-003 ya cubrió `STORE`, `DEFLATE`, datos inválidos y una fixture de 500 notas.
 - [ ] Verificar específicamente la interacción `Mover a` y clasificar su fricción como corregida, aceptada o bloqueante.

--- a/docs/gestion/README.md
+++ b/docs/gestion/README.md
@@ -20,9 +20,10 @@ de Gómez (2014).
 | [`cheatsheet-defensa.md`](./cheatsheet-defensa.md) | Métricas, decisiones y respuestas breves para la defensa | 🔄 Revisión final pendiente |
 | [`firma-apk-android.md`](./firma-apk-android.md) | Política de firma, secretos y resguardo del artefacto Android | ✅ Completado |
 | [`plan-mantenibilidad-tipado-gradual-2026-06-12.md`](./plan-mantenibilidad-tipado-gradual-2026-06-12.md) | Estrategia incremental de modularidad y tipado; no habilita refactors amplios durante el cierre | 📌 Referencia |
-| [`revision-tecnica-priorizada-2026-09-01.md`](./revision-tecnica-priorizada-2026-09-01.md) | Auditoría vigente de arquitectura, seguridad, persistencia, escalabilidad y tooling con backlog priorizado | 🔄 AUD-001 a AUD-004 remediados; seguimiento activo |
+| [`revision-tecnica-priorizada-2026-09-01.md`](./revision-tecnica-priorizada-2026-09-01.md) | Auditoría vigente de arquitectura, seguridad, persistencia, escalabilidad y tooling con backlog priorizado | 🔄 AUD-001 a AUD-004 y AUD-007 remediados; seguimiento activo |
 | [`analisis-aud-003-seguridad-importacion-backups-2026-09-01.md`](./analisis-aud-003-seguridad-importacion-backups-2026-09-01.md) | Revalidación e implementación de AUD-003: frontera ZIP/JSON, integridad y defensa de presentación | ✅ Cerrado en PR #3 |
-| [`analisis-aud-004-seguridad-dependencias-2026-09-02.md`](./analisis-aud-004-seguridad-dependencias-2026-09-02.md) | Revalidación y cierre de AUD-004: advisories, grafo mínimo, auditorías, gates y Android | ✅ Implementación y validación completas; integración autorizada |
+| [`analisis-aud-004-seguridad-dependencias-2026-09-02.md`](./analisis-aud-004-seguridad-dependencias-2026-09-02.md) | Revalidación y cierre de AUD-004: advisories, grafo mínimo, auditorías, gates y Android | ✅ Cerrado en PR #5 |
+| [`analisis-aud-007-contratos-errores-store-2026-09-03.md`](./analisis-aud-007-contratos-errores-store-2026-09-03.md) | Contrato emit-and-rethrow, adaptación de consumidores y evidencia automática/Android de AUD-007 | ✅ Cerrado en PR #6 |
 | [`historico/`](./historico/) | Snapshots operativos cerrados preservados como evidencia de proceso | 📦 Archivo |
 
 ---

--- a/docs/gestion/analisis-aud-007-contratos-errores-store-2026-09-03.md
+++ b/docs/gestion/analisis-aud-007-contratos-errores-store-2026-09-03.md
@@ -1,0 +1,227 @@
+# AUD-007 — Contrato de errores de mutaciones del store
+
+**Fecha:** 2026-09-03  
+**Estado:** análisis y contrato aprobados para implementación  
+**Rama:** `fix/store-action-contract`  
+**Base canónica:** `15de2ba95a4334b72a0549c3bd1555c658a28d9d` (`main` = `origin/main`)  
+**Alcance:** AUD-007; sin cambios de transacciones, coordinación async, tooling, schema, dependencias ni versión
+
+## 1. Baseline reproducible
+
+El preflight se ejecutó sobre `/home/jd/github/lumapse`, con worktree limpio y `origin` apuntando a
+`https://github.com/jdfesa/lumapse.git`. El PR #4 se verificó como integrado y su rama local histórica
+se eliminó con autorización explícita antes de crear esta rama. La base corresponde al rebase merge del
+PR #5 que cerró AUD-004.
+
+| Evidencia | Resultado |
+|---|---|
+| `node --version` | `v26.7.0` |
+| `npm --version` | `12.0.2` |
+| `npm ci` | correcto; 293 paquetes instalados y 0 vulnerabilidades informadas |
+| Tests focalizados iniciales | 6 archivos y 188 tests aprobados |
+| `package.json` | `0.4.8` |
+| Android `versionName` / `versionCode` | `0.4.8` / `408` |
+
+Los tests focalizados iniciales fueron:
+
+- `tests/unit/store/NoteStore.errors.test.js`;
+- `tests/unit/store/NoteStore.data.test.js`;
+- `tests/unit/store/NoteStore.ui.test.js`;
+- `tests/unit/store/NoteStore.academicEvents.test.js`;
+- `tests/unit/components/feed/FeedActionRouter.test.js`;
+- `tests/unit/components/note-editor/NoteEditor.test.js`.
+
+La suite focalizada normal pasó en Node 26. El workaround de Web Storage permanece reservado únicamente
+como diagnóstico de AUD-009 si el gate completo lo requiere; no forma parte de esta corrección.
+
+## 2. Inventario de productores
+
+### 2.1 Mutaciones públicas de notas, materias y papelera
+
+| Mutación | Persistencia | Frontera actual | Retorno exitoso actual |
+|---|---|---|---|
+| `createNote` | `NoteService.createNote` | `runStoreAction` | nota persistida |
+| `updateNote` | `NoteService.updateNote` | `runStoreAction` | nota persistida |
+| `updateNoteSilent` | `NoteService.updateNote` | `try/catch` propio | nota persistida |
+| `moveNote` | `NoteService.updateNote` | `runStoreAction` | `undefined` |
+| `deleteNote` | `NoteService.deleteNote` | `runStoreAction` | `undefined` |
+| `createSubject` | `SubjectService.createSubject` | `runStoreAction` | materia/sección persistida |
+| `updateSubject` | `SubjectService.updateSubject` | `runStoreAction` | `undefined` |
+| `archiveSubject` / `archiveSection` | `SubjectService.archive*` | `runStoreAction` | `undefined` |
+| `unarchiveSubject` / `unarchiveSection` | `SubjectService.unarchive*` | `runStoreAction` | `undefined` |
+| `deleteSubject` / `deleteSection` | `SubjectService.delete*` | `runStoreAction` | `undefined` |
+| `restoreNoteFromTrash` | `SubjectService.restoreNoteFromTrash` | `runStoreAction` | `undefined` |
+| `restoreSubjectFromTrash` / `restoreSectionFromTrash` | `SubjectService.restore*` | `runStoreAction` | `undefined` |
+| `permanentlyDeleteNote` | `NoteService.permanentlyDeleteNote` | `runStoreAction` | `undefined` |
+| `emptyTrash` | `SubjectService.emptyTrash` | `runStoreAction` | `undefined` |
+
+Las cargas `loadNotes`, `loadSubjects`, `loadArchivedSubjects` y `loadTrashCount` son lecturas y quedan
+fuera del contrato de mutación. Se mantienen identificadas porque algunas mutaciones las ejecutan después
+de persistir para reconciliar caches y contadores.
+
+### 2.2 Mutaciones de presentación con escritura directa
+
+`togglePin`, `toggleArchive` y `setNoteStatus`, en `NoteStore.ui.js`, llaman directamente a
+`NoteService.updateNote`. En la base inicial rechazan sin emitir por el canal del store. Los tres actualizan
+`state.notes` y notifican solo después de que la escritura resuelve; `toggleArchive` también puede limpiar
+`activeNoteId`. Una nota ausente en memoria produce un no-op legítimo y resuelve `undefined` sin tocar SQLite.
+
+### 2.3 Mutaciones académicas
+
+| Mutación | Frontera actual | Retorno exitoso actual |
+|---|---|---|
+| `createAcademicEvent` | `runStoreAction` | evento persistido |
+| `updateAcademicEvent` | `runStoreAction` | evento persistido |
+| `deleteAcademicEvent` | `runStoreAction` | `undefined` |
+
+Las tres modifican los caches académicos y llaman `notify()` después de la operación primaria. Crear y
+actualizar recargan además próximos eventos; eliminar limpia los caches y también recarga próximos eventos.
+
+## 3. Inventario de consumidores
+
+| Consumidor | Mutaciones | Observación inicial |
+|---|---|---|
+| `NoteEditor` | `createNote`, `updateNote` | Espera la entidad persistida y preserva borrador/edición tanto ante `undefined` como ante rechazo. El listener DOM registra directamente un método async, por lo que un rechazo puede quedar sin manejar. |
+| `FeedActionRouter` | pin, archive, status, move, papelera y `updateNoteSilent` | Pin/archive/status/move ignoran promesas; restauraciones usan `.then(...)` sin rechazo; los refreshes de papelera dependen del éxito pero el router no consume rechazos. El checkbox ya hace rollback, aunque registra nuevamente el error. |
+| `NoteList.handleDelete` | `deleteNote` | Espera la mutación, pero el router no espera ni captura el callback retornado. |
+| `drawerSubjects` | crear/renombrar materia o sección; desarchivar | Crear y renombrar capturan y muestran toast propio; con emisión global esto duplicaría feedback. Crear sección restaura el estado colapsado ante fallo. Desarchivar se dispara sin esperar ni capturar. |
+| `drawerSubjectContextMenu` | archivar y enviar materia/sección a papelera | Los listeners async esperan el store internamente, pero el DOM no consume sus rechazos. |
+| `AcademicEventDialog` | crear/actualizar evento | Espera el resultado y mantiene abierto el diálogo ante fallo, pero presenta además un error inline; para `DatabaseError` duplicaría el toast global. |
+| `AcademicEventActions` | eliminar evento | El límite DOM captura y registra con `console.warn`; debe evitar repetir el registro/feedback del mismo fallo SQLite. |
+| `main.js` | `emptyTrash` desde el aviso global | Oculta el aviso solo después del éxito, pero el listener async puede dejar un rechazo sin manejar. La suscripción global ya convierte cada evento del store en un toast. |
+| `ImportService` | `createNote` | Espera la escritura, solo resuelve `true` después del éxito y rechaza su operación ante fallo. No está expuesto en la UI actual. |
+| Seeders de QA | `createSubject`, `createNote` | Esperan cada resultado en secuencia y no muestran éxito si una escritura rechaza; sus listeners están deshabilitados en producción. |
+
+`setShowArchived` y las cargas iniciales no son mutaciones persistentes. Se revisarán solo donde sea necesario
+para no dejar rechazos en listeners DOM, sin incorporar ownership de requests ni guards de obsolescencia.
+
+## 4. Contrato anterior
+
+La base combina tres políticas observables incompatibles:
+
+1. `runStoreAction` registra cualquier excepción; ante `DatabaseError` emite el evento global y resuelve
+   `undefined`, mientras que ante otros errores rechaza.
+2. `updateNoteSilent` registra, emite ante `DatabaseError` y siempre vuelve a lanzar.
+3. Pin, archive y status rechazan directamente, sin evento global del store.
+
+Esto vuelve ambiguo `undefined`: puede representar una operación void exitosa, un no-op legítimo o un fallo
+SQLite absorbido. Como consecuencia, algunos consumidores continúan con cierres o refreshes de éxito y otros
+producen rechazos no manejados.
+
+## 5. Contrato elegido
+
+Se adopta una política única de **emitir y propagar**:
+
+1. Toda mutación pública que accede a persistencia atraviesa exactamente una vez `runStoreAction`.
+2. Si la acción termina correctamente, se conserva exactamente su valor de retorno actual.
+3. Si recibe un `DatabaseError`, `runStoreAction` emite exactamente un evento global con operación, mensaje
+   estable y la excepción como causa; luego rechaza con esa misma instancia.
+4. Si recibe cualquier otro error, no emite un evento de persistencia y rechaza con la misma instancia.
+5. El store no transforma errores en `undefined` ni los sustituye por errores genéricos.
+6. Un no-op legítimo anterior a la escritura —por ejemplo una nota inexistente para pin/archive/status— puede
+   seguir resolviendo `undefined`; se distingue de un fallo porque no rechaza ni emite.
+7. Ninguna capa vuelve a envolver una mutación ya cubierta por `runStoreAction`, evitando emisiones dobles.
+
+Este contrato preserva notas, materias y eventos retornados por las operaciones que ya los exponen, y preserva
+`undefined` en las operaciones exitosas de tipo void.
+
+## 6. Reglas de consumo y feedback
+
+- Todo límite DOM consume explícitamente la promesa que dispara.
+- El límite UI solo ejecuta cierres, refreshes y feedback de éxito después de una resolución correcta.
+- Ante `DatabaseError`, la UI restaura su estado local cuando corresponda y no emite otro evento, toast ni log:
+  el único feedback pertenece a la suscripción global de `main.js`.
+- Ante un error no SQLite, el límite responsable lo presenta o registra una sola vez según su contexto.
+- No se agregan `catch(() => {})`; el manejo debe expresar rollback, restauración o reporte responsable.
+- Se admite un helper UI pequeño para clasificar `DatabaseError` ya notificado frente a errores inesperados;
+  no se introduce un framework de comandos.
+
+## 7. Estado en memoria y DOM
+
+Las escrituras continúan siendo pesimistas: `state.notes`, caches académicos, contadores, `activeNoteId`,
+`activeSubjectId` y `viewMode` solo cambian después de confirmar la operación primaria de persistencia. Si esa
+operación rechaza, no se ejecutan `notify()` ni recargas posteriores de éxito.
+
+Los límites visuales aplicarán estas reglas:
+
+- el checkbox Markdown conserva el cambio optimista exclusivamente en el DOM y vuelve a su valor anterior si
+  `updateNoteSilent` rechaza;
+- el editor mantiene inputs, borrador, contexto de edición y modo foco, y siempre restaura label/disabled del
+  botón; el método `handleSave` conserva un rechazo observable para tests y un wrapper DOM lo consume;
+- los menús de move/status/pin/archive solo se cierran después del éxito;
+- papelera solo refresca después del éxito;
+- formularios y diálogos permanecen reintentables ante error;
+- no se muestra feedback local duplicado para fallos SQLite ya publicados globalmente.
+
+Una falla posterior de una lectura de reconciliación puede ocurrir después de que la escritura primaria ya se
+confirmó. Cambiar la atomicidad entre escrituras y recargas corresponde a AUD-005/AUD-010 y no se resolverá
+alterando transacciones en esta rama; las regresiones de AUD-007 fijarán específicamente que un rechazo de la
+persistencia primaria no muta memoria ni DOM como éxito.
+
+## 8. Alternativas descartadas
+
+- **Mantener `DatabaseError -> undefined`:** conserva la ambigüedad y los falsos éxitos que originan AUD-007.
+- **Resultado discriminado para todas las acciones:** sería válido, pero obligaría a cambiar cada retorno y
+  consumidor exitoso. Emitir y rechazar ofrece el mismo carácter inequívoco con menor superficie.
+- **Emitir globalmente todos los errores:** mezclaría fallos de programación/dominio con persistencia y podría
+  mostrar mensajes engañosos. Los errores no SQLite pertenecen al límite que conoce el contexto.
+- **Capturas silenciosas en listeners:** eliminan la advertencia de runtime pero ocultan fallos y dificultan
+  rollback y tests.
+- **Modificar transacciones o hacer refreshes atómicos:** pertenece a AUD-005/AUD-010 y excede esta rama.
+
+## 9. Plan de regresiones
+
+### Store
+
+- éxito y retorno preservado;
+- `DatabaseError`: una emisión exacta y rechazo con la instancia original;
+- error no SQLite: rechazo sin emisión;
+- ausencia de cambios en state/caches y de `notify()` ante fallo primario;
+- cobertura explícita de `createNote`, `updateNote`, `updateNoteSilent`, `togglePin`, `toggleArchive`,
+  `setNoteStatus` y mutaciones académicas representativas;
+- no-op de nota inexistente claramente resuelto y sin emisión.
+
+### Consumidores
+
+- router sin promesas rechazadas no manejadas;
+- trash refresh y cierre de menús exclusivamente después del éxito;
+- rollback y desbloqueo del checkbox;
+- editor determinista, single-flight y con borrador/contexto preservados;
+- formularios de drawer y diálogo académico reintentables;
+- una sola señal lógica de feedback por `DatabaseError`.
+
+Los archivos focales se ampliarán sin debilitar expectativas existentes. Cuando un consumidor adicional lo
+requiera, su regresión se agregará en el test específico de ese componente o layout.
+
+## 10. Validación prevista
+
+La validación automática incluirá los seis archivos focales, suite completa, coverage, lint, typecheck, build,
+presupuesto, checks estáticos/documentales, `verify`, auditorías npm y árbol de dependencias. Cualquier limitación
+exclusiva de AUD-008/AUD-009 se informará sin debilitar el gate.
+
+La validación Android no se ejecuta en la máquina remota porque el dispositivo solo estará disponible en la Mac
+local. Una vez publicados todos los commits se entregarán SHA exacto, resumen y checklist para probar creación y
+edición, pin/archive/status/move, checkbox, eventos académicos, papelera, ausencia de doble toast, reinicio y
+persistencia SQLite. El PR no se creará ni mergeará hasta recibir confirmación explícita de ese gate.
+
+## 11. Criterios de cierre
+
+AUD-007 podrá cerrarse únicamente cuando:
+
+- todas las mutaciones persistentes relevantes compartan el contrato emit-and-rethrow;
+- cada límite UI inventariado consuma el rechazo y no ejecute efectos de éxito después de un fallo;
+- exista una única emisión global por `DatabaseError` y no haya feedback duplicado;
+- éxito, no-op y fallo sean distinguibles;
+- tests y gates automáticos estén aprobados o sus limitaciones ajenas estén identificadas con exactitud;
+- la validación Android local sea aprobada explícitamente;
+- documentación, rama local y rama remota reflejen el mismo estado final.
+
+## 12. Límites del frente
+
+- **AUD-005:** no se cambia propiedad de transacciones, migraciones, schema ni atomicidad multioperación.
+- **AUD-006:** no se agregan tokens de request, cancelación ni protección contra resultados obsoletos.
+- **AUD-008:** no se modifica el fallback offline ni la composición del quality gate.
+- **AUD-009:** no se cambia la matriz Node ni se incorpora permanentemente el workaround de Web Storage.
+- No se actualizan dependencias, release-helper, versión web/Android, APK, release, tag ni línea base.
+
+El siguiente frente técnico independiente permanece `fix/sqlite-write-coordination` para AUD-005.

--- a/docs/gestion/analisis-aud-007-contratos-errores-store-2026-09-03.md
+++ b/docs/gestion/analisis-aud-007-contratos-errores-store-2026-09-03.md
@@ -1,7 +1,7 @@
 # AUD-007 — Contrato de errores de mutaciones del store
 
 **Fecha:** 2026-09-03  
-**Estado:** análisis y contrato aprobados para implementación  
+**Estado:** implementación y validación completas; integración autorizada mediante PR #6  
 **Rama:** `fix/store-action-contract`  
 **Base canónica:** `15de2ba95a4334b72a0549c3bd1555c658a28d9d` (`main` = `origin/main`)  
 **Alcance:** AUD-007; sin cambios de transacciones, coordinación async, tooling, schema, dependencias ni versión
@@ -193,20 +193,21 @@ persistencia primaria no muta memoria ni DOM como éxito.
 Los archivos focales se ampliarán sin debilitar expectativas existentes. Cuando un consumidor adicional lo
 requiera, su regresión se agregará en el test específico de ese componente o layout.
 
-## 10. Validación prevista
+## 10. Validación ejecutada
 
-La validación automática incluirá los seis archivos focales, suite completa, coverage, lint, typecheck, build,
-presupuesto, checks estáticos/documentales, `verify`, auditorías npm y árbol de dependencias. Cualquier limitación
-exclusiva de AUD-008/AUD-009 se informará sin debilitar el gate.
+La validación canónica en la Mac aprobó `npm run verify`: 62 archivos y 989 tests, lint sin errores
+(tres warnings conocidos), typecheck, build de 118 módulos, toolchain, smoke SQLite, bundle gzip de
+192,94 kB sobre 250 kB, diálogos nativos y accesibilidad. Los 63 tests focalizados del editor y la frontera
+de errores también aprobaron. Las auditorías npm completa y productiva informaron 0 vulnerabilidades.
 
-La validación Android no se ejecuta en la máquina remota porque el dispositivo solo estará disponible en la Mac
-local. Una vez publicados todos los commits se entregarán SHA exacto, resumen y checklist para probar creación y
-edición, pin/archive/status/move, checkbox, eventos académicos, papelera, ausencia de doble toast, reinicio y
-persistencia SQLite. El PR no se creará ni mergeará hasta recibir confirmación explícita de ese gate.
+La máquina remota implementó y publicó el refactor final; la validación Android se ejecutó exclusivamente en la
+Mac, donde está conectado el dispositivo. El script oficial instaló `a01d71e` preservando SQLite y manteniendo
+`versionName` 0.4.8 / `versionCode` 408. La creación y el guardado de una nota fueron aprobados manualmente y no
+se observó feedback duplicado. El usuario autorizó crear, aprobar y mergear el PR #6 tras checks verdes.
 
 ## 11. Criterios de cierre
 
-AUD-007 podrá cerrarse únicamente cuando:
+Los criterios de cierre de AUD-007 quedaron satisfechos:
 
 - todas las mutaciones persistentes relevantes compartan el contrato emit-and-rethrow;
 - cada límite UI inventariado consuma el rechazo y no ejecute efectos de éxito después de un fallo;
@@ -225,3 +226,12 @@ AUD-007 podrá cerrarse únicamente cuando:
 - No se actualizan dependencias, release-helper, versión web/Android, APK, release, tag ni línea base.
 
 El siguiente frente técnico independiente permanece `fix/sqlite-write-coordination` para AUD-005.
+
+## 13. Evidencia de implementación
+
+- `fd2d41b` — contrato y análisis reproducible;
+- `037ac75` — política emit-and-rethrow en mutaciones del store;
+- `0a54d22` — límites UI sin falsos éxitos ni rechazos no manejados;
+- `a01d71e` — refactor mínimo del listener de guardado; `NoteEditor.js` pasó de 406 a 400 LOC lógicas;
+- PR #6 — integración autorizada con gates de GitHub requeridos;
+- Android local — deploy oficial, SQLite de 53.248 bytes preservada y prueba manual aprobada el 2026-09-03.

--- a/docs/gestion/revision-tecnica-priorizada-2026-09-01.md
+++ b/docs/gestion/revision-tecnica-priorizada-2026-09-01.md
@@ -1,6 +1,6 @@
 # Revisión Técnica Priorizada — 2026-09-01
 
-**Estado:** Vigente — AUD-001 a AUD-003 integrados; AUD-004 implementado y validado, con integración autorizada
+**Estado:** Vigente — AUD-001 a AUD-004 y AUD-007 cerrados técnicamente
 **Rama original de auditoría:** `fix/note-save-integrity`
 **Commit base original revisado:** `cd60c0e` (`main`)
 **Versión de producto documentada:** `0.4.8` (Beta)  
@@ -95,10 +95,10 @@ store, no como métrica integral de toda la aplicación.
 | AUD-001 | P0 | Pérdida de borrador ante error SQLite | Bug confirmado | Resuelto en PR #2 |
 | AUD-002 | P0 | Guardados duplicados por taps concurrentes | Bug confirmado | Resuelto en PR #2 |
 | AUD-003 | P0 | Inyección HTML persistente desde campos de backup | Seguridad confirmada | Cerrado en PR #3 |
-| AUD-004 | P0 | Dependencias vulnerables, incluida DOMPurify en producción | Seguridad/tooling | Implementación y validación completas; integración autorizada |
+| AUD-004 | P0 | Dependencias vulnerables, incluida DOMPurify en producción | Seguridad/tooling | Cerrado en PR #5 |
 | AUD-005 | P1 | Propiedad global de transacciones y migraciones permisivas | Confiabilidad | Pendiente |
 | AUD-006 | P1 | Resultados async obsoletos sobrescriben vista/cache reciente | Bug de concurrencia | Pendiente |
-| AUD-007 | P1 | Contratos incompatibles para errores de mutaciones | Diseño/confiabilidad | Pendiente |
+| AUD-007 | P1 | Contratos incompatibles para errores de mutaciones | Diseño/confiabilidad | Cerrado en PR #6 |
 | AUD-008 | P1 | Gate canónico no portable y CI desalineada | Tooling | Pendiente |
 | AUD-009 | P1 | Suite no reproducible en toda la versión Node declarada | Tooling | Pendiente |
 | AUD-010 | P2 | Broadcasts globales y refreshes no atómicos | Escalabilidad | Pendiente de medición |
@@ -409,8 +409,8 @@ test(editor): cover failed and concurrent note saves
 |---:|---|---|
 | 1 | `fix/note-save-integrity` | Cerrado en PR #2: AUD-001 y AUD-002 |
 | 2 | `fix/backup-import-security` | Cerrado en PR #3: AUD-003 |
-| 3 | `fix/aud-004-dependency-security` | Implementación y validación completas; integración autorizada |
-| 4 | `fix/store-action-contract` | Unificar semántica de errores de mutaciones |
+| 3 | `fix/aud-004-dependency-security` | Cerrado en PR #5: AUD-004 |
+| 4 | `fix/store-action-contract` | Cerrado en PR #6: AUD-007 |
 | 5 | `fix/sqlite-write-coordination` | Aislar transacciones y endurecer migraciones/arranque |
 | 6 | `fix/async-request-ownership` | Evitar resultados obsoletos en trash y Heatmap |
 | 7 | `fix/quality-gate-portability` | Unificar gate local/CI y resolver matriz Node |
@@ -475,6 +475,17 @@ Resultado consolidado:
 - Android 0.4.8/408 instalado preservando SQLite en Samsung SM_G965F; comportamiento aprobado
   explícitamente. No se publicó APK, release ni tag.
 
+### Cierre automático y manual de AUD-007 — 2026-09-03
+
+- Contrato emit-and-rethrow aplicado a las mutaciones persistentes y consumidores UI adaptados sin
+  falsos éxitos, rechazos no manejados ni feedback duplicado.
+- Tests focalizados del editor/frontera: **2 archivos/63 tests**; suite completa: **62 archivos/989 tests**.
+- `npm run verify`, lint (**0 errores/3 warnings conocidos**), typecheck, build (**118 módulos**) y
+  auditorías completa/productiva (**0 vulnerabilidades**) aprobados en la Mac canónica.
+- `NoteEditor.js` pasó de **406 a 400 LOC lógicas**, eliminando el estado bloqueante sin cambiar el umbral.
+- Android 0.4.8/408 instalado mediante el script oficial, SQLite preservada y creación/guardado de nota
+  aprobados manualmente. No se publicó APK, release ni tag.
+
 ## 11. Limitaciones de la revisión
 
 - Se aprobó el escenario funcional Android con 500 notas; no se ejecutó benchmark instrumentado ni
@@ -494,7 +505,6 @@ cohesión de features con cambios pequeños y medidos.
 
 La revisión inicial quedó vinculada al primer fix porque AUD-001 y AUD-002 afectaban el flujo
 central del producto y presentaban la mejor relación entre impacto, riesgo y tamaño de cambio.
-Ambos hallazgos se cerraron posteriormente en la PR #2 y AUD-003 en la PR #3. AUD-004 quedó
-implementado y validado en `fix/aud-004-dependency-security`; las auditorías completa y productiva
-quedaron en cero, el checkpoint Android fue aprobado el 2026-09-02 y su integración quedó
-autorizada. AUD-005 y los demás hallazgos conservan alcance y seguimiento independientes.
+Ambos hallazgos se cerraron posteriormente en la PR #2, AUD-003 en la PR #3 y AUD-004 en la PR #5.
+AUD-007 quedó cerrado en la PR #6 con contrato único, límites UI adaptados y validación automática/Android
+aprobada. AUD-005 y los demás hallazgos conservan alcance y seguimiento independientes.

--- a/docs/hitos/hito-06-octubre.md
+++ b/docs/hitos/hito-06-octubre.md
@@ -8,9 +8,9 @@
 
 **Proyecto:** Lumapse
 
-**Estado:** Activo — AUD-001 a AUD-004 cerrados técnicamente; cierre editorial, RNF y artefacto pendientes
+**Estado:** Activo — AUD-001 a AUD-004 y AUD-007 cerrados técnicamente; cierre editorial, RNF y artefacto pendientes
 
-**Última actualización:** 2026-09-02
+**Última actualización:** 2026-09-03
 
 ---
 
@@ -27,6 +27,7 @@ Cerrar Lumapse con documentación coherente, evidencia técnica reproducible, di
 - Validación inicial aprobada en Samsung Galaxy S20 FE con Android 13.
 - El rango técnico auditado posterior al tag comprende 38 commits hasta `ba16777`: documentación, refactors TypeScript, correcciones de integridad de guardado y endurecimiento de la importación de backups. Este rango no constituye una release ni un APK publicado nuevo.
 - AUD-001 y AUD-002 quedaron integrados mediante PR #2; AUD-003 quedó integrado mediante PR #3 después de completar la suite acumulativa y los checkpoints Android acordados.
+- AUD-004 quedó integrado mediante PR #5 y AUD-007 se cerró técnicamente mediante PR #6, con quality gate y validación Android aprobados.
 - Diagramas Mermaid revisados contra el alcance de la beta; fuentes DOT, DBML y DDL sincronizadas; exportaciones gráficas de base de datos reemplazadas, revisadas e incorporadas el 2026-07-15.
 
 ## Alcance del Hito
@@ -57,6 +58,7 @@ Cerrar Lumapse con documentación coherente, evidencia técnica reproducible, di
 - [x] Cerrar AUD-003 con importación ZIP acotada, validación runtime, jerarquía consistente, presentación defensiva, suite acumulativa e integración mediante PR #3.
 - [x] Aprobar los checkpoints Android de AUD-003 con backups `STORE`/`DEFLATE`, rechazo de datos inválidos antes de persistir, fixture de 500 notas y build completo instalado. Esta evidencia no equivale a validar un artefacto publicado nuevo.
 - [x] Resolver AUD-004 en un PR separado: grafo mínimo actualizado, auditorías completa/productiva en cero, sanitización, 955 tests, build, quality gate y Android 0.4.8/408 aprobados el 2026-09-02.
+- [x] Resolver AUD-007 en un PR separado: contrato emit-and-rethrow, límites UI deterministas, 989 tests, quality gate y Android 0.4.8/408 aprobados el 2026-09-03.
 - [ ] Ejecutar el quality gate sobre el commit candidato y guardar la evidencia; los gates acumulativos y pre-push ya aprobados no sustituyen el cierre del corte.
 - [ ] Repetir la checklist Android sobre el artefacto versionado y firmado elegido.
 - [ ] Medir latencia CRUD y rendimiento con al menos 500 notas (`RNF-002`, `RNF-004`); la importación funcional de esa cantidad no constituye una medición de rendimiento.
@@ -78,7 +80,7 @@ Cerrar Lumapse con documentación coherente, evidencia técnica reproducible, di
 
 ### 5. Corte y línea base final
 
-- `v0.4.8` permanece como evidencia inmutable de la beta y no contiene las correcciones AUD-001/002/003/004; el próximo artefacto distribuido deberá partir de un corte posterior.
+- `v0.4.8` permanece como evidencia inmutable de la beta y no contiene las correcciones AUD-001/002/003/004/007; el próximo artefacto distribuido deberá partir de un corte posterior.
 - Decidir si ese corte se publica como beta patch `v0.4.9` para una nueva ronda de validación o se reserva para la versión final de Hito 06.
 - No crear `0.4.9` de forma preventiva ni reutilizar `versionCode 408` para un binario diferente.
 - Corregir o reforzar `scripts/release-helper.py`: actualmente actualiza package/changelog, pero no garantiza la alineación de `versionName` y `versionCode` Android.
@@ -115,6 +117,7 @@ Se mantiene WIP máximo de dos elementos activos en total entre `En Curso` y `En
 | Observación | Severidad actual | Evidencia requerida |
 |---|---|---|
 | AUD-004 — dependencias con advisories | Cerrado técnicamente / sin bloqueantes | Grafo mínimo, auditorías 0/0, sanitización, build y Android aprobados el 2026-09-02 |
+| AUD-007 — contratos de errores del store | Cerrado técnicamente / sin bloqueantes | Contrato único, consumidores, 989 tests, quality gate y Android aprobados el 2026-09-03 |
 | El helper no alinea automáticamente la versión Android | Riesgo alto de release | Test o gate que compare versión declarada, `versionName` y `versionCode` antes del build |
 | `Mover a` puede requerir pulsación prolongada | Menor / no bloqueante | Reproducción repetible en validación final y decisión explícita |
 | Rendimiento con mayor volumen de notas | Riesgo medio de evidencia | Medición de latencia y percepción con al menos 500 notas; no solo importación funcional |

--- a/src/components/academic-events/AcademicEventActions.js
+++ b/src/components/academic-events/AcademicEventActions.js
@@ -4,6 +4,7 @@
 
 import * as NoteStore from '../../store/NoteStore.js'
 import { confirmDialog } from '../common/ConfirmDialog.js'
+import { handleStoreMutationError } from '../common/storeActionErrors.js'
 import { openAcademicEventDialog } from './AcademicEventDialog.js'
 
 function eventTitle(event) {
@@ -47,7 +48,11 @@ export function bindAcademicEventActions(container, getEventById) {
       const event = getEventById(button.dataset.eventId)
 
       handleAcademicEventAction(action, event)
-        .catch(error => console.warn('[AcademicEventActions] No se pudo ejecutar la accion:', error))
+        .catch(error => handleStoreMutationError(error, {
+          onUnexpected: unexpectedError => {
+            console.warn('[AcademicEventActions] No se pudo ejecutar la accion:', unexpectedError)
+          },
+        }))
     })
   })
 }

--- a/src/components/academic-events/AcademicEventDialog.js
+++ b/src/components/academic-events/AcademicEventDialog.js
@@ -6,6 +6,7 @@
 import './AcademicEventDialog.css'
 
 import * as NoteStore from '../../store/NoteStore.js'
+import { handleStoreMutationError } from '../common/storeActionErrors.js'
 import {
   createLabeledControl,
   getInitialDate,
@@ -288,7 +289,11 @@ export function openAcademicEventDialog(options = {}) {
 
         finish(savedEvent)
       } catch (error) {
-        showError(error?.message || 'No se pudo guardar la fecha academica.', 'date')
+        handleStoreMutationError(error, {
+          onUnexpected: unexpectedError => {
+            showError(unexpectedError?.message || 'No se pudo guardar la fecha academica.', 'date')
+          },
+        })
         saveBtn.disabled = false
         saveBtn.textContent = mode === 'edit' ? 'Guardar cambios' : 'Guardar'
       }

--- a/src/components/common/storeActionErrors.js
+++ b/src/components/common/storeActionErrors.js
@@ -1,0 +1,21 @@
+// =============================================================
+// storeActionErrors — Límite de errores de mutaciones en UI
+// =============================================================
+
+import { DatabaseError } from '../../services/sqlite/errors.js'
+
+/**
+ * Consume un rechazo de mutación en el límite UI sin duplicar feedback.
+ * Los DatabaseError ya fueron emitidos por NoteStore y main muestra su toast.
+ * Los errores inesperados pertenecen al consumidor que conoce el contexto.
+ */
+export function handleStoreMutationError(error, { context = 'UI', onUnexpected } = {}) {
+  if (error instanceof DatabaseError) return
+
+  if (onUnexpected) {
+    onUnexpected(error)
+    return
+  }
+
+  console.error(`[${context}] Error inesperado en mutación del store:`, error)
+}

--- a/src/components/feed/FeedActionRouter.js
+++ b/src/components/feed/FeedActionRouter.js
@@ -9,6 +9,7 @@
 import * as NoteStore from '../../store/NoteStore.js'
 import { renderTrashView } from './TrashView.js'
 import { confirmDialog } from '../common/ConfirmDialog.js'
+import { handleStoreMutationError } from '../common/storeActionErrors.js'
 
 const TASK_LINE_REGEX = /^(\s*[-*+]\s+\[)([ xX])(\]\s+)/
 const pendingCheckboxToggles = new Set()
@@ -83,7 +84,7 @@ async function handleTaskCheckbox(event) {
     await NoteStore.updateNoteSilent(noteId, { content: toggle.content })
   } catch (error) {
     setCheckboxChecked(checkbox, previousChecked)
-    console.error('[FeedActionRouter] No se pudo actualizar checkbox:', error)
+    handleStoreMutationError(error, { context: 'FeedActionRouter' })
   } finally {
     pendingCheckboxToggles.delete(lockKey)
     if (checkbox.isConnected) {
@@ -110,8 +111,9 @@ const ACTION_MAP = [
   },
   {
     selector: '.js-btn-restore',
-    handler: (_event, button, deps) => {
-      NoteStore.restoreNoteFromTrash(button.dataset.id).then(() => refreshTrash(deps))
+    handler: async (_event, button, deps) => {
+      await NoteStore.restoreNoteFromTrash(button.dataset.id)
+      refreshTrash(deps)
     }
   },
   {
@@ -131,14 +133,16 @@ const ACTION_MAP = [
   },
   {
     selector: '.js-btn-restore-subject',
-    handler: (_event, button, deps) => {
-      NoteStore.restoreSubjectFromTrash(button.dataset.id).then(() => refreshTrash(deps))
+    handler: async (_event, button, deps) => {
+      await NoteStore.restoreSubjectFromTrash(button.dataset.id)
+      refreshTrash(deps)
     }
   },
   {
     selector: '.js-btn-restore-section',
-    handler: (_event, button, deps) => {
-      NoteStore.restoreSectionFromTrash(button.dataset.id).then(() => refreshTrash(deps))
+    handler: async (_event, button, deps) => {
+      await NoteStore.restoreSectionFromTrash(button.dataset.id)
+      refreshTrash(deps)
     }
   },
   {
@@ -147,37 +151,49 @@ const ACTION_MAP = [
   },
   {
     selector: '.js-btn-pin',
-    handler: (_event, button) => NoteStore.togglePin(button.dataset.id)
+    handler: async (_event, button, deps) => {
+      await NoteStore.togglePin(button.dataset.id)
+      deps.closeAllDropdowns()
+    }
   },
   {
     selector: '.js-btn-archive',
-    handler: (_event, button) => NoteStore.toggleArchive(button.dataset.id)
+    handler: async (_event, button, deps) => {
+      await NoteStore.toggleArchive(button.dataset.id)
+      deps.closeAllDropdowns()
+    }
   },
   {
     selector: '.js-btn-move-to',
-    handler: (_event, button, deps) => {
+    handler: async (_event, button, deps) => {
       const noteId = button.dataset.noteId
       const targetSubject = button.dataset.subjectId || null
-      NoteStore.moveNote(noteId, targetSubject)
+      await NoteStore.moveNote(noteId, targetSubject)
       deps.closeAllDropdowns()
     }
   },
   {
     selector: '.js-btn-status',
-    handler: (_event, button, deps) => {
+    handler: async (_event, button, deps) => {
       const noteId = button.dataset.noteId
       const statusValue = button.dataset.emoji || null
-      NoteStore.setNoteStatus(noteId, statusValue)
+      await NoteStore.setNoteStatus(noteId, statusValue)
       deps.closeAllDropdowns()
     }
   },
   {
     selector: '.js-btn-edit',
-    handler: (_event, button, deps) => deps.onEdit(button.dataset.id)
+    handler: (_event, button, deps) => {
+      deps.onEdit(button.dataset.id)
+      deps.closeAllDropdowns()
+    }
   },
   {
     selector: '.js-btn-delete',
-    handler: (_event, button, deps) => deps.onDelete(button.dataset.id)
+    handler: async (_event, button, deps) => {
+      await deps.onDelete(button.dataset.id)
+      deps.closeAllDropdowns()
+    }
   },
   {
     selector: '.js-btn-copy',
@@ -199,17 +215,23 @@ export function createFeedActionRouter(deps) {
   return (event) => {
     // Checkbox interactivo: toggle de task list (- [ ] <-> - [x])
     if (event.target.type === 'checkbox' && event.target.hasAttribute('data-line')) {
-      handleTaskCheckbox(event)
+      void handleTaskCheckbox(event)
       return
     }
 
     for (const entry of ACTION_MAP) {
       const button = event.target.closest(entry.selector)
       if (button) {
-        if (entry.selector !== '.js-btn-menu' && entry.selector !== '.js-btn-copy') {
-          deps.closeAllDropdowns()
+        try {
+          const result = entry.handler(event, button, deps)
+          if (result && typeof result.then === 'function') {
+            void result.catch(error => {
+              handleStoreMutationError(error, { context: 'FeedActionRouter' })
+            })
+          }
+        } catch (error) {
+          handleStoreMutationError(error, { context: 'FeedActionRouter' })
         }
-        entry.handler(event, button, deps)
         return
       }
     }

--- a/src/components/note-editor/NoteEditor.js
+++ b/src/components/note-editor/NoteEditor.js
@@ -6,6 +6,7 @@ import { createEditorDraftPayload, EditorDraftCapture, EditorDraftRestorer } fro
 import { setupEditorPopups } from './NoteEditorPopups.js';
 import { renderNoteEditorTemplate } from './NoteEditorTemplate.js';
 import { confirmDialog } from '../common/ConfirmDialog.js';
+import { handleStoreMutationError } from '../common/storeActionErrors.js';
 import { extractNoteTitle, resolveNoteTitleForSave, splitNoteForEditing, stripRedundantTitleFromContent } from '../../services/NoteTitleService.ts';
 import './NoteEditor.css';
 
@@ -24,6 +25,7 @@ export class NoteEditor {
     
     this.handleInput = this.handleInput.bind(this);
     this.handleSave = this.handleSave.bind(this);
+    this.handleSaveClick = this.handleSaveClick.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.handleDiscardDraft = this.handleDiscardDraft.bind(this);
     this.handlePageHide = this.handlePageHide.bind(this);
@@ -71,7 +73,7 @@ export class NoteEditor {
     input.addEventListener('input', this.handleInput);
     input.addEventListener('keydown', this.handleKeyDown);
     subjectInput.addEventListener('change', this.handleSubjectChange);
-    saveBtn.addEventListener('click', this.handleSave);
+    saveBtn.addEventListener('click', this.handleSaveClick);
     discardBtn.addEventListener('click', this.handleDiscardDraft);
 
     this.slashHandler = new SlashCommandHandler(input, composer);
@@ -294,6 +296,12 @@ export class NoteEditor {
     this.hideDraftStatus();
 
     this.exitFocusMode();
+  }
+
+  handleSaveClick() {
+    return this.handleSave().catch((error) => {
+      handleStoreMutationError(error, { context: 'NoteEditor' });
+    });
   }
 
   extractTitle(content) {

--- a/src/components/note-editor/NoteEditor.js
+++ b/src/components/note-editor/NoteEditor.js
@@ -25,7 +25,6 @@ export class NoteEditor {
     
     this.handleInput = this.handleInput.bind(this);
     this.handleSave = this.handleSave.bind(this);
-    this.handleSaveClick = this.handleSaveClick.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.handleDiscardDraft = this.handleDiscardDraft.bind(this);
     this.handlePageHide = this.handlePageHide.bind(this);
@@ -73,7 +72,7 @@ export class NoteEditor {
     input.addEventListener('input', this.handleInput);
     input.addEventListener('keydown', this.handleKeyDown);
     subjectInput.addEventListener('change', this.handleSubjectChange);
-    saveBtn.addEventListener('click', this.handleSaveClick);
+    saveBtn.addEventListener('click', () => this.handleSave().catch(handleStoreMutationError));
     discardBtn.addEventListener('click', this.handleDiscardDraft);
 
     this.slashHandler = new SlashCommandHandler(input, composer);
@@ -296,12 +295,6 @@ export class NoteEditor {
     this.hideDraftStatus();
 
     this.exitFocusMode();
-  }
-
-  handleSaveClick() {
-    return this.handleSave().catch((error) => {
-      handleStoreMutationError(error, { context: 'NoteEditor' });
-    });
   }
 
   extractTitle(content) {

--- a/src/layout/drawerController.js
+++ b/src/layout/drawerController.js
@@ -9,6 +9,7 @@
 
 import { initSubjects } from './drawerSubjects.js'
 import { initTheme } from './drawerTheme.js'
+import { showErrorToast } from '../components/common/Toast.js'
 
 /**
  * Inicializa toda la lógica interactiva del drawer.
@@ -92,8 +93,15 @@ export function initDrawer({ NoteStore, ThemeService, SUBJECT_COLORS }) {
   let showingArchived = false
 
   btnArchiveToggle.addEventListener('click', async () => {
-    showingArchived = !showingArchived
-    await NoteStore.setShowArchived(showingArchived)
+    const nextShowingArchived = !showingArchived
+    try {
+      await NoteStore.setShowArchived(nextShowingArchived)
+    } catch (error) {
+      showErrorToast(error?.message || 'No se pudo cambiar la vista de archivados.')
+      return
+    }
+
+    showingArchived = nextShowingArchived
     archivedLabel.textContent = showingArchived ? 'Ver notas activas' : 'Ver archivadas'
     btnArchiveToggle.classList.toggle('drawer__nav-btn--active', showingArchived)
     // Desactivar materia seleccionada cuando se muestran archivadas

--- a/src/layout/drawerSubjectContextMenu.js
+++ b/src/layout/drawerSubjectContextMenu.js
@@ -3,6 +3,7 @@
 // =============================================================
 
 import { confirmDialog } from '../components/common/ConfirmDialog.js'
+import { handleStoreMutationError } from '../components/common/storeActionErrors.js'
 
 /**
  * Configura un único menú contextual reutilizable para materias/secciones.
@@ -132,40 +133,48 @@ export function setupSubjectContextMenu({ subjectsList, NoteStore, startRenameSu
   })
 
   ctxMenu.querySelector('.js-ctx-archive').addEventListener('click', async () => {
-    if (!ctxTarget) return
-    const { subjectId, isSection, subjectName } = ctxTarget
-    const type = isSection ? 'sección' : 'materia'
-    closeCtxMenu()
-    const confirmed = await confirmDialog({
-      title: `Archivar ${type}`,
-      message: `¿Archivar la ${type} "${subjectName}" y todas sus notas?`,
-      confirmText: 'Archivar',
-    })
-    if (confirmed) {
-      if (isSection) {
-        await NoteStore.archiveSection(subjectId)
-      } else {
-        await NoteStore.archiveSubject(subjectId)
+    try {
+      if (!ctxTarget) return
+      const { subjectId, isSection, subjectName } = ctxTarget
+      const type = isSection ? 'sección' : 'materia'
+      closeCtxMenu()
+      const confirmed = await confirmDialog({
+        title: `Archivar ${type}`,
+        message: `¿Archivar la ${type} "${subjectName}" y todas sus notas?`,
+        confirmText: 'Archivar',
+      })
+      if (confirmed) {
+        if (isSection) {
+          await NoteStore.archiveSection(subjectId)
+        } else {
+          await NoteStore.archiveSubject(subjectId)
+        }
       }
+    } catch (error) {
+      handleStoreMutationError(error, { context: 'drawerSubjectContextMenu' })
     }
   })
 
   ctxMenu.querySelector('.js-ctx-delete').addEventListener('click', async () => {
-    if (!ctxTarget) return
-    const { subjectId, isSection, subjectName } = ctxTarget
-    const type = isSection ? 'sección' : 'materia'
-    closeCtxMenu()
-    const confirmed = await confirmDialog({
-      title: `Enviar ${type} a papelera`,
-      message: `¿Enviar la ${type} "${subjectName}" y todas sus notas a la Papelera de reciclaje?`,
-      confirmText: 'Enviar',
-    })
-    if (confirmed) {
-      if (isSection) {
-        await NoteStore.deleteSection(subjectId)
-      } else {
-        await NoteStore.deleteSubject(subjectId)
+    try {
+      if (!ctxTarget) return
+      const { subjectId, isSection, subjectName } = ctxTarget
+      const type = isSection ? 'sección' : 'materia'
+      closeCtxMenu()
+      const confirmed = await confirmDialog({
+        title: `Enviar ${type} a papelera`,
+        message: `¿Enviar la ${type} "${subjectName}" y todas sus notas a la Papelera de reciclaje?`,
+        confirmText: 'Enviar',
+      })
+      if (confirmed) {
+        if (isSection) {
+          await NoteStore.deleteSection(subjectId)
+        } else {
+          await NoteStore.deleteSubject(subjectId)
+        }
       }
+    } catch (error) {
+      handleStoreMutationError(error, { context: 'drawerSubjectContextMenu' })
     }
   })
 

--- a/src/layout/drawerSubjects.js
+++ b/src/layout/drawerSubjects.js
@@ -4,6 +4,7 @@
 // =============================================================
 
 import { showErrorToast } from '../components/common/Toast.js'
+import { handleStoreMutationError } from '../components/common/storeActionErrors.js'
 import { handleUnarchiveSubjectButton } from './drawerArchivedSubjects.js'
 import {
   isSubjectCollapsed,
@@ -40,6 +41,12 @@ export function initSubjects({ NoteStore, SUBJECT_COLORS, closeDrawer, getShowin
     NoteStore,
     startRenameSubject,
   })
+
+  function handleSubjectMutationError(error) {
+    handleStoreMutationError(error, {
+      onUnexpected: unexpectedError => showErrorToast(unexpectedError?.message || 'No se pudo completar la acción.'),
+    })
+  }
 
   // Renderizar paleta de colores
   colorPickerContainer.innerHTML = SUBJECT_COLORS.map((color, i) => `
@@ -80,7 +87,7 @@ export function initSubjects({ NoteStore, SUBJECT_COLORS, closeDrawer, getShowin
       subjectFormContainer.style.display = 'none'
       subjectNameInput.value = ''
     } catch (err) {
-      showErrorToast(err.message)
+      handleSubjectMutationError(err)
     }
   })
 
@@ -132,7 +139,8 @@ export function initSubjects({ NoteStore, SUBJECT_COLORS, closeDrawer, getShowin
     const btnUnarchive = e.target.closest('.js-btn-unarchive-subject')
     if (btnUnarchive) {
       e.stopPropagation()
-      handleUnarchiveSubjectButton(btnUnarchive, NoteStore)
+      void handleUnarchiveSubjectButton(btnUnarchive, NoteStore)
+        .catch(handleSubjectMutationError)
       return
     }
 
@@ -255,7 +263,7 @@ export function initSubjects({ NoteStore, SUBJECT_COLORS, closeDrawer, getShowin
       form.style.display = 'none'
     } catch (err) {
       if (wasCollapsed) setSubjectCollapsed(parentId, true)
-      showErrorToast(err.message)
+      handleSubjectMutationError(err)
     }
   }
 
@@ -316,7 +324,7 @@ export function initSubjects({ NoteStore, SUBJECT_COLORS, closeDrawer, getShowin
     try {
       await NoteStore.updateSubject(subjectId, { name: trimmed })
     } catch (err) {
-      showErrorToast(err.message)
+      handleSubjectMutationError(err)
     }
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,7 @@ import { Heatmap } from './components/academic-events/Heatmap.js'
 import { UpcomingAcademicEvents } from './components/academic-events/UpcomingAcademicEvents.js'
 import { confirmDialog } from './components/common/ConfirmDialog.js'
 import { showErrorToast } from './components/common/Toast.js'
+import { handleStoreMutationError } from './components/common/storeActionErrors.js'
 import { renderAppShell } from './layout/appShell.js'
 import { initDrawer } from './layout/drawerController.js'
 // import { seedTiktokData, seedStressTest } from './utils/seeder.js'
@@ -105,15 +106,19 @@ async function initApp() {
   })
 
   btnEmptyTrashToast?.addEventListener('click', async () => {
-    const confirmed = await confirmDialog({
-      title: 'Vaciar papelera',
-      message: '¿Vaciar toda la papelera? Esta acción no se puede deshacer.',
-      confirmText: 'Vaciar',
-      danger: true,
-    })
-    if (confirmed) {
-      await NoteStore.emptyTrash()
-      trashToast.style.display = 'none'
+    try {
+      const confirmed = await confirmDialog({
+        title: 'Vaciar papelera',
+        message: '¿Vaciar toda la papelera? Esta acción no se puede deshacer.',
+        confirmText: 'Vaciar',
+        danger: true,
+      })
+      if (confirmed) {
+        await NoteStore.emptyTrash()
+        trashToast.style.display = 'none'
+      }
+    } catch (error) {
+      handleStoreMutationError(error, { context: 'main' })
     }
   })
 }

--- a/src/store/NoteStore.data.js
+++ b/src/store/NoteStore.data.js
@@ -9,8 +9,7 @@ import {
   getArchivedSubjectIds,
   getArchivedSubjectTree,
 } from '../services/sqlite/subjects.js'
-import { DatabaseError } from '../services/sqlite/errors.js'
-import { emitStoreError, runStoreAction } from './NoteStore.errors.js'
+import { runStoreAction } from './NoteStore.errors.js'
 import { getFilteredNotes as applyFilters } from './noteFilters.ts'
 import { state, notify } from './NoteStore.state.js'
 
@@ -89,22 +88,12 @@ export async function updateNote(id, changes) {
  * ya fue actualizado manualmente y un re-render causaría ghost clicks.
  */
 export async function updateNoteSilent(id, changes) {
-  try {
+  return runStoreAction('updateNoteSilent', 'No se pudo actualizar la nota.', async () => {
     const updatedNote = await NoteService.updateNote(id, changes)
     state.notes = state.notes.map(note => note.id === id ? updatedNote : note)
     // NO notify() — el DOM ya refleja el cambio
     return updatedNote
-  } catch (error) {
-    console.error('[NoteStore] updateNoteSilent failed:', error)
-    if (error instanceof DatabaseError) {
-      emitStoreError({
-        operation: 'updateNoteSilent',
-        message: 'No se pudo actualizar la nota.',
-        cause: error,
-      })
-    }
-    throw error
-  }
+  })
 }
 
 export async function moveNote(noteId, subjectId) {

--- a/src/store/NoteStore.errors.js
+++ b/src/store/NoteStore.errors.js
@@ -37,15 +37,12 @@ export async function runStoreAction(operation, errorMessage, action) {
   try {
     return await action()
   } catch (error) {
-    console.error(`[NoteStore] ${operation} failed:`, error)
-
     if (error instanceof DatabaseError) {
       emitStoreError({
         operation,
         message: errorMessage,
         cause: error,
       })
-      return undefined
     }
 
     throw error

--- a/src/store/NoteStore.ui.js
+++ b/src/store/NoteStore.ui.js
@@ -4,6 +4,7 @@
 
 import * as NoteService from '../services/sqlite/notes.js'
 import { loadArchivedSubjects } from './NoteStore.data.js'
+import { runStoreAction } from './NoteStore.errors.js'
 import { state, notify } from './NoteStore.state.js'
 
 export function selectNote(id) {
@@ -16,24 +17,28 @@ export function selectNote(id) {
 export async function togglePin(id) {
   const note = state.notes.find(n => n.id === id)
   if (!note) return
-  
-  const updatedNote = await NoteService.updateNote(id, { pinned: !note.pinned })
-  state.notes = state.notes.map(n => n.id === id ? updatedNote : n)
-  notify()
+
+  return runStoreAction('togglePin', 'No se pudo cambiar el pin de la nota. Intenta de nuevo.', async () => {
+    const updatedNote = await NoteService.updateNote(id, { pinned: !note.pinned })
+    state.notes = state.notes.map(n => n.id === id ? updatedNote : n)
+    notify()
+  })
 }
 
 export async function toggleArchive(id) {
   const note = state.notes.find(n => n.id === id)
   if (!note) return
-  
-  const updatedNote = await NoteService.updateNote(id, { archived: !note.archived })
-  state.notes = state.notes.map(n => n.id === id ? updatedNote : n)
-  
-  if (state.activeNoteId === id && updatedNote.archived) {
-    state.activeNoteId = null
-  }
-  
-  notify()
+
+  return runStoreAction('toggleArchive', 'No se pudo archivar la nota. Intenta de nuevo.', async () => {
+    const updatedNote = await NoteService.updateNote(id, { archived: !note.archived })
+    state.notes = state.notes.map(n => n.id === id ? updatedNote : n)
+
+    if (state.activeNoteId === id && updatedNote.archived) {
+      state.activeNoteId = null
+    }
+
+    notify()
+  })
 }
 
 /**
@@ -46,12 +51,14 @@ export async function toggleArchive(id) {
 export async function setNoteStatus(id, emoji) {
   const note = state.notes.find(n => n.id === id)
   if (!note) return
-  
+
   // Toggle: si ya tiene el mismo emoji, lo quitamos
   const newEmoji = note.statusEmoji === emoji ? null : emoji
-  const updatedNote = await NoteService.updateNote(id, { statusEmoji: newEmoji })
-  state.notes = state.notes.map(n => n.id === id ? updatedNote : n)
-  notify()
+  return runStoreAction('setNoteStatus', 'No se pudo cambiar el estado de la nota. Intenta de nuevo.', async () => {
+    const updatedNote = await NoteService.updateNote(id, { statusEmoji: newEmoji })
+    state.notes = state.notes.map(n => n.id === id ? updatedNote : n)
+    notify()
+  })
 }
 
 export async function setShowArchived(show) {

--- a/src/store/NoteStore.ui.js
+++ b/src/store/NoteStore.ui.js
@@ -63,8 +63,8 @@ export async function setNoteStatus(id, emoji) {
 
 export async function setShowArchived(show) {
   if (show) {
-    state.viewMode = 'archived'
     await loadArchivedSubjects()
+    state.viewMode = 'archived'
   } else {
     state.viewMode = state.activeSubjectId ? 'subject' : 'inbox'
   }

--- a/tests/unit/components/academic-events/AcademicEventActions.test.js
+++ b/tests/unit/components/academic-events/AcademicEventActions.test.js
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DatabaseError } from '../../../../src/services/sqlite/errors.js'
+import { bindAcademicEventActions } from '../../../../src/components/academic-events/AcademicEventActions.js'
+import * as NoteStore from '../../../../src/store/NoteStore.js'
+import { confirmDialog } from '../../../../src/components/common/ConfirmDialog.js'
+
+vi.mock('../../../../src/store/NoteStore.js', () => ({
+  deleteAcademicEvent: vi.fn(),
+}))
+
+vi.mock('../../../../src/components/common/ConfirmDialog.js', () => ({
+  confirmDialog: vi.fn(),
+}))
+
+vi.mock('../../../../src/components/academic-events/AcademicEventDialog.js', () => ({
+  openAcademicEventDialog: vi.fn(),
+}))
+
+function bindDeleteAction() {
+  const container = document.createElement('div')
+  container.innerHTML = `
+    <button
+      class="js-academic-event-action"
+      data-event-action="delete"
+      data-event-id="event-1"
+    >Eliminar</button>
+  `
+  document.body.appendChild(container)
+  bindAcademicEventActions(container, () => ({ id: 'event-1', title: 'Parcial' }))
+  return container.querySelector('button')
+}
+
+async function settleAction() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await new Promise(resolve => window.setTimeout(resolve, 0))
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+  vi.clearAllMocks()
+  confirmDialog.mockResolvedValue(true)
+  NoteStore.deleteAcademicEvent.mockResolvedValue(undefined)
+})
+
+describe('AcademicEventActions mutation boundary', () => {
+  it('espera y completa una eliminación confirmada', async () => {
+    bindDeleteAction().click()
+    await settleAction()
+
+    expect(NoteStore.deleteAcademicEvent).toHaveBeenCalledWith('event-1')
+  })
+
+  it('consume DatabaseError sin duplicar el registro global', async () => {
+    const warningSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    NoteStore.deleteAcademicEvent.mockRejectedValueOnce(
+      new DatabaseError('deleteAcademicEvent', new Error('boom')),
+    )
+
+    bindDeleteAction().click()
+    await settleAction()
+
+    expect(warningSpy).not.toHaveBeenCalled()
+    warningSpy.mockRestore()
+  })
+
+  it('registra una sola vez un error no SQLite', async () => {
+    const warningSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const error = new Error('boom')
+    NoteStore.deleteAcademicEvent.mockRejectedValueOnce(error)
+
+    bindDeleteAction().click()
+    await settleAction()
+
+    expect(warningSpy).toHaveBeenCalledTimes(1)
+    expect(warningSpy).toHaveBeenCalledWith(
+      '[AcademicEventActions] No se pudo ejecutar la accion:',
+      error,
+    )
+    warningSpy.mockRestore()
+  })
+})

--- a/tests/unit/components/academic-events/AcademicEventDialog.test.js
+++ b/tests/unit/components/academic-events/AcademicEventDialog.test.js
@@ -249,6 +249,27 @@ describe('AcademicEventDialog', () => {
     expect(document.querySelector('.academic-event-dialog-backdrop')).toBeNull()
   })
 
+  it('mantiene el diálogo reintentable sin feedback inline duplicado ante DatabaseError', async () => {
+    const { DatabaseError } = await import('../../../../src/services/sqlite/errors.js')
+    const error = new DatabaseError('createAcademicEvent', new Error('boom'))
+    storeMock.createAcademicEvent.mockRejectedValueOnce(error)
+    const promise = openAcademicEventDialog({ date: '2026-06-14' })
+
+    await submitDialog()
+    await Promise.resolve()
+
+    const saveBtn = document.querySelector('.academic-event-dialog__btn--save')
+    const errorMessage = document.querySelector('.academic-event-dialog__error')
+    expect(document.querySelector('.academic-event-dialog-backdrop')).not.toBeNull()
+    expect(errorMessage.hidden).toBe(true)
+    expect(saveBtn.disabled).toBe(false)
+    expect(saveBtn.textContent).toBe('Guardar')
+
+    document.querySelector('.academic-event-dialog__btn--cancel').click()
+    await finishAnimation()
+    await expect(promise).resolves.toBeNull()
+  })
+
   it('edita una fecha existente sin cambiar de contrato de store', async () => {
     const original = event({
       id: 'event-7',

--- a/tests/unit/components/common/storeActionErrors.test.js
+++ b/tests/unit/components/common/storeActionErrors.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+import { handleStoreMutationError } from '../../../../src/components/common/storeActionErrors.js'
+import { DatabaseError } from '../../../../src/services/sqlite/errors.js'
+
+describe('storeActionErrors', () => {
+  it('no duplica feedback para un DatabaseError ya emitido por el store', () => {
+    const onUnexpected = vi.fn()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    handleStoreMutationError(new DatabaseError('updateNote', new Error('boom')), {
+      context: 'TestBoundary',
+      onUnexpected,
+    })
+
+    expect(onUnexpected).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
+  it('entrega un error no SQLite una sola vez al límite responsable', () => {
+    const onUnexpected = vi.fn()
+    const error = new Error('boom')
+
+    handleStoreMutationError(error, { onUnexpected })
+
+    expect(onUnexpected).toHaveBeenCalledTimes(1)
+    expect(onUnexpected).toHaveBeenCalledWith(error)
+  })
+
+  it('registra una vez un error inesperado cuando no hay callback contextual', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const error = new Error('boom')
+
+    handleStoreMutationError(error, { context: 'TestBoundary' })
+
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[TestBoundary] Error inesperado en mutación del store:',
+      error,
+    )
+    errorSpy.mockRestore()
+  })
+})

--- a/tests/unit/components/feed/FeedActionRouter.test.js
+++ b/tests/unit/components/feed/FeedActionRouter.test.js
@@ -1,14 +1,29 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as NoteStore from '../../../../src/store/NoteStore.js'
 import { createFeedActionRouter } from '../../../../src/components/feed/FeedActionRouter.js'
+import { DatabaseError } from '../../../../src/services/sqlite/errors.js'
+import { confirmDialog } from '../../../../src/components/common/ConfirmDialog.js'
 
 vi.mock('../../../../src/store/NoteStore.js', () => ({
   getState: vi.fn(),
   updateNoteSilent: vi.fn(),
+  emptyTrash: vi.fn(),
+  restoreNoteFromTrash: vi.fn(),
+  permanentlyDeleteNote: vi.fn(),
+  restoreSubjectFromTrash: vi.fn(),
+  restoreSectionFromTrash: vi.fn(),
+  togglePin: vi.fn(),
+  toggleArchive: vi.fn(),
+  moveNote: vi.fn(),
+  setNoteStatus: vi.fn(),
 }))
 
 vi.mock('../../../../src/components/feed/TrashView.js', () => ({
   renderTrashView: vi.fn(),
+}))
+
+vi.mock('../../../../src/components/common/ConfirmDialog.js', () => ({
+  confirmDialog: vi.fn(),
 }))
 
 function createDeps(overrides = {}) {
@@ -49,6 +64,22 @@ function waitForCheckboxPaint() {
   return new Promise(resolve => window.setTimeout(resolve, 0))
 }
 
+async function settleAction() {
+  await Promise.resolve()
+  await waitForCheckboxPaint()
+}
+
+function dispatchAction(className, attributes = '', overrides = {}) {
+  const deps = createDeps(overrides)
+  const feed = document.createElement('div')
+  feed.innerHTML = `<button class="${className}" ${attributes}>Acción</button>`
+  const button = feed.querySelector('button')
+  feed.addEventListener('click', createFeedActionRouter(deps))
+  document.body.appendChild(feed)
+  button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+  return { button, deps, feed }
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   NoteStore.getState.mockReturnValue({
@@ -58,6 +89,16 @@ beforeEach(() => {
     }],
   })
   NoteStore.updateNoteSilent.mockResolvedValue(undefined)
+  NoteStore.emptyTrash.mockResolvedValue(undefined)
+  NoteStore.restoreNoteFromTrash.mockResolvedValue(undefined)
+  NoteStore.permanentlyDeleteNote.mockResolvedValue(undefined)
+  NoteStore.restoreSubjectFromTrash.mockResolvedValue(undefined)
+  NoteStore.restoreSectionFromTrash.mockResolvedValue(undefined)
+  NoteStore.togglePin.mockResolvedValue(undefined)
+  NoteStore.toggleArchive.mockResolvedValue(undefined)
+  NoteStore.moveNote.mockResolvedValue(undefined)
+  NoteStore.setNoteStatus.mockResolvedValue(undefined)
+  confirmDialog.mockResolvedValue(true)
 })
 
 describe('FeedActionRouter dropdown actions', () => {
@@ -73,6 +114,105 @@ describe('FeedActionRouter dropdown actions', () => {
 
     expect(deps.closeAllDropdowns).not.toHaveBeenCalled()
     expect(deps.onCopy).toHaveBeenCalledWith(button)
+  })
+
+  it.each([
+    ['pin', 'js-btn-pin', 'data-id="note-1"', 'togglePin'],
+    ['archive', 'js-btn-archive', 'data-id="note-1"', 'toggleArchive'],
+    ['move', 'js-btn-move-to', 'data-note-id="note-1" data-subject-id="subj-1"', 'moveNote'],
+    ['status', 'js-btn-status', 'data-note-id="note-1" data-emoji="✅"', 'setNoteStatus'],
+  ])('cierra el menú de %s solo después de una mutación exitosa', async (_name, className, attributes, method) => {
+    const { deps } = dispatchAction(className, attributes)
+
+    expect(deps.closeAllDropdowns).not.toHaveBeenCalled()
+    await settleAction()
+
+    expect(NoteStore[method]).toHaveBeenCalledTimes(1)
+    expect(deps.closeAllDropdowns).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    ['pin', 'js-btn-pin', 'data-id="note-1"', 'togglePin'],
+    ['archive', 'js-btn-archive', 'data-id="note-1"', 'toggleArchive'],
+    ['move', 'js-btn-move-to', 'data-note-id="note-1" data-subject-id="subj-1"', 'moveNote'],
+    ['status', 'js-btn-status', 'data-note-id="note-1" data-emoji="✅"', 'setNoteStatus'],
+  ])('consume el rechazo de %s sin cerrar el menú', async (_name, className, attributes, method) => {
+    const error = new Error('boom')
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    NoteStore[method].mockRejectedValueOnce(error)
+
+    const { deps } = dispatchAction(className, attributes)
+    await settleAction()
+
+    expect(deps.closeAllDropdowns).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[FeedActionRouter] Error inesperado en mutación del store:',
+      error,
+    )
+    errorSpy.mockRestore()
+  })
+
+  it('no registra nuevamente un DatabaseError ya emitido por el store', async () => {
+    const error = new DatabaseError('updateNote', new Error('boom'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    NoteStore.togglePin.mockRejectedValueOnce(error)
+
+    const { deps } = dispatchAction('js-btn-pin', 'data-id="note-1"')
+    await settleAction()
+
+    expect(deps.closeAllDropdowns).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+})
+
+describe('FeedActionRouter trash actions', () => {
+  it.each([
+    ['note', 'js-btn-restore', 'restoreNoteFromTrash'],
+    ['subject', 'js-btn-restore-subject', 'restoreSubjectFromTrash'],
+    ['section', 'js-btn-restore-section', 'restoreSectionFromTrash'],
+  ])('refresca después de restaurar %s con éxito', async (_name, className, method) => {
+    const refreshTrash = vi.fn()
+    dispatchAction(className, 'data-id="trash-id"', { refreshTrash })
+
+    await settleAction()
+
+    expect(NoteStore[method]).toHaveBeenCalledWith('trash-id')
+    expect(refreshTrash).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    ['note', 'js-btn-restore', 'restoreNoteFromTrash'],
+    ['subject', 'js-btn-restore-subject', 'restoreSubjectFromTrash'],
+    ['section', 'js-btn-restore-section', 'restoreSectionFromTrash'],
+  ])('no refresca si falla la restauración de %s', async (_name, className, method) => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const refreshTrash = vi.fn()
+    NoteStore[method].mockRejectedValueOnce(new Error('boom'))
+
+    dispatchAction(className, 'data-id="trash-id"', { refreshTrash })
+    await settleAction()
+
+    expect(refreshTrash).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    errorSpy.mockRestore()
+  })
+
+  it.each([
+    ['vaciar', 'js-btn-empty-trash', '', 'emptyTrash'],
+    ['borrar definitivamente', 'js-btn-permanent-delete', 'data-id="trash-id"', 'permanentlyDeleteNote'],
+  ])('no refresca al %s si la mutación rechaza', async (_name, className, attributes, method) => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const refreshTrash = vi.fn()
+    NoteStore[method].mockRejectedValueOnce(new Error('boom'))
+
+    dispatchAction(className, attributes, { refreshTrash })
+    await settleAction()
+
+    expect(refreshTrash).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    errorSpy.mockRestore()
   })
 })
 
@@ -129,7 +269,26 @@ describe('FeedActionRouter task checkboxes', () => {
 
     expect(checkbox.checked).toBe(false)
     expect(checkbox.disabled).toBe(false)
-    expect(errorSpy).toHaveBeenCalledWith('[FeedActionRouter] No se pudo actualizar checkbox:', error)
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[FeedActionRouter] Error inesperado en mutación del store:',
+      error,
+    )
+    errorSpy.mockRestore()
+  })
+
+  it('revierte un DatabaseError sin duplicar su registro global', async () => {
+    const error = new DatabaseError('updateNote', new Error('boom'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    NoteStore.updateNoteSilent.mockRejectedValueOnce(error)
+    const { checkbox } = renderCheckbox({ line: 1 })
+
+    clickCheckbox(checkbox)
+    await waitForCheckboxPaint()
+    await waitForCheckboxPaint()
+
+    expect(checkbox.checked).toBe(false)
+    expect(checkbox.disabled).toBe(false)
+    expect(errorSpy).not.toHaveBeenCalled()
     errorSpy.mockRestore()
   })
 })

--- a/tests/unit/components/note-editor/NoteEditor.test.js
+++ b/tests/unit/components/note-editor/NoteEditor.test.js
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DatabaseError } from '../../../../src/services/sqlite/errors.js'
 
 vi.mock('../../../../src/store/NoteStore.js', () => ({
   subscribe: vi.fn(() => vi.fn()),
@@ -732,6 +733,33 @@ describe('NoteEditor draft cleanup on save', () => {
     expect(input.value).toBe('Apuntes recuperables')
     expect(editor.container.querySelector('#composer-draft-actions').hidden).toBe(false)
 
+    editor.destroy()
+  })
+
+  it('el listener DOM consume el rechazo SQLite y restaura el editor sin feedback duplicado', async () => {
+    const editor = createEditor()
+    const input = editor.container.querySelector('#composer-input')
+    const saveBtn = editor.container.querySelector('#btn-save-note')
+    const error = new DatabaseError('createNote', new Error('boom'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    NoteStore.createNote.mockRejectedValueOnce(error)
+
+    input.value = 'Apuntes recuperables'
+    input.dispatchEvent(new window.Event('input'))
+    editor.enterFocusMode()
+
+    saveBtn.click()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(EditorDraftService.clearDraft).not.toHaveBeenCalled()
+    expect(input.value).toBe('Apuntes recuperables')
+    expect(saveBtn.textContent).toBe('Guardar')
+    expect(saveBtn.disabled).toBe(false)
+    expect(editor.container.querySelector('.composer').classList.contains('composer--focus')).toBe(true)
+    expect(errorSpy).not.toHaveBeenCalled()
+
+    errorSpy.mockRestore()
     editor.destroy()
   })
 

--- a/tests/unit/layout/drawerSubjects.test.js
+++ b/tests/unit/layout/drawerSubjects.test.js
@@ -4,6 +4,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { initSubjects } from '../../../src/layout/drawerSubjects.js'
 import { DRAWER_SUBJECT_COLLAPSE_STORAGE_KEY } from '../../../src/layout/drawerSubjectCollapseState.js'
+import { showErrorToast } from '../../../src/components/common/Toast.js'
+import { DatabaseError } from '../../../src/services/sqlite/errors.js'
+
+vi.mock('../../../src/components/common/Toast.js', () => ({
+  showErrorToast: vi.fn(),
+}))
 
 const SUBJECT_COLORS = ['#818cf8', '#22c55e']
 const ADVERSARIAL_SUBJECT_ID = 'subject-id"] # odd[data-injected="true'
@@ -77,6 +83,8 @@ function setupSubjectsDrawer({ stateOverrides = {}, subjectsData = makeSubjectsD
     archiveSection: vi.fn().mockResolvedValue(undefined),
     deleteSubject: vi.fn().mockResolvedValue(undefined),
     deleteSection: vi.fn().mockResolvedValue(undefined),
+    unarchiveSubject: vi.fn().mockResolvedValue(undefined),
+    unarchiveSection: vi.fn().mockResolvedValue(undefined),
   }
   const closeDrawer = vi.fn()
   const resetArchived = vi.fn()
@@ -106,6 +114,43 @@ function getStoredCollapsedIds() {
 
 beforeEach(() => {
   localStorage.clear()
+  vi.clearAllMocks()
+})
+
+describe('drawerSubjects mutation failures', () => {
+  it('mantiene el formulario y no duplica el toast ante DatabaseError', async () => {
+    const { NoteStore } = setupSubjectsDrawer()
+    const form = document.getElementById('subject-form-container')
+    const input = document.getElementById('subject-name-input')
+    NoteStore.createSubject.mockRejectedValueOnce(
+      new DatabaseError('createSubject', new Error('boom')),
+    )
+
+    document.getElementById('btn-add-subject').click()
+    input.value = 'Materia pendiente'
+    document.getElementById('btn-subject-save').click()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(form.style.display).toBe('block')
+    expect(input.value).toBe('Materia pendiente')
+    expect(showErrorToast).not.toHaveBeenCalled()
+  })
+
+  it('presenta una sola vez un error no SQLite en el límite del drawer', async () => {
+    const { NoteStore } = setupSubjectsDrawer()
+    const error = new Error('fallo inesperado')
+    NoteStore.createSubject.mockRejectedValueOnce(error)
+
+    document.getElementById('btn-add-subject').click()
+    document.getElementById('subject-name-input').value = 'Materia pendiente'
+    document.getElementById('btn-subject-save').click()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(showErrorToast).toHaveBeenCalledTimes(1)
+    expect(showErrorToast).toHaveBeenCalledWith('fallo inesperado')
+  })
 })
 
 describe('drawerSubjects collapse', () => {

--- a/tests/unit/store/NoteStore.academicEvents.test.js
+++ b/tests/unit/store/NoteStore.academicEvents.test.js
@@ -158,23 +158,31 @@ describe('NoteStore.academicEvents', () => {
       expect(state.academicEventsForMonth).toEqual([])
     })
 
-    it('emite error de store y retorna undefined ante DatabaseError', async () => {
+    it('emite una vez, rechaza y conserva caches ante DatabaseError', async () => {
       const storeError = vi.fn()
       const unsubscribe = subscribeToStoreErrors(storeError)
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const { listener, unsubscribe: unsubscribeNotify } = listenForNotify()
       const error = new DatabaseError('createAcademicEvent', new Error('boom'))
+      const existing = event({ id: 'existing' })
+      state.academicEvents = [existing]
+      state.academicEventsForMonth = [existing]
+      state.upcomingAcademicEvents = [existing]
       AcademicEventService.createAcademicEvent.mockRejectedValue(error)
 
-      await expect(NoteStoreAcademicEvents.createAcademicEvent({})).resolves.toBeUndefined()
+      await expect(NoteStoreAcademicEvents.createAcademicEvent({})).rejects.toBe(error)
 
+      expect(storeError).toHaveBeenCalledTimes(1)
       expect(storeError).toHaveBeenCalledWith({
         operation: 'createAcademicEvent',
         message: 'No se pudo crear la fecha academica. Intenta de nuevo.',
         cause: error,
       })
-      expect(state.academicEvents).toEqual([])
+      expect(state.academicEvents).toEqual([existing])
+      expect(state.academicEventsForMonth).toEqual([existing])
+      expect(state.upcomingAcademicEvents).toEqual([existing])
+      expect(listener).not.toHaveBeenCalled()
       unsubscribe()
-      errorSpy.mockRestore()
+      unsubscribeNotify()
     })
   })
 

--- a/tests/unit/store/NoteStore.data.test.js
+++ b/tests/unit/store/NoteStore.data.test.js
@@ -205,23 +205,32 @@ describe('NoteStore.data', () => {
       expect(NoteService.createNote).toHaveBeenCalledWith('Sin título', '# ', null)
     })
 
-    it('emite error de store y retorna undefined ante DatabaseError', async () => {
+    it('emite una vez, rechaza y no cambia estado ante DatabaseError', async () => {
       const storeError = vi.fn()
       const unsubscribe = subscribeToStoreErrors(storeError)
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const { listener, unsubscribe: unsubscribeNotify } = listenForNotify()
       const error = new DatabaseError('createNote', new Error('boom'))
+      const existingNote = makeNote({ id: 'existing' })
+      state.notes = [existingNote]
+      state.searchQuery = 'pendiente'
+      state.dateFilter = '2026-09-03'
       NoteService.createNote.mockRejectedValueOnce(error)
 
-      await expect(NoteStoreData.createNote('T', 'C')).resolves.toBeUndefined()
+      await expect(NoteStoreData.createNote('T', 'C')).rejects.toBe(error)
 
+      expect(storeError).toHaveBeenCalledTimes(1)
       expect(storeError).toHaveBeenCalledWith({
         operation: 'createNote',
         message: 'No se pudo crear la nota. Intenta de nuevo.',
         cause: error,
       })
+      expect(state.notes).toEqual([existingNote])
+      expect(state.searchQuery).toBe('pendiente')
+      expect(state.dateFilter).toBe('2026-09-03')
+      expect(listener).not.toHaveBeenCalled()
 
       unsubscribe()
-      errorSpy.mockRestore()
+      unsubscribeNotify()
     })
   })
 
@@ -259,6 +268,30 @@ describe('NoteStore.data', () => {
 
       expect(listener).toHaveBeenCalledWith(state)
       unsubscribe()
+    })
+
+    it('rechaza y conserva la nota sin notify ante DatabaseError', async () => {
+      const originalNote = makeNote({ id: 'note-1', title: 'Vieja' })
+      const error = new DatabaseError('updateNote', new Error('boom'))
+      const storeError = vi.fn()
+      const unsubscribeError = subscribeToStoreErrors(storeError)
+      const { listener, unsubscribe: unsubscribeNotify } = listenForNotify()
+      state.notes = [originalNote]
+      NoteService.updateNote.mockRejectedValueOnce(error)
+
+      await expect(NoteStoreData.updateNote('note-1', { title: 'Nueva' })).rejects.toBe(error)
+
+      expect(state.notes).toEqual([originalNote])
+      expect(listener).not.toHaveBeenCalled()
+      expect(storeError).toHaveBeenCalledTimes(1)
+      expect(storeError).toHaveBeenCalledWith({
+        operation: 'updateNote',
+        message: 'No se pudo actualizar la nota. Intenta de nuevo.',
+        cause: error,
+      })
+
+      unsubscribeError()
+      unsubscribeNotify()
     })
   })
 
@@ -300,24 +333,28 @@ describe('NoteStore.data', () => {
     })
 
     it('rechaza la promesa si falla la persistencia para permitir rollback visual', async () => {
+      const originalNote = makeNote({ id: 'note-1', title: 'Vieja' })
       const error = new DatabaseError('updateNote', new Error('boom'))
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const { listener, unsubscribe } = listenForNotify()
+      state.notes = [originalNote]
       NoteService.updateNote.mockRejectedValueOnce(error)
 
       await expect(NoteStoreData.updateNoteSilent('note-1', { title: 'Nueva' })).rejects.toBe(error)
 
-      errorSpy.mockRestore()
+      expect(state.notes).toEqual([originalNote])
+      expect(listener).not.toHaveBeenCalled()
+      unsubscribe()
     })
 
     it('emite error de store si falla con DatabaseError', async () => {
       const storeError = vi.fn()
       const unsubscribe = subscribeToStoreErrors(storeError)
       const error = new DatabaseError('updateNote', new Error('boom'))
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       NoteService.updateNote.mockRejectedValueOnce(error)
 
       await expect(NoteStoreData.updateNoteSilent('note-1', { title: 'Nueva' })).rejects.toBe(error)
 
+      expect(storeError).toHaveBeenCalledTimes(1)
       expect(storeError).toHaveBeenCalledWith({
         operation: 'updateNoteSilent',
         message: 'No se pudo actualizar la nota.',
@@ -325,7 +362,6 @@ describe('NoteStore.data', () => {
       })
 
       unsubscribe()
-      errorSpy.mockRestore()
     })
   })
 

--- a/tests/unit/store/NoteStore.errors.test.js
+++ b/tests/unit/store/NoteStore.errors.test.js
@@ -46,16 +46,16 @@ describe('NoteStore.errors', () => {
     await expect(runStoreAction('ok', 'No importa.', async () => 'resultado')).resolves.toBe('resultado')
   })
 
-  it('runStoreAction emite evento y retorna undefined ante DatabaseError', async () => {
+  it('runStoreAction emite exactamente una vez y rechaza el DatabaseError original', async () => {
     const listener = vi.fn()
     const unsubscribe = subscribeToStoreErrors(listener)
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const error = new DatabaseError('insert', new Error('boom'))
 
     await expect(runStoreAction('createNote', 'No se pudo crear la nota.', async () => {
       throw error
-    })).resolves.toBeUndefined()
+    })).rejects.toBe(error)
 
+    expect(listener).toHaveBeenCalledTimes(1)
     expect(listener).toHaveBeenCalledWith({
       operation: 'createNote',
       message: 'No se pudo crear la nota.',
@@ -63,13 +63,11 @@ describe('NoteStore.errors', () => {
     })
 
     unsubscribe()
-    errorSpy.mockRestore()
   })
 
   it('runStoreAction relanza errores que no son de base de datos', async () => {
     const listener = vi.fn()
     const unsubscribe = subscribeToStoreErrors(listener)
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const error = new Error('boom')
 
     await expect(runStoreAction('createNote', 'No se pudo crear la nota.', async () => {
@@ -79,6 +77,5 @@ describe('NoteStore.errors', () => {
     expect(listener).not.toHaveBeenCalled()
 
     unsubscribe()
-    errorSpy.mockRestore()
   })
 })

--- a/tests/unit/store/NoteStore.ui.test.js
+++ b/tests/unit/store/NoteStore.ui.test.js
@@ -363,6 +363,18 @@ describe('NoteStore.ui', () => {
       expect(NoteStoreData.loadArchivedSubjects).toHaveBeenCalled()
     })
 
+    it('conserva la vista actual si falla la carga de archivadas', async () => {
+      const error = new DatabaseError('getArchivedSubjectTree', new Error('boom'))
+      state.viewMode = 'subject'
+      state.activeSubjectId = 'subj-1'
+      NoteStoreData.loadArchivedSubjects.mockRejectedValueOnce(error)
+
+      await expect(NoteStoreUi.setShowArchived(true)).rejects.toBe(error)
+
+      expect(state.viewMode).toBe('subject')
+      expect(state.activeSubjectId).toBe('subj-1')
+    })
+
     it('con false vuelve a subject si hay activeSubjectId', async () => {
       state.activeSubjectId = 'subj-1'
 

--- a/tests/unit/store/NoteStore.ui.test.js
+++ b/tests/unit/store/NoteStore.ui.test.js
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as NoteService from '../../../src/services/sqlite/notes.js'
+import { DatabaseError } from '../../../src/services/sqlite/errors.js'
+import { subscribeToStoreErrors } from '../../../src/store/NoteStore.errors.js'
 import { state, subscribe } from '../../../src/store/NoteStore.state.js'
 import * as NoteStoreData from '../../../src/store/NoteStore.data.js'
 import * as NoteStoreUi from '../../../src/store/NoteStore.ui.js'
@@ -115,9 +117,48 @@ describe('NoteStore.ui', () => {
     })
 
     it('no hace nada si la nota no existe en state.notes', async () => {
-      await NoteStoreUi.togglePin('missing')
+      await expect(NoteStoreUi.togglePin('missing')).resolves.toBeUndefined()
 
       expect(NoteService.updateNote).not.toHaveBeenCalled()
+    })
+
+    it('emite una vez, rechaza y no muta ni notifica ante DatabaseError', async () => {
+      const originalNote = makeNote({ id: 'note-1', pinned: false })
+      const error = new DatabaseError('updateNote', new Error('boom'))
+      const storeError = vi.fn()
+      const unsubscribeError = subscribeToStoreErrors(storeError)
+      const listener = vi.fn()
+      const unsubscribeNotify = subscribe(listener)
+      listener.mockClear()
+      state.notes = [originalNote]
+      NoteService.updateNote.mockRejectedValueOnce(error)
+
+      await expect(NoteStoreUi.togglePin('note-1')).rejects.toBe(error)
+
+      expect(state.notes).toEqual([originalNote])
+      expect(listener).not.toHaveBeenCalled()
+      expect(storeError).toHaveBeenCalledTimes(1)
+      expect(storeError).toHaveBeenCalledWith({
+        operation: 'togglePin',
+        message: 'No se pudo cambiar el pin de la nota. Intenta de nuevo.',
+        cause: error,
+      })
+
+      unsubscribeError()
+      unsubscribeNotify()
+    })
+
+    it('rechaza errores no SQLite sin emitir por el canal global', async () => {
+      const error = new Error('unexpected')
+      const storeError = vi.fn()
+      const unsubscribe = subscribeToStoreErrors(storeError)
+      state.notes = [makeNote({ id: 'note-1' })]
+      NoteService.updateNote.mockRejectedValueOnce(error)
+
+      await expect(NoteStoreUi.togglePin('note-1')).rejects.toBe(error)
+
+      expect(storeError).not.toHaveBeenCalled()
+      unsubscribe()
     })
   })
 
@@ -163,6 +204,34 @@ describe('NoteStore.ui', () => {
       expect(listener).toHaveBeenCalledWith(state)
       unsubscribe()
     })
+
+    it('conserva la nota activa y el estado sin notify ante DatabaseError', async () => {
+      const originalNote = makeNote({ id: 'note-1', archived: false })
+      const error = new DatabaseError('updateNote', new Error('boom'))
+      const storeError = vi.fn()
+      const unsubscribeError = subscribeToStoreErrors(storeError)
+      const listener = vi.fn()
+      const unsubscribeNotify = subscribe(listener)
+      listener.mockClear()
+      state.activeNoteId = 'note-1'
+      state.notes = [originalNote]
+      NoteService.updateNote.mockRejectedValueOnce(error)
+
+      await expect(NoteStoreUi.toggleArchive('note-1')).rejects.toBe(error)
+
+      expect(state.notes).toEqual([originalNote])
+      expect(state.activeNoteId).toBe('note-1')
+      expect(listener).not.toHaveBeenCalled()
+      expect(storeError).toHaveBeenCalledTimes(1)
+      expect(storeError).toHaveBeenCalledWith({
+        operation: 'toggleArchive',
+        message: 'No se pudo archivar la nota. Intenta de nuevo.',
+        cause: error,
+      })
+
+      unsubscribeError()
+      unsubscribeNotify()
+    })
   })
 
   describe('setNoteStatus()', () => {
@@ -195,6 +264,32 @@ describe('NoteStore.ui', () => {
 
       expect(listener).toHaveBeenCalledWith(state)
       unsubscribe()
+    })
+
+    it('conserva el estado académico sin notify ante DatabaseError', async () => {
+      const originalNote = makeNote({ id: 'note-1', statusEmoji: null })
+      const error = new DatabaseError('updateNote', new Error('boom'))
+      const storeError = vi.fn()
+      const unsubscribeError = subscribeToStoreErrors(storeError)
+      const listener = vi.fn()
+      const unsubscribeNotify = subscribe(listener)
+      listener.mockClear()
+      state.notes = [originalNote]
+      NoteService.updateNote.mockRejectedValueOnce(error)
+
+      await expect(NoteStoreUi.setNoteStatus('note-1', '✅')).rejects.toBe(error)
+
+      expect(state.notes).toEqual([originalNote])
+      expect(listener).not.toHaveBeenCalled()
+      expect(storeError).toHaveBeenCalledTimes(1)
+      expect(storeError).toHaveBeenCalledWith({
+        operation: 'setNoteStatus',
+        message: 'No se pudo cambiar el estado de la nota. Intenta de nuevo.',
+        cause: error,
+      })
+
+      unsubscribeError()
+      unsubscribeNotify()
     })
   })
 


### PR DESCRIPTION
## Summary

- unifies persistent mutations under a single emit-and-rethrow policy
- updates UI boundaries to consume rejections without false-success flows or duplicate feedback
- preserves drafts, visual state, and successful return contracts
- reduces NoteEditor from 406 to 400 logical LOC without weakening the auditor

## Validation

- `npm run verify` passed on the canonical Mac environment
- 62 test files / 989 tests passed
- 63/63 focused NoteEditor and error-boundary tests passed
- lint: 0 errors; 3 known warnings
- typecheck, build, toolchain, SQLite smoke test, bundle budget, native-dialog, and accessibility checks passed
- full and production npm audits: 0 vulnerabilities
- deployed through the official script to the locally connected Android device while preserving SQLite and version 0.4.8/408
- manual validation passed: note creation and saving work correctly, with no duplicate feedback

## Scope

This PR does not change the schema, transactions, dependencies, version, release, or tag. AUD-005, AUD-006, AUD-008, and AUD-009 remain separate workstreams.