### PR TITLE
fix(sqlite): isolate write ownership and recover startup

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,7 +4,7 @@ Este documento funciona como bandeja viva de tareas, deuda y decisiones pendient
 
 > **Hito activo:** 06 — Entrega Final
 > **Hito 05:** Cerrado documentalmente el 2026-07-15 sobre la beta operativa `v0.4.8`
-> **Última actualización:** 2026-09-03 — AUD-001 a AUD-004 y AUD-007 cerrados técnicamente; AUD-005 es el próximo frente técnico independiente
+> **Última actualización:** 2026-09-04 — AUD-005 implementado en rama; pendiente de validación canónica, Android e integración
 > **Snapshot histórico:** [`docs/gestion/historico/backlog-historico-hito-04-2026-06-01.md`](docs/gestion/historico/backlog-historico-hito-04-2026-06-01.md)
 
 ---
@@ -54,7 +54,8 @@ El análisis detallado permanece en [`docs/gestion/revision-tecnica-priorizada-2
 | AUD-002 | P0 | Guardados duplicados por taps concurrentes | Cerrado en PR #2; single-flight y estado visual validados |
 | AUD-003 | P0 | Frontera y presentación de backups no confiables | Cerrado en PR #3; suite acumulativa y checkpoints Android aprobados |
 | AUD-004 | P0 | Dependencias con advisories de seguridad | Cerrado en PR #5; auditorías 0/0 y Android aprobados |
-| AUD-005–AUD-006 | P1 | Coordinación de persistencia y resultados async obsoletos | Pendientes; AUD-005 es el próximo frente técnico independiente |
+| AUD-005 | P1 | Coordinación SQLite, migraciones y arranque | Implementado en `fix/sqlite-write-coordination`; regresiones automáticas aprobadas, gate canónico y Android pendientes; no integrado. [Evidencia](docs/gestion/analisis-aud-005-coordinacion-sqlite-2026-09-04.md) |
+| AUD-006 | P1 | Resultados async obsoletos | Pendiente; iniciar en rama separada únicamente después de integrar AUD-005 |
 | AUD-007 | P1 | Contratos incompatibles para errores de mutaciones | Cerrado en PR #6; contrato único, consumidores y Android aprobados |
 | AUD-008–AUD-009 | P1 | Portabilidad del gate y Node 26 | Pendientes; abordar sin relajar controles |
 | AUD-010–AUD-013 | P2 | Escalabilidad, rendimiento, cohesión y margen de bundle/coverage | Monitorear o medir; no bloquean por sí solos el cierre actual |
@@ -97,7 +98,7 @@ Estas tareas no bloquean el MVP. Se conservan como decisiones trazables para rea
 | Framework UI | No incorporar Svelte por ahora | Baja | Costo de migracion alto vs beneficio actual; reabrir solo si DOM manual se vuelve una carga clara |
 | Documentación | Congelar documentos antes del corte final | Alta | La reconciliación posterior a AUD-001/002/003 se completó el 2026-09-02; restan evidencia final, revisión de maquetación y el corte elegido |
 | Dependencias | Repetir auditorías en cada corte candidato | Recurrente | AUD-004 quedó cerrado con grafo mínimo, auditorías 0/0 y Android aprobado; revalidar porque los advisories evolucionan |
-| Persistencia y asincronía | Planificar AUD-005–AUD-006 | Alta/Media | AUD-007 quedó cerrado en PR #6; mantener ramas separadas para propiedad transaccional/migraciones y resultados async obsoletos |
+| Persistencia y asincronía | Validar e integrar AUD-005; luego ejecutar AUD-006 | Alta | AUD-005 implementado con ADR-009 y regresiones; faltan gate canónico, Android y autorizaciones. AUD-006 sigue separado y pendiente |
 | Tooling | Resolver portabilidad de gate y Node 26 (AUD-008/AUD-009) | Media | Distinguir falsos positivos CSP del fallback offline y eliminar la dependencia del workaround de Web Storage sin relajar controles |
 | Tooling DB | Ampliar el smoke test a `academic_events` y constraints relevantes | Media | El DDL completo se ejecuta, pero las aserciones explícitas de tablas/columnas/relaciones se concentran en materias, notas y metadata; decidir su ampliación antes de presentar cobertura exhaustiva |
 | Tooling de release | Sincronizar versión Android desde el helper | Alta | `scripts/release-helper.py` actualiza package/changelog, pero no `versionName` ni `versionCode`; corregirlo o agregar un gate explícito antes de generar otra APK |

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,7 +4,7 @@ Este documento funciona como bandeja viva de tareas, deuda y decisiones pendient
 
 > **Hito activo:** 06 — Entrega Final
 > **Hito 05:** Cerrado documentalmente el 2026-07-15 sobre la beta operativa `v0.4.8`
-> **Última actualización:** 2026-09-04 — AUD-005 implementado en rama; pendiente de validación canónica, Android e integración
+> **Última actualización:** 2026-09-04 — AUD-005 cerrado técnicamente; validación canónica y Android aprobadas, integración autorizada
 > **Snapshot histórico:** [`docs/gestion/historico/backlog-historico-hito-04-2026-06-01.md`](docs/gestion/historico/backlog-historico-hito-04-2026-06-01.md)
 
 ---
@@ -15,7 +15,7 @@ Hito 04 quedó cerrado formalmente como bloque de Organización y UX. El cierre 
 
 Hito 05 quedó cerrado documentalmente el 2026-07-15. Entregó el quality gate, APK firmada, validación inicial en Android real y publicación de la beta controlada [`v0.4.8`](https://github.com/jdfesa/lumapse/releases/tag/v0.4.8), junto con mejoras funcionales acotadas: borradores persistentes (`RF-005`), backup manual (`RF-017`), importación ZIP (`RF-018`), Acerca de (`RF-023`), fechas académicas discretas (`RF-027`) y editor enriquecido (`RF-028`). Las observaciones sobre `Mover a` y rendimiento con más notas no bloquearon ese cierre.
 
-Hito 06 queda activo para completar la documentación final, verificar la maquetación de los gráficos de base de datos ya actualizados, repetir la validación sobre un corte congelado y preparar la presentación. La única versión publicada continúa siendo `v0.4.8`; el trabajo posterior al tag ya incluye los cierres técnicos AUD-001 a AUD-004 y AUD-007, pero todavía no constituye una release ni un APK distribuible nuevo. La decisión pendiente debe distinguir entre una beta de corrección `v0.4.9` y el artefacto final de Hito 06, sin renombrar preventivamente el estado actual de `main`.
+Hito 06 queda activo para completar la documentación final, verificar la maquetación de los gráficos de base de datos ya actualizados, repetir la validación sobre un corte congelado y preparar la presentación. La única versión publicada continúa siendo `v0.4.8`; el trabajo posterior al tag ya incluye los cierres técnicos AUD-001 a AUD-005 y AUD-007, pero todavía no constituye una release ni un APK distribuible nuevo. La decisión pendiente debe distinguir entre una beta de corrección `v0.4.9` y el artefacto final de Hito 06, sin renombrar preventivamente el estado actual de `main`.
 
 La revisión técnica priorizada del 2026-09-01 abrió trece hallazgos trazables. AUD-001 y AUD-002 quedaron resueltos mediante PR #2; AUD-003 quedó validado en Android e integrado mediante PR #3; AUD-004 cerró dependencias vulnerables en PR #5. AUD-007 unificó el contrato emit-and-rethrow del store, adaptó los límites UI, aprobó 989 tests, quality gate y Android 0.4.8/408, y se integra mediante PR #6. La validación funcional de 500 notas de AUD-003 no sustituye las mediciones de latencia y rendimiento exigidas por `RNF-002` y `RNF-004`. Los hallazgos restantes mantienen sus prioridades y no se incorporan automáticamente al alcance de Hito 06.
 
@@ -46,7 +46,7 @@ La trazabilidad de `v0.4.8` queda distribuida entre `docs/gestion/lineas-base.md
 
 ## Revisión técnica priorizada — estado vivo
 
-El análisis detallado permanece en [`docs/gestion/revision-tecnica-priorizada-2026-09-01.md`](docs/gestion/revision-tecnica-priorizada-2026-09-01.md). Esta tabla fija el estado operativo después de cerrar AUD-001 a AUD-004 y AUD-007.
+El análisis detallado permanece en [`docs/gestion/revision-tecnica-priorizada-2026-09-01.md`](docs/gestion/revision-tecnica-priorizada-2026-09-01.md). Esta tabla fija el estado operativo después de cerrar AUD-001 a AUD-005 y AUD-007.
 
 | ID | Prioridad | Frente | Estado operativo |
 |---|---|---|---|
@@ -54,7 +54,7 @@ El análisis detallado permanece en [`docs/gestion/revision-tecnica-priorizada-2
 | AUD-002 | P0 | Guardados duplicados por taps concurrentes | Cerrado en PR #2; single-flight y estado visual validados |
 | AUD-003 | P0 | Frontera y presentación de backups no confiables | Cerrado en PR #3; suite acumulativa y checkpoints Android aprobados |
 | AUD-004 | P0 | Dependencias con advisories de seguridad | Cerrado en PR #5; auditorías 0/0 y Android aprobados |
-| AUD-005 | P1 | Coordinación SQLite, migraciones y arranque | Implementado en `fix/sqlite-write-coordination`; regresiones automáticas aprobadas, gate canónico y Android pendientes; no integrado. [Evidencia](docs/gestion/analisis-aud-005-coordinacion-sqlite-2026-09-04.md) |
+| AUD-005 | P1 | Coordinación SQLite, migraciones y arranque | Cerrado técnicamente; 1035 tests, gate canónico y prueba manual Android aprobados; integración autorizada. [Evidencia](docs/gestion/analisis-aud-005-coordinacion-sqlite-2026-09-04.md) |
 | AUD-006 | P1 | Resultados async obsoletos | Pendiente; iniciar en rama separada únicamente después de integrar AUD-005 |
 | AUD-007 | P1 | Contratos incompatibles para errores de mutaciones | Cerrado en PR #6; contrato único, consumidores y Android aprobados |
 | AUD-008–AUD-009 | P1 | Portabilidad del gate y Node 26 | Pendientes; abordar sin relajar controles |
@@ -98,7 +98,7 @@ Estas tareas no bloquean el MVP. Se conservan como decisiones trazables para rea
 | Framework UI | No incorporar Svelte por ahora | Baja | Costo de migracion alto vs beneficio actual; reabrir solo si DOM manual se vuelve una carga clara |
 | Documentación | Congelar documentos antes del corte final | Alta | La reconciliación posterior a AUD-001/002/003 se completó el 2026-09-02; restan evidencia final, revisión de maquetación y el corte elegido |
 | Dependencias | Repetir auditorías en cada corte candidato | Recurrente | AUD-004 quedó cerrado con grafo mínimo, auditorías 0/0 y Android aprobado; revalidar porque los advisories evolucionan |
-| Persistencia y asincronía | Validar e integrar AUD-005; luego ejecutar AUD-006 | Alta | AUD-005 implementado con ADR-009 y regresiones; faltan gate canónico, Android y autorizaciones. AUD-006 sigue separado y pendiente |
+| Persistencia y asincronía | Ejecutar AUD-006 después de integrar AUD-005 | Alta | AUD-005 validado con ADR-009, 1035 tests y aprobación manual Android. AUD-006 sigue separado y pendiente |
 | Tooling | Resolver portabilidad de gate y Node 26 (AUD-008/AUD-009) | Media | Distinguir falsos positivos CSP del fallback offline y eliminar la dependencia del workaround de Web Storage sin relajar controles |
 | Tooling DB | Ampliar el smoke test a `academic_events` y constraints relevantes | Media | El DDL completo se ejecuta, pero las aserciones explícitas de tablas/columnas/relaciones se concentran en materias, notas y metadata; decidir su ampliación antes de presentar cobertura exhaustiva |
 | Tooling de release | Sincronizar versión Android desde el helper | Alta | `scripts/release-helper.py` actualiza package/changelog, pero no `versionName` ni `versionCode`; corregirlo o agregar un gate explícito antes de generar otra APK |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ y este proyecto adhiere a [Conventional Commits](https://www.conventionalcommits
 
 ### Fixed
 
+- **Coordinación SQLite y arranque (AUD-005, pendiente de integración):** Propiedad transaccional explícita y cola compartida con CRUD/lecturas, cascadas sin commits parciales, errores de persistencia web propagados y conexión incierta en cuarentena. Migraciones estrictas e idempotentes y arranque accesible en español con reintento seguro; regresiones automáticas aprobadas, validación canónica y Android pendientes. Contrato documentado en ADR-009.
+
 - **Integridad del guardado (AUD-001):** El editor solo limpia los campos y descarta el borrador tras confirmar la persistencia; ante un fallo conserva contenido, borrador, contexto de edición y modo foco para permitir el reintento.
 - **Guardados concurrentes (AUD-002):** Una protección single-flight serializa el guardado y mantiene un estado visual mientras la operación está pendiente, evitando mutaciones duplicadas o fuera de orden por taps repetidos.
 - **Descarte de borrador distinguible:** La acción destructiva de descartar quedó diferenciada visualmente del guardado y cubierta por una regresión de presentación.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ y este proyecto adhiere a [Conventional Commits](https://www.conventionalcommits
 
 ## [Unreleased] — Trabajo posterior a `v0.4.8`
 
-> `main` conserva la versión declarada `0.4.8`, pero contiene trabajo posterior al tag. No existe una release `0.4.9` ni un APK posterior publicado. Este bloque resume el trabajo desde `v0.4.8`, incluidos los cierres técnicos AUD-001 a AUD-004 y AUD-007. Las ejecuciones Android sobre código posterior al tag son evidencia de validación y no constituyen un artefacto publicado.
+> `main` conserva la versión declarada `0.4.8`, pero contiene trabajo posterior al tag. No existe una release `0.4.9` ni un APK posterior publicado. Este bloque resume el trabajo desde `v0.4.8`, incluidos los cierres técnicos AUD-001 a AUD-005 y AUD-007. Las ejecuciones Android sobre código posterior al tag son evidencia de validación y no constituyen un artefacto publicado.
 
 ### Added
 
@@ -41,7 +41,7 @@ y este proyecto adhiere a [Conventional Commits](https://www.conventionalcommits
 
 ### Fixed
 
-- **Coordinación SQLite y arranque (AUD-005, pendiente de integración):** Propiedad transaccional explícita y cola compartida con CRUD/lecturas, cascadas sin commits parciales, errores de persistencia web propagados y conexión incierta en cuarentena. Migraciones estrictas e idempotentes y arranque accesible en español con reintento seguro; regresiones automáticas aprobadas, validación canónica y Android pendientes. Contrato documentado en ADR-009.
+- **Coordinación SQLite y arranque (AUD-005):** Propiedad transaccional explícita y cola compartida con CRUD/lecturas, cascadas sin commits parciales, errores de persistencia web propagados y conexión incierta en cuarentena. Migraciones estrictas e idempotentes y arranque accesible en español con reintento seguro; 1035 tests, gate canónico y funcionamiento general Android aprobados. Contrato documentado en ADR-009; integración autorizada sin nueva release.
 
 - **Integridad del guardado (AUD-001):** El editor solo limpia los campos y descarta el borrador tras confirmar la persistencia; ante un fallo conserva contenido, borrador, contexto de edición y modo foco para permitir el reintento.
 - **Guardados concurrentes (AUD-002):** Una protección single-flight serializa el guardado y mantiene un estado visual mientras la operación está pendiente, evitando mutaciones duplicadas o fuera de orden por taps repetidos.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ lumapse/
 │   ├── scripts/            # Pipeline modular de análisis
 │   └── graficos/           # Gráficos generados (12 archivos)
 ├── docs/                   # Documentación del proyecto
-│   ├── adr/                # Architecture Decision Records (8 ADRs)
+│   ├── adr/                # Architecture Decision Records (9 ADRs)
 │   ├── diagramas/          # Diagramas UML (Mermaid)
 │   ├── gestion/            # Estimación, planificación y control de avance
 │   ├── hitos/              # Informes de avance mensuales

--- a/TODO
+++ b/TODO
@@ -35,6 +35,8 @@
 - [ ] Contrastar los metadatos bibliográficos de Gómez (2014) y Parada (2026) contra los originales de cátedra y cerrar la sección de referencias.
 - [x] Resolver AUD-004 en un PR separado: DOMPurify y siete dependencias de tooling parcheadas, auditorías 0/0, 955 tests, build, quality gate y Android 0.4.8/408 aprobados (2026-09-02).
 - [x] Resolver AUD-007 en PR #6: contrato de errores de mutaciones unificado, límites UI adaptados, 989 tests, quality gate y prueba manual Android aprobados (2026-09-03).
+- [ ] Validar canónicamente y en Android AUD-005 sobre su SHA publicado; implementación y regresiones automáticas listas en `fix/sqlite-write-coordination`, sin PR ni integración todavía. Ver [evidencia](docs/gestion/analisis-aud-005-coordinacion-sqlite-2026-09-04.md).
+- [ ] Después de integrar AUD-005, iniciar AUD-006 en `fix/async-request-ownership` con su propio ciclo de validación y aprobación.
 - [ ] Ejecutar el gate final sobre el commit y artefacto candidatos y guardar la evidencia; el gate acumulativo de AUD-003 y los pre-push documentales no sustituyen este cierre.
 - [ ] Repetir la validación Android sobre el artefacto versionado con un conjunto de datos representativo; el checkpoint de AUD-003 ya cubrió `STORE`, `DEFLATE`, datos inválidos y una fixture de 500 notas.
 - [ ] Verificar específicamente la interacción `Mover a` y clasificar su fricción como corregida, aceptada o bloqueante.

--- a/TODO
+++ b/TODO
@@ -4,11 +4,11 @@
 
 ## Hito actual: 06 — Entrega Final
 
-**Estado:** activo; AUD-001 a AUD-004 y AUD-007 quedaron cerrados técnicamente mediante PR #2, #3, #5 y #6.
+**Estado:** activo; AUD-001 a AUD-005 y AUD-007 quedaron cerrados técnicamente mediante PR #2, #3, #5 y #6 y la validación automática/Android de AUD-005.
 
 **Corte operativo vigente:** beta/candidata [`v0.4.8`](https://github.com/jdfesa/lumapse/releases/tag/v0.4.8), publicada y validada inicialmente en Android real.
 
-**Versión:** `v0.4.8`; el trabajo posterior al tag —incluidos AUD-001 a AUD-004 y AUD-007— permanece no publicado y no existe una release `0.4.9`. La versión del próximo artefacto solo se decidirá después de cerrar sus bloqueos y validaciones.
+**Versión:** `v0.4.8`; el trabajo posterior al tag —incluidos AUD-001 a AUD-005 y AUD-007— permanece no publicado y no existe una release `0.4.9`. La versión del próximo artefacto solo se decidirá después de cerrar sus bloqueos y validaciones.
 
 **Objetivo:** cerrar documentación, gráficos de base de datos, validación final y materiales de presentación sin ampliar el producto.
 
@@ -35,7 +35,7 @@
 - [ ] Contrastar los metadatos bibliográficos de Gómez (2014) y Parada (2026) contra los originales de cátedra y cerrar la sección de referencias.
 - [x] Resolver AUD-004 en un PR separado: DOMPurify y siete dependencias de tooling parcheadas, auditorías 0/0, 955 tests, build, quality gate y Android 0.4.8/408 aprobados (2026-09-02).
 - [x] Resolver AUD-007 en PR #6: contrato de errores de mutaciones unificado, límites UI adaptados, 989 tests, quality gate y prueba manual Android aprobados (2026-09-03).
-- [ ] Validar canónicamente y en Android AUD-005 sobre su SHA publicado; implementación y regresiones automáticas listas en `fix/sqlite-write-coordination`, sin PR ni integración todavía. Ver [evidencia](docs/gestion/analisis-aud-005-coordinacion-sqlite-2026-09-04.md).
+- [x] Validar canónicamente y en Android AUD-005: SHA `0832a75`, 1035 tests, gate y funcionamiento general aprobados; integración autorizada. Ver [evidencia](docs/gestion/analisis-aud-005-coordinacion-sqlite-2026-09-04.md).
 - [ ] Después de integrar AUD-005, iniciar AUD-006 en `fix/async-request-ownership` con su propio ciclo de validación y aprobación.
 - [ ] Ejecutar el gate final sobre el commit y artefacto candidatos y guardar la evidencia; el gate acumulativo de AUD-003 y los pre-push documentales no sustituyen este cierre.
 - [ ] Repetir la validación Android sobre el artefacto versionado con un conjunto de datos representativo; el checkpoint de AUD-003 ya cubrió `STORE`, `DEFLATE`, datos inválidos y una fixture de 500 notas.

--- a/docs/adr/ADR-009-propiedad-transaccional-sqlite.md
+++ b/docs/adr/ADR-009-propiedad-transaccional-sqlite.md
@@ -1,0 +1,73 @@
+# ADR-009: Propiedad transaccional explícita en SQLite
+
+**Fecha:** 2026-09-04  
+**Estado:** Propuesto; implementado en `fix/sqlite-write-coordination`, pendiente de validación Android e integración  
+**Alcance:** AUD-005; complementa ADR-006 y ADR-008 sin cambiar motor, schema final ni plataforma
+
+## Contexto
+
+El contador global `transactionDepth` confundía operaciones async independientes con anidamiento.
+Una escritura CRUD podía incorporarse a una cascada ajena, informar éxito antes de persistir y
+desaparecer con el rollback de otra operación. Una cola aplicada solo a `runTransaction` no cerraba
+esa entrada lateral. `persistWeb` también absorbía errores de almacenamiento.
+
+## Decisión
+
+- Una cola de promesas por conexión serializa transacciones independientes, escrituras CRUD y
+  lecturas externas. Estas últimas no observan cambios sin confirmar de otra operación.
+- `getDb()` expone una fachada limitada a `query` y `run`, nunca el objeto nativo. Cada `run`
+  independiente comprende begin, escritura, commit y persistencia web dentro del mismo turno.
+- `runTransaction(async scope => …)` entrega una capacidad opaca ligada a esa transacción.
+  Para componer, el consumidor pasa `scope` al CRUD, a `getDb(scope)` o como segundo argumento de
+  `runTransaction(action, scope)`. Las cascadas de materias aceptan `parentScope` opcional.
+- Sin capacidad, la operación es independiente: no se infiere propiedad por tiempo, contador,
+  pila síncrona ni estado global. Todos los consumidores actuales se adaptan explícitamente.
+- Las operaciones internas deben esperarse con `await`; sus resultados son provisionales hasta
+  que resuelva la propietaria. No hay commits internos. Un fallo interno, incluso capturado por
+  el callback, impide confirmar parcialmente. Las capacidades expiran al terminar el callback.
+- El resultado externo solo resuelve después de commit y `saveToStore` en web. El coordinador
+  conserva la excepción original; el CRUD mantiene su `DatabaseError` con `originalError`, sin
+  modificar el contrato emit-and-rethrow ni el canal de feedback de AUD-007.
+- Un rollback exitoso tras un fallo de escritura libera la cola. Un fallo de begin, commit,
+  rollback o persistencia pone la conexión en cuarentena: las operaciones pendientes rechazan
+  y no reutilizan silenciosamente ese estado.
+- La recuperación ocurre mediante `initDatabase`, single-flight. Antes de cerrar/reabrir,
+  comprueba si la base está abierta y si hay una transacción; revierte y verifica su fin.
+  Un estado no comprobable bloquea la recuperación. Esto es importante porque `jeep-sqlite`
+  persiste al cerrar. No se elimina ni se recrea la base de usuario.
+
+## Migraciones y arranque
+
+Las migraciones consultan `PRAGMA table_info` antes de agregar columnas. La existencia comprobada
+permite omitir el ALTER; cualquier fallo inesperado aborta con nombre de migración y `cause`.
+Los CREATE idempotentes se conservan. El SQL permanece en `connection.js` para los checks de
+schema/DBML; el modelo final no cambia.
+
+La migración legada distingue ausencia comprobada de errores de IndexedDB. Notas y marcador se
+confirman en una sola transacción; un reintento no reemplaza notas SQLite existentes.
+
+`main.js` sigue siendo el composition root: primero prepara persistencia y datos, después monta
+componentes/listeners. Un límite pequeño muestra estado accesible en español y permite reintentar
+la preparación sin montar dos veces. Si falla el montaje síncrono parcial, el botón recarga la
+WebView en lugar de reinstalar listeners en el mismo documento. El mensaje visible no incluye SQL,
+contenidos de notas ni detalles de excepciones.
+
+## Alternativas descartadas
+
+- **Cola únicamente en `runTransaction`:** deja el CRUD externo dentro de la transacción ajena.
+- **Contador/bandera ambiental:** no identifica a un propietario async.
+- **Contexto async exclusivo de Node:** incompatible con WebView/Capacitor.
+- **Conexión por operación o framework de unidad de trabajo:** mayor costo y superficie sin
+  necesidad para esta aplicación local.
+- **Recrear la base o ignorar errores de migración:** amenaza datos o permite iniciar con schema incompleto.
+
+## Consecuencias y verificación
+
+La capacidad debe propagarse explícitamente al componer operaciones. Las lecturas externas pueden
+esperar a una transacción larga; no se introduce batching ni optimización N+1. Un fallo después del
+commit pero antes de persistir tiene resultado incierto: se rechaza y se exige recuperación, nunca
+se promete que la escritura no ocurrió ni se repite automáticamente.
+
+Las regresiones usan promesas controladas y SQLite real en memoria, sin sleeps ni bases personales.
+La evidencia y las pausas de aprobación se registran en el
+[informe de AUD-005](../gestion/analisis-aud-005-coordinacion-sqlite-2026-09-04.md).

--- a/docs/adr/ADR-009-propiedad-transaccional-sqlite.md
+++ b/docs/adr/ADR-009-propiedad-transaccional-sqlite.md
@@ -1,7 +1,8 @@
 # ADR-009: Propiedad transaccional explícita en SQLite
 
 **Fecha:** 2026-09-04  
-**Estado:** Propuesto; implementado en `fix/sqlite-write-coordination`, pendiente de validación Android e integración  
+**Estado:** Aceptado; validación canónica y Android aprobadas, integración autorizada
+
 **Alcance:** AUD-005; complementa ADR-006 y ADR-008 sin cambiar motor, schema final ni plataforma
 
 ## Contexto

--- a/docs/adr/ADR-009-propiedad-transaccional-sqlite.md
+++ b/docs/adr/ADR-009-propiedad-transaccional-sqlite.md
@@ -49,7 +49,9 @@ confirman en una sola transacción; un reintento no reemplaza notas SQLite exist
 `main.js` sigue siendo el composition root: primero prepara persistencia y datos, después monta
 componentes/listeners. Un límite pequeño muestra estado accesible en español y permite reintentar
 la preparación sin montar dos veces. Si falla el montaje síncrono parcial, el botón recarga la
-WebView en lugar de reinstalar listeners en el mismo documento. El mensaje visible no incluye SQL,
+WebView en lugar de reinstalar listeners en el mismo documento. Antes de recargar, espera el cierre
+seguro de SQLite: bloquea operaciones nuevas, drena lo activo y verifica el estado nativo. Si falla,
+conserva el reintento sin recargar. El mensaje visible no incluye SQL,
 contenidos de notas ni detalles de excepciones.
 
 ## Alternativas descartadas

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,7 +14,7 @@ Los ADR conservan decisiones importantes, sus alternativas y consecuencias. Un A
 | [ADR-006](./ADR-006-arquitectura-de-persistencia-y-tooling-sqlite-para-desarrollo-web-y-native.md) | Persistencia SQLite multiplataforma | Aceptado y validado |
 | [ADR-007](./ADR-007-organizacion-componentes-por-feature.md) | Componentes UI organizados por feature | Aceptado |
 | [ADR-008](./ADR-008-arquitectura-modular-y-patrones.md) | Arquitectura modular y patrones aplicados | Aceptado |
-| [ADR-009](./ADR-009-propiedad-transaccional-sqlite.md) | Propiedad transaccional SQLite y recuperación de arranque (AUD-005) | Propuesto; implementado en rama, pendiente de Android e integración |
+| [ADR-009](./ADR-009-propiedad-transaccional-sqlite.md) | Propiedad transaccional SQLite y recuperación de arranque (AUD-005) | Aceptado; validación canónica y Android aprobadas |
 
 ## Decisiones vigentes en una frase
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,6 +14,7 @@ Los ADR conservan decisiones importantes, sus alternativas y consecuencias. Un A
 | [ADR-006](./ADR-006-arquitectura-de-persistencia-y-tooling-sqlite-para-desarrollo-web-y-native.md) | Persistencia SQLite multiplataforma | Aceptado y validado |
 | [ADR-007](./ADR-007-organizacion-componentes-por-feature.md) | Componentes UI organizados por feature | Aceptado |
 | [ADR-008](./ADR-008-arquitectura-modular-y-patrones.md) | Arquitectura modular y patrones aplicados | Aceptado |
+| [ADR-009](./ADR-009-propiedad-transaccional-sqlite.md) | Propiedad transaccional SQLite y recuperación de arranque (AUD-005) | Propuesto; implementado en rama, pendiente de Android e integración |
 
 ## Decisiones vigentes en una frase
 

--- a/docs/gestion/README.md
+++ b/docs/gestion/README.md
@@ -24,6 +24,7 @@ de Gómez (2014).
 | [`analisis-aud-003-seguridad-importacion-backups-2026-09-01.md`](./analisis-aud-003-seguridad-importacion-backups-2026-09-01.md) | Revalidación e implementación de AUD-003: frontera ZIP/JSON, integridad y defensa de presentación | ✅ Cerrado en PR #3 |
 | [`analisis-aud-004-seguridad-dependencias-2026-09-02.md`](./analisis-aud-004-seguridad-dependencias-2026-09-02.md) | Revalidación y cierre de AUD-004: advisories, grafo mínimo, auditorías, gates y Android | ✅ Cerrado en PR #5 |
 | [`analisis-aud-007-contratos-errores-store-2026-09-03.md`](./analisis-aud-007-contratos-errores-store-2026-09-03.md) | Contrato emit-and-rethrow, adaptación de consumidores y evidencia automática/Android de AUD-007 | ✅ Cerrado en PR #6 |
+| [`analisis-aud-005-coordinacion-sqlite-2026-09-04.md`](./analisis-aud-005-coordinacion-sqlite-2026-09-04.md) | Propiedad SQLite explícita, migraciones estrictas y arranque recuperable | 🔄 Implementado en rama; validación canónica y Android pendientes |
 | [`historico/`](./historico/) | Snapshots operativos cerrados preservados como evidencia de proceso | 📦 Archivo |
 
 ---

--- a/docs/gestion/README.md
+++ b/docs/gestion/README.md
@@ -20,11 +20,11 @@ de Gómez (2014).
 | [`cheatsheet-defensa.md`](./cheatsheet-defensa.md) | Métricas, decisiones y respuestas breves para la defensa | 🔄 Revisión final pendiente |
 | [`firma-apk-android.md`](./firma-apk-android.md) | Política de firma, secretos y resguardo del artefacto Android | ✅ Completado |
 | [`plan-mantenibilidad-tipado-gradual-2026-06-12.md`](./plan-mantenibilidad-tipado-gradual-2026-06-12.md) | Estrategia incremental de modularidad y tipado; no habilita refactors amplios durante el cierre | 📌 Referencia |
-| [`revision-tecnica-priorizada-2026-09-01.md`](./revision-tecnica-priorizada-2026-09-01.md) | Auditoría vigente de arquitectura, seguridad, persistencia, escalabilidad y tooling con backlog priorizado | 🔄 AUD-001 a AUD-004 y AUD-007 remediados; seguimiento activo |
+| [`revision-tecnica-priorizada-2026-09-01.md`](./revision-tecnica-priorizada-2026-09-01.md) | Auditoría vigente de arquitectura, seguridad, persistencia, escalabilidad y tooling con backlog priorizado | 🔄 AUD-001 a AUD-005 y AUD-007 remediados; seguimiento activo |
 | [`analisis-aud-003-seguridad-importacion-backups-2026-09-01.md`](./analisis-aud-003-seguridad-importacion-backups-2026-09-01.md) | Revalidación e implementación de AUD-003: frontera ZIP/JSON, integridad y defensa de presentación | ✅ Cerrado en PR #3 |
 | [`analisis-aud-004-seguridad-dependencias-2026-09-02.md`](./analisis-aud-004-seguridad-dependencias-2026-09-02.md) | Revalidación y cierre de AUD-004: advisories, grafo mínimo, auditorías, gates y Android | ✅ Cerrado en PR #5 |
 | [`analisis-aud-007-contratos-errores-store-2026-09-03.md`](./analisis-aud-007-contratos-errores-store-2026-09-03.md) | Contrato emit-and-rethrow, adaptación de consumidores y evidencia automática/Android de AUD-007 | ✅ Cerrado en PR #6 |
-| [`analisis-aud-005-coordinacion-sqlite-2026-09-04.md`](./analisis-aud-005-coordinacion-sqlite-2026-09-04.md) | Propiedad SQLite explícita, migraciones estrictas y arranque recuperable | 🔄 Implementado en rama; validación canónica y Android pendientes |
+| [`analisis-aud-005-coordinacion-sqlite-2026-09-04.md`](./analisis-aud-005-coordinacion-sqlite-2026-09-04.md) | Propiedad SQLite explícita, migraciones estrictas y arranque recuperable | ✅ Cerrado técnicamente; integración autorizada |
 | [`historico/`](./historico/) | Snapshots operativos cerrados preservados como evidencia de proceso | 📦 Archivo |
 
 ---

--- a/docs/gestion/analisis-aud-005-coordinacion-sqlite-2026-09-04.md
+++ b/docs/gestion/analisis-aud-005-coordinacion-sqlite-2026-09-04.md
@@ -1,0 +1,157 @@
+# AUD-005 — Coordinación SQLite y arranque recuperable
+
+**Fecha:** 2026-09-04  
+**Rama:** `fix/sqlite-write-coordination`  
+**Base remota verificada:** `57e653c1638af3cecff6dd72513a1a52216bff62`  
+**Estado:** implementado; regresiones automáticas aprobadas; pendiente de validación canónica, Android e integración
+
+## Alcance y preflight
+
+Checkout: `/home/jd/github/lumapse`. Remoto: `https://github.com/jdfesa/lumapse.git`.
+Se comprobaron ubicación, rama, árbol limpio y ausencia de commits locales sin publicar. Se ejecutaron
+`git fetch origin --prune`, `git switch main` y `git pull --ff-only origin main`; HEAD y origin/main
+coincidieron con la base indicada. No se borraron ramas, datos ni trabajo ajeno.
+
+Solo se trata AUD-005. AUD-006 no comenzó y requiere integrar primero esta corrección.
+AUD-007 conserva su contrato emit-and-rethrow. AUD-008/AUD-009 no se modifican. Hito 06 continúa activo:
+no se cierran RNF, documentación final, defensa ni release. No cambian dependencias, lockfile,
+toolchain, versión `0.4.8`, Android `408`, tags, firma ni artefactos publicados.
+
+## Causa y contrato
+
+El contador global confundía concurrencia independiente con anidamiento; el CRUD podía incorporarse
+a otra transacción. Migraciones y persistencia web absorbían fallos. `initApp()` dejaba el rechazo de
+inicio sin frontera visual.
+
+La solución y sus alternativas están en [ADR-009](../adr/ADR-009-propiedad-transaccional-sqlite.md):
+capacidad explícita, cola compartida, fachada SQLite sin acceso al objeto nativo, éxito después de
+commit/persistencia y cuarentena ante estado incierto. Las cascadas, restauración de nota huérfana,
+vaciado y purgado se confirman como unidades. No se agrega batching ni se optimiza N+1.
+
+Las migraciones omiten únicamente columnas comprobadas por PRAGMA; cualquier error inesperado
+aborta con contexto y causa. La importación legada usa una transacción para notas y marcador, sin
+reemplazar notas SQLite. El schema final y las cascadas FK no cambian.
+
+El arranque separa preparación async de montaje síncrono, ambos compuestos en `main.js`. Antes de
+terminar la preparación no existen componentes/listeners nuevos. La UI de error es accesible, en
+español y sin SQL ni contenidos privados. Un montaje parcial fallido exige recargar la WebView,
+no reinstalar componentes sobre el mismo documento.
+
+Rutas principales revisadas/modificadas:
+
+- `/home/jd/github/lumapse/src/services/sqlite/connection.js`: conexión, schema y recuperación.
+- `/home/jd/github/lumapse/src/services/sqlite/writeCoordinator.js`: cola y propietario explícito.
+- `/home/jd/github/lumapse/src/services/sqlite/legacyMigration.js`: migración legada transaccional.
+- `/home/jd/github/lumapse/src/main.js`: composición de preparación y montaje.
+- `/home/jd/github/lumapse/src/layout/appStartup.js`: estado accesible y reintento single-flight.
+- `/home/jd/github/lumapse/tests/unit/services/sqlite/connection.test.js`: regresiones de conexión.
+
+## Evidencia reproducible
+
+Entorno remoto: **Node v26.7.0 / npm 12.0.2**. `npm ci` completó con el lockfile vigente: 293 paquetes.
+npm informó el bloqueo preexistente del postinstall de `esbuild`; no se cambió su configuración y el
+build funcionó. Ambas auditorías npm se consultaron en vivo: **0 vulnerabilidades** en base y corrección.
+El sandbox inicialmente bloqueó fetch/auditorías; se repitieron con autorización, sin asumir resultados offline.
+
+Los logs locales están en `/tmp/lumapse-aud005/base/` y `/tmp/lumapse-aud005/final/`.
+Para evitar mezclar la base con archivos en edición, la comparación adicional usa un `git archive`
+del SHA base en `/tmp/lumapse-aud005/baseline-checkout`, con el mismo `node_modules` instalado desde
+el lockfile inalterado. No se reutilizan cifras de sesiones anteriores.
+
+### Regresiones red → green
+
+| Reproducción previa | Evidencia local | Resultado corregido |
+|---|---|---|
+| Transacción independiente, CRUD intercalado, persistencia fallida, migración inesperada y doble init: 5 fallos | `/tmp/lumapse-aud005/red-connection.log` | Casos aprobados |
+| Montaje prematuro y fallo sin pantalla/reintento: 2 fallos y 1 rechazo no manejado | `/tmp/lumapse-aud005/red-startup.log` | Casos aprobados; sin rechazo no manejado |
+| Vaciado de papelera confirmaba notas antes de fallar materias | `/tmp/lumapse-aud005/red-trash-atomicity.log` | Rollback completo en SQLite real |
+| Reintento consultaba transacciones después de fallar `open()` | `/tmp/lumapse-aud005/red-open-retry.log` | Comprueba primero si la base está abierta |
+| Un estado transaccional no booleano se interpretaba como inactivo | `/tmp/lumapse-aud005/red-unknown-state.log` | Recuperación bloqueada hasta comprobar estado |
+
+Las promesas se controlan explícitamente, sin sleeps arbitrarios. Se cubren además anidamiento,
+capacidades expiradas/ajenas, errores begin/write/commit/rollback, recuperación de cola/conexión,
+persistencia web pendiente, idempotencia de schema, errores de IndexedDB, importación no destructiva,
+desacople de lecturas externas y protección contra doble montaje.
+
+### Comandos
+
+Todos los comandos shell se ejecutaron con prefijo `rtk` (o `rtk proxy` para conservar salida completa).
+Desde `/home/jd/github/lumapse`:
+
+```bash
+rtk npm ci
+rtk npm test -- tests/unit/services/sqlite tests/unit/SubjectService.test.js tests/unit/services/backup/BackupImportDataSource.test.js tests/unit/services/backup/BackupImportRegression.test.js tests/unit/main.test.js tests/unit/layout/appStartup.test.js
+rtk npm run verify
+rtk npm run test:coverage
+rtk npm run check:docs
+rtk npm run check:traceability
+rtk npm run check:schema
+rtk npm run check:dbml
+rtk npm audit
+rtk npm audit --omit=dev
+```
+
+Como `verify` se detiene en quality, también se ejecutan independientemente sus checks posteriores:
+`typecheck`, `check:toolchain`, `check:db-smoke`, `check:size`, `check:native-dialogs` y `check:a11y`.
+La medición diagnóstica en este Node se reproduce con:
+
+```bash
+rtk proxy env NODE_OPTIONS=--no-experimental-webstorage npm run test:coverage
+```
+
+Este diagnóstico **no sustituye ni vuelve verde** el comando canónico fallido.
+
+### Matriz comparada
+
+| Control | Base | Corrección |
+|---|---|---|
+| Focalizados | 8 archivos / 196 tests | 13 archivos / 235 tests aprobados |
+| Suite completa diagnóstica | 62 archivos / 989 tests | 67 archivos / 1028 tests aprobados |
+| `verify` normal | Falla: AUD-009 + AUD-008 | Mismas limitaciones; no verde |
+| `test:coverage` normal | Falla: 53 tests Web Storage | Mismos 53 fallos; no verde |
+| Coverage diagnóstico global, statements | 94,19% (2351/2496) | 95,63% (2477/2590) |
+| Coverage diagnóstico `src/services/**`, statements | 93,58% (1910/2041) | 95,36% (2036/2135) |
+| Lint / typecheck | 0 errores, 3 warnings / aprobado | Sin nuevos warnings / aprobado |
+| Build y bundle gzip | 192,03 kB / 250 kB | 193,43 kB / 250 kB; aprobado |
+| Docs / trazabilidad / schema / DBML | Aprobados | Aprobados |
+| Toolchain / DB smoke / diálogos / a11y estática | Aprobados | Aprobados |
+| Auditoría npm completa / productiva | 0 / 0 vulnerabilidades | 0 / 0 vulnerabilidades |
+
+**Clasificación de fallos:** AUD-009 reproduce `localStorage.clear` sobre un valor indefinido en
+cinco archivos, tanto en base como corrección. AUD-008 reproduce los dos falsos positivos del CSP
+`capacitor://localhost http://localhost` en `index.html:19-20` mediante el fallback de `quality`.
+No se tocaron reglas, umbrales, cobertura ni scripts para ocultarlos. Antes de integrar debe existir
+validación canónica satisfactoria del **SHA final**, no solo este diagnóstico remoto.
+
+Durante el desarrollo, `check:db-smoke` detectó una regresión nueva: el literal clasificador
+`'ALTER TABLE'` se interpretaba como SQL incompleto por el extractor existente. Se corrigió el
+clasificador de producción, sin modificar el checker, y se repitieron smoke/schema/DBML con éxito.
+Ese fallo no se atribuyó a AUD-008/AUD-009.
+
+## Pausa para validación local
+
+La rama y el SHA exacto publicado se entregan en el handoff. No hay PR abierto ni autorización de
+merge. La Mac debe sincronizar ese SHA en un checkout limpio, comprobar `git rev-parse HEAD` y
+ejecutar la validación canónica antes de integrar. No usar reset, limpieza, desinstalación ni `--clean`.
+
+El Android está exclusivamente conectado a la Mac. Usar el
+[procedimiento oficial, sección 5.2](../flujo-desarrollo-android.md):
+`npm run deploy:android` (con `--target` si corresponde), preservando SQLite y preferencias.
+
+Checklist proporcional:
+
+1. Abrir la instalación existente y volver a abrirla: notas, materias, secciones, eventos y borrador
+   siguen presentes; una única UI, sin pantalla vacía ni controles duplicados.
+2. Crear/editar una nota y una fecha académica; cerrar y reabrir: cambios conservados.
+3. Archivar/desarchivar y enviar/restaurar una materia con sección y notas de prueba: cascada completa
+   y navegación conservada, sin acciones duplicadas.
+4. Enviar elementos **de prueba** a papelera, restaurarlos y vaciar solo si su contenido es descartable;
+   cancelar el vaciado si hubiera información que conservar. No purgar datos personales para validar.
+5. Importar un ZIP Lumapse de prueba y repetir el preview: datos existentes conservados, duplicados
+   omitidos según la política vigente. Exportar backup para comprobar continuidad del flujo.
+6. Repetir los flujos básicos en modo avión. Los fallos de DB/migración/reintento quedan cubiertos con
+   fixtures aisladas; **no se pide corromper ni borrar la base real**.
+
+Después de aprobación manual: abrir PR en inglés contra `main`, revisar checks del SHA final y
+esperar autorización explícita de integración. Cambios posteriores de código requieren revalidación
+y nueva aprobación. Después del merge se informará PR/SHA; no se eliminarán ramas sin confirmación.

--- a/docs/gestion/analisis-aud-005-coordinacion-sqlite-2026-09-04.md
+++ b/docs/gestion/analisis-aud-005-coordinacion-sqlite-2026-09-04.md
@@ -101,7 +101,7 @@ rtk proxy env NODE_OPTIONS=--no-experimental-webstorage npm run test:coverage
 
 Este diagnóstico **no sustituye ni vuelve verde** el comando canónico fallido.
 
-### Matriz comparada
+### Matriz comparada — checkpoint previo a la interrupción
 
 | Control | Base | Corrección |
 |---|---|---|
@@ -127,6 +127,33 @@ Durante el desarrollo, `check:db-smoke` detectó una regresión nueva: el litera
 `'ALTER TABLE'` se interpretaba como SQL incompleto por el extractor existente. Se corrigió el
 clasificador de producción, sin modificar el checker, y se repitieron smoke/schema/DBML con éxito.
 Ese fallo no se atribuyó a AUD-008/AUD-009.
+
+## Recuperación de la sesión interrumpida
+
+El límite de uso interrumpió la sesión después del commit `bf79c98`, antes de implementar dos
+regresiones nuevas de cierre nativo. La matriz anterior describe el checkpoint previo; no representa
+el resultado final de esa interrupción. Se resguardaron los archivos sin commit antes de continuar.
+
+El commit `8110de4` completó `beforeReload`, enlazado desde `main.js` a `closeDatabaseForReload`.
+El cierre comparte una promesa, impide nuevas operaciones, espera inicialización y trabajo activo,
+comprueba el estado transaccional y libera la conexión antes de recargar. Un fallo de cierre conserva
+la referencia y permite reintentar; nunca recarga ni vuelve a montar componentes mientras el estado
+sea incierto. Las fachadas SQLite retenidas también quedan invalidadas. No se borran bases ni preferencias.
+
+Validación repetida sobre la implementación recuperada, con el mismo Node/npm remoto:
+
+- Red → green ampliado: **7 fallos reproducidos; 3 archivos / 33 tests aprobados** después del fix.
+- Suite completa diagnóstica con `NODE_OPTIONS=--no-experimental-webstorage`: **67 archivos / 1035 tests aprobados**.
+- `npm run verify` normal: **no verde**, conserva los **53 fallos basales** de Web Storage (AUD-009)
+  y los dos falsos positivos CSP (AUD-008). No se relajaron controles.
+- Coverage diagnóstico global: **95,66% de statements**; no es coverage integral de UI.
+- Lint sin errores ni warnings nuevos, typecheck, build, toolchain, DB smoke, schema, DBML,
+  documentación, trazabilidad, diálogos y a11y estática aprobados.
+- Bundle gzip: **193,57 kB / 250 kB**. Auditorías npm completa y productiva: **0 / 0 vulnerabilidades**.
+- Logs adicionales: `/tmp/lumapse-aud005/recovery-red.log`, `recovery-green.log` y `recovery/`.
+
+Esta recuperación aún requiere validar el SHA publicado en la Mac canónica y en Android. No implica
+aprobación manual, apertura de PR ni autorización de merge.
 
 ## Pausa para validación local
 

--- a/docs/gestion/analisis-aud-005-coordinacion-sqlite-2026-09-04.md
+++ b/docs/gestion/analisis-aud-005-coordinacion-sqlite-2026-09-04.md
@@ -3,7 +3,7 @@
 **Fecha:** 2026-09-04  
 **Rama:** `fix/sqlite-write-coordination`  
 **Base remota verificada:** `57e653c1638af3cecff6dd72513a1a52216bff62`  
-**Estado:** implementado; regresiones automáticas aprobadas; pendiente de validación canónica, Android e integración
+**Estado:** cerrado técnicamente; validación canónica y Android aprobadas; integración y limpieza de rama autorizadas
 
 ## Alcance y preflight
 
@@ -152,14 +152,15 @@ Validación repetida sobre la implementación recuperada, con el mismo Node/npm 
 - Bundle gzip: **193,57 kB / 250 kB**. Auditorías npm completa y productiva: **0 / 0 vulnerabilidades**.
 - Logs adicionales: `/tmp/lumapse-aud005/recovery-red.log`, `recovery-green.log` y `recovery/`.
 
-Esta recuperación aún requiere validar el SHA publicado en la Mac canónica y en Android. No implica
-aprobación manual, apertura de PR ni autorización de merge.
+En ese checkpoint remoto todavía faltaban la validación canónica y Android. La sección de cierre
+siguiente registra la evidencia posterior y la autorización del usuario.
 
-## Pausa para validación local
+## Validación local — procedimiento y checklist
 
-La rama y el SHA exacto publicado se entregan en el handoff. No hay PR abierto ni autorización de
-merge. La Mac debe sincronizar ese SHA en un checkout limpio, comprobar `git rev-parse HEAD` y
-ejecutar la validación canónica antes de integrar. No usar reset, limpieza, desinstalación ni `--clean`.
+El procedimiento exige sincronizar el SHA publicado en un checkout limpio, comprobar
+`git rev-parse HEAD` y ejecutar la validación canónica antes de integrar. No usar reset, limpieza,
+desinstalación ni `--clean`. Este checklist define los escenarios sugeridos, no acredita por sí solo
+la ejecución individual de todos ellos.
 
 El Android está exclusivamente conectado a la Mac. Usar el
 [procedimiento oficial, sección 5.2](../flujo-desarrollo-android.md):
@@ -182,3 +183,28 @@ Checklist proporcional:
 Después de aprobación manual: abrir PR en inglés contra `main`, revisar checks del SHA final y
 esperar autorización explícita de integración. Cambios posteriores de código requieren revalidación
 y nueva aprobación. Después del merge se informará PR/SHA; no se eliminarán ramas sin confirmación.
+
+
+## Cierre canónico y aprobación Android — 2026-09-04
+
+- **Código validado:** `0832a75fe262da7ad3633008d69278df345bbefd`; los cambios posteriores de este cierre
+  son exclusivamente documentales, sin cambios de código, dependencias ni configuración Android.
+- **Mac canónica:** Node 22.20.0 / npm 10.9.3. `npm ci`, `npm run verify`, `npm run test:coverage`,
+  docs, trazabilidad, schema y DBML aprobados sin workaround: **67 archivos / 1035 tests**,
+  **0 errores de lint / 3 warnings conocidos**, **95,66% statements** en el scope configurado.
+  Las auditorías npm completa y productiva informaron **0 / 0 vulnerabilidades**.
+- **Instalación:** script oficial `npm run deploy:android -- --target <dispositivo>` desde la Mac,
+  sin `--clean` ni desinstalación. Samsung **SM_G965F**, paquete `com.lumapse.app`, versión **0.4.8/408**.
+  Build Vite, sync, Gradle e instalación completados; actualización registrada a las **23:19:36**.
+- **SHA-256 del APK local e instalado, comprobados iguales:**
+  `b311ae558f08ca92769172542f515e845925e1c5a71d7b9eeb4140c9bf207118`.
+- **Aprobación del usuario:** después de la instalación informó «aparentemente todo funciona ok»
+  y autorizó aceptar el PR, hacer merge y borrar ramas locales/remotas. Esto acredita una aprobación
+  manual de funcionamiento general; no se atribuye una ejecución individual exhaustiva del checklist
+  ni se amplía el cierre a la matriz RNF o a mediciones de rendimiento.
+- **Integración:** autorizada, condicionada a revisión y checks satisfactorios del head final del PR.
+  La limpieza queda limitada a `fix/sqlite-write-coordination` después de verificar su integración
+  y la ausencia de trabajo sin publicar en ambas máquinas. AUD-006 no se inicia en este cierre.
+
+El APK sigue siendo evidencia de prueba: no se publicó una release, no se cambió la versión y
+no se modificó la beta distribuida `v0.4.8`.

--- a/docs/gestion/revision-tecnica-priorizada-2026-09-01.md
+++ b/docs/gestion/revision-tecnica-priorizada-2026-09-01.md
@@ -1,6 +1,6 @@
 # Revisión Técnica Priorizada — 2026-09-01
 
-**Estado:** Vigente — AUD-001 a AUD-004 y AUD-007 cerrados técnicamente
+**Estado:** Vigente — AUD-001 a AUD-005 y AUD-007 cerrados técnicamente
 **Rama original de auditoría:** `fix/note-save-integrity`
 **Commit base original revisado:** `cd60c0e` (`main`)
 **Versión de producto documentada:** `0.4.8` (Beta)  
@@ -96,7 +96,7 @@ store, no como métrica integral de toda la aplicación.
 | AUD-002 | P0 | Guardados duplicados por taps concurrentes | Bug confirmado | Resuelto en PR #2 |
 | AUD-003 | P0 | Inyección HTML persistente desde campos de backup | Seguridad confirmada | Cerrado en PR #3 |
 | AUD-004 | P0 | Dependencias vulnerables, incluida DOMPurify en producción | Seguridad/tooling | Cerrado en PR #5 |
-| AUD-005 | P1 | Propiedad global de transacciones y migraciones permisivas | Confiabilidad | Pendiente |
+| AUD-005 | P1 | Propiedad global de transacciones y migraciones permisivas | Confiabilidad | Cerrado técnicamente; integración autorizada |
 | AUD-006 | P1 | Resultados async obsoletos sobrescriben vista/cache reciente | Bug de concurrencia | Pendiente |
 | AUD-007 | P1 | Contratos incompatibles para errores de mutaciones | Diseño/confiabilidad | Cerrado en PR #6 |
 | AUD-008 | P1 | Gate canónico no portable y CI desalineada | Tooling | Pendiente |
@@ -217,6 +217,11 @@ SQLite y su funcionamiento fue aprobado explícitamente en Samsung SM_G965F. No 
 release ni se cambió la versión; la integración quedó autorizada.
 
 ### AUD-005 — Coordinación SQLite y arranque
+
+> **Cierre técnico 2026-09-04:** propiedad explícita, migraciones estrictas y arranque recuperable
+> implementados. 1035 tests, gate canónico y funcionamiento general Android aprobados; integración
+> autorizada. Ver [evidencia AUD-005](./analisis-aud-005-coordinacion-sqlite-2026-09-04.md).
+> La evidencia original siguiente describe el defecto previo a la remediación.
 
 > **Seguimiento 2026-09-04:** implementado en `fix/sqlite-write-coordination`, con regresiones automáticas y ADR-009. Pendiente de gate canónico satisfactorio sobre el SHA final, Android y autorización de integración; todavía no cerrado. Ver [evidencia de AUD-005](analisis-aud-005-coordinacion-sqlite-2026-09-04.md). El diagnóstico siguiente conserva el hallazgo inicial.
 
@@ -509,4 +514,5 @@ La revisión inicial quedó vinculada al primer fix porque AUD-001 y AUD-002 afe
 central del producto y presentaban la mejor relación entre impacto, riesgo y tamaño de cambio.
 Ambos hallazgos se cerraron posteriormente en la PR #2, AUD-003 en la PR #3 y AUD-004 en la PR #5.
 AUD-007 quedó cerrado en la PR #6 con contrato único, límites UI adaptados y validación automática/Android
-aprobada. AUD-005 y los demás hallazgos conservan alcance y seguimiento independientes.
+aprobada. AUD-005 cerró técnicamente con validación canónica y Android aprobadas; AUD-006 y los demás hallazgos
+conservan alcance y seguimiento independientes.

--- a/docs/gestion/revision-tecnica-priorizada-2026-09-01.md
+++ b/docs/gestion/revision-tecnica-priorizada-2026-09-01.md
@@ -218,6 +218,8 @@ release ni se cambió la versión; la integración quedó autorizada.
 
 ### AUD-005 — Coordinación SQLite y arranque
 
+> **Seguimiento 2026-09-04:** implementado en `fix/sqlite-write-coordination`, con regresiones automáticas y ADR-009. Pendiente de gate canónico satisfactorio sobre el SHA final, Android y autorización de integración; todavía no cerrado. Ver [evidencia de AUD-005](analisis-aud-005-coordinacion-sqlite-2026-09-04.md). El diagnóstico siguiente conserva el hallazgo inicial.
+
 **Transacciones**
 
 `src/services/sqlite/connection.js:18-86` representa propiedad transaccional mediante el global

--- a/docs/hitos/hito-06-octubre.md
+++ b/docs/hitos/hito-06-octubre.md
@@ -8,7 +8,7 @@
 
 **Proyecto:** Lumapse
 
-**Estado:** Activo — AUD-001 a AUD-004 y AUD-007 cerrados técnicamente; cierre editorial, RNF y artefacto pendientes
+**Estado:** Activo — AUD-001 a AUD-005 y AUD-007 cerrados técnicamente; cierre editorial, RNF y artefacto pendientes
 
 **Última actualización:** 2026-09-03
 
@@ -59,6 +59,7 @@ Cerrar Lumapse con documentación coherente, evidencia técnica reproducible, di
 - [x] Aprobar los checkpoints Android de AUD-003 con backups `STORE`/`DEFLATE`, rechazo de datos inválidos antes de persistir, fixture de 500 notas y build completo instalado. Esta evidencia no equivale a validar un artefacto publicado nuevo.
 - [x] Resolver AUD-004 en un PR separado: grafo mínimo actualizado, auditorías completa/productiva en cero, sanitización, 955 tests, build, quality gate y Android 0.4.8/408 aprobados el 2026-09-02.
 - [x] Resolver AUD-007 en un PR separado: contrato emit-and-rethrow, límites UI deterministas, 989 tests, quality gate y Android 0.4.8/408 aprobados el 2026-09-03.
+- [x] Validar AUD-005: propiedad SQLite explícita, migraciones estrictas, arranque recuperable, 1035 tests, gate canónico y funcionamiento general Android aprobados el 2026-09-04; integración autorizada.
 - [ ] Ejecutar el quality gate sobre el commit candidato y guardar la evidencia; los gates acumulativos y pre-push ya aprobados no sustituyen el cierre del corte.
 - [ ] Repetir la checklist Android sobre el artefacto versionado y firmado elegido.
 - [ ] Medir latencia CRUD y rendimiento con al menos 500 notas (`RNF-002`, `RNF-004`); la importación funcional de esa cantidad no constituye una medición de rendimiento.

--- a/src/layout/appStartup.css
+++ b/src/layout/appStartup.css
@@ -1,0 +1,18 @@
+.startup-state {
+  max-width: 36rem;
+  margin: 12vh auto;
+  padding: 1.5rem;
+  line-height: 1.6;
+}
+
+.startup-state button {
+  min-height: 48px;
+  padding: 0.5rem 1.5rem;
+  font: inherit;
+  cursor: pointer;
+}
+
+.startup-state button:focus-visible {
+  outline: 3px solid currentColor;
+  outline-offset: 3px;
+}

--- a/src/layout/appStartup.js
+++ b/src/layout/appStartup.js
@@ -1,0 +1,57 @@
+import './appStartup.css'
+
+// La preparación puede reintentarse; el montaje síncrono ocurre solo después de ella.
+export function createAppStartup({ app, prepare, mount, beforeReload = () => {}, reload = () => window.location.reload() }) {
+  let pending = null
+  let mounted = false
+  let needsReload = false
+  let reloadPending = null
+
+  function retryAfterPartialMount(button) {
+    if (reloadPending || button.disabled) return
+    button.disabled = true
+    reloadPending = Promise.resolve().then(beforeReload).then(reload).catch(error => {
+      console.error('[Lumapse] No se pudo liberar la conexión para reintentar:', error)
+      showFailure()
+    }).finally(() => { reloadPending = null })
+  }
+
+  function showFailure() {
+    app.innerHTML = `
+      <section class="startup-state" role="alert" aria-labelledby="startup-title">
+        <h1 id="startup-title" tabindex="-1">No se pudo iniciar Lumapse</h1>
+        <p>No pudimos abrir tus datos. No borres los datos de la aplicación.</p>
+        <p>Podés reintentar de forma segura. Si el problema continúa, cerrá y volvé a abrir la aplicación.</p>
+        <button id="startup-retry" type="button">Reintentar</button>
+      </section>`
+    app.querySelector('#startup-title').focus()
+    app.querySelector('#startup-retry').addEventListener('click', event => {
+      if (needsReload) {
+        // La WebView no libera por sí sola el estado del plugin nativo.
+        retryAfterPartialMount(event.currentTarget)
+      }
+      else void start()
+    })
+  }
+
+  function start() {
+    if (pending) return pending
+    if (mounted) return Promise.resolve(true)
+    if (needsReload) return Promise.resolve(false)
+    app.innerHTML = '<section class="startup-state" role="status" aria-live="polite">Iniciando Lumapse…</section>'
+    pending = Promise.resolve().then(async () => {
+      await prepare()
+      needsReload = true
+      mount()
+      mounted = true
+      return true
+    }).catch(error => {
+      console.error('[Lumapse] No se pudo completar el arranque:', error)
+      showFailure()
+      return false // Frontera terminal: el DOM nunca recibe una promesa rechazada.
+    }).finally(() => { pending = null })
+    return pending
+  }
+
+  return { start }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@
 // =============================================================
 
 import './styles/main.css'
-import { initDatabase } from './services/sqlite/connection.js'
+import { initDatabase, closeDatabaseForReload } from './services/sqlite/connection.js'
 import * as NoteStore from './store/NoteStore.js'
 import * as ThemeService from './services/ThemeService.ts'
 import { SUBJECT_COLORS, autoPurge } from './services/SubjectService.js'
@@ -21,12 +21,32 @@ import { showErrorToast } from './components/common/Toast.js'
 import { handleStoreMutationError } from './components/common/storeActionErrors.js'
 import { renderAppShell } from './layout/appShell.js'
 import { initDrawer } from './layout/drawerController.js'
+import { createAppStartup } from './layout/appStartup.js'
 // import { seedTiktokData, seedStressTest } from './utils/seeder.js'
 
-async function initApp() {
-  // 1. Inicializar base de datos SQLite
+async function prepareApp() {
   await initDatabase()
-  
+  // Preparar datos antes de crear componentes o suscripciones.
+  await NoteStore.loadSubjects()
+  await NoteStore.loadNotes()
+  await NoteStore.loadAcademicEvents()
+  const today = new Date()
+  await NoteStore.loadAcademicEventsByMonth(today.getFullYear(), today.getMonth() + 1)
+  await NoteStore.loadUpcomingAcademicEvents()
+
+  // Auto-purgado de papelera (RF-026): elimina items > 30 días
+  try {
+    await autoPurge(30)
+    console.log('[Lumapse] Auto-purge completado.')
+  } catch (err) {
+    console.warn('[Lumapse] Error en auto-purge:', err)
+  }
+
+  // Cargar conteo de papelera (para badge)
+  await NoteStore.loadTrashCount()
+}
+
+function mountApp() {
   // 2. Renderizar el shell HTML
   const app = document.getElementById('app')
   app.innerHTML = renderAppShell()
@@ -71,25 +91,6 @@ async function initApp() {
     calendarPopup.classList.remove('is-open')
   })
   
-  // 6. Cargar datos iniciales
-  await NoteStore.loadSubjects()
-  await NoteStore.loadNotes()
-  await NoteStore.loadAcademicEvents()
-  const today = new Date()
-  await NoteStore.loadAcademicEventsByMonth(today.getFullYear(), today.getMonth() + 1)
-  await NoteStore.loadUpcomingAcademicEvents()
-
-  // 7. Auto-purgado de papelera (RF-026): elimina items > 30 días
-  try {
-    await autoPurge(30)
-    console.log('[Lumapse] Auto-purge completado.')
-  } catch (err) {
-    console.warn('[Lumapse] Error en auto-purge:', err)
-  }
-
-  // 8. Cargar conteo de papelera (para badge)
-  await NoteStore.loadTrashCount()
-
   // 9. Toast de alerta de papelera (RF-026)
   const trashToast = document.getElementById('trash-warning-toast')
   const btnEmptyTrashToast = document.getElementById('btn-empty-trash-toast')
@@ -123,5 +124,11 @@ async function initApp() {
   })
 }
 
-// Iniciar aplicación
-initApp()
+// Una sola preparación concurrente, sin componentes ni listeners antes de cargar los datos.
+const startup = createAppStartup({
+  app: document.getElementById('app'),
+  prepare: prepareApp,
+  mount: mountApp,
+  beforeReload: closeDatabaseForReload,
+})
+void startup.start()

--- a/src/services/SubjectService.crud.ts
+++ b/src/services/SubjectService.crud.ts
@@ -60,13 +60,14 @@ async function updateArchiveStateWithUniqueName(
   subject: Subject,
   archived: boolean,
   allSubjects: Subject[],
+  scope: object,
 ): Promise<Subject[]> {
   const uniqueName = getUniqueNameForLevel(subject.name, subject.parentSubjectId, subject.id, allSubjects)
   const changes: SubjectChanges = uniqueName === subject.name.trim()
     ? { archived }
     : { archived, name: uniqueName }
 
-  await updateSubjectRow(subject.id, changes)
+  await updateSubjectRow(subject.id, changes, scope)
 
   return allSubjects.map(s => s.id === subject.id
     ? { ...s, name: uniqueName, archived }
@@ -161,14 +162,14 @@ export async function updateSubject(id: EntityId, changes: SubjectChanges): Prom
  * Orden: secciones hijas -> padre.
  * @param {string} id ID de la materia raíz
  */
-export async function archiveSubject(id: EntityId): Promise<void> {
-  return runTransaction(async () => {
+export async function archiveSubject(id: EntityId, parentScope?: object): Promise<void> {
+  return runTransaction(async (scope) => {
     // 1. Archivar secciones hijas
-    await archiveChildSubjects(id)
+    await archiveChildSubjects(id, scope)
 
     // 2. Archivar el subject padre
-    await updateSubjectRow(id, { archived: true })
-  })
+    await updateSubjectRow(id, { archived: true }, scope)
+  }, parentScope)
 }
 
 /**
@@ -177,22 +178,22 @@ export async function archiveSubject(id: EntityId): Promise<void> {
  * Orden: padre -> secciones hijas.
  * @param {string} id ID de la materia raíz
  */
-export async function unarchiveSubject(id: EntityId): Promise<void> {
-  return runTransaction(async () => {
-    const subject = await getSubjectRowById(id) as Subject | undefined
+export async function unarchiveSubject(id: EntityId, parentScope?: object): Promise<void> {
+  return runTransaction(async (scope) => {
+    const subject = await getSubjectRowById(id, scope) as Subject | undefined
     if (!subject) return
 
-    let allSubjects = await getAllSubjectRowsIncludingArchived() as Subject[]
+    let allSubjects = await getAllSubjectRowsIncludingArchived(scope) as Subject[]
 
     // 1. Desarchivar el subject padre con nombre navegable único
-    allSubjects = await updateArchiveStateWithUniqueName(subject, false, allSubjects)
+    allSubjects = await updateArchiveStateWithUniqueName(subject, false, allSubjects, scope)
 
     // 2. Desarchivar secciones hijas una por una para resolver duplicados previos
     const childSubjects = allSubjects.filter(s => s.parentSubjectId === id && s.archived)
     for (const child of childSubjects) {
-      allSubjects = await updateArchiveStateWithUniqueName(child, false, allSubjects)
+      allSubjects = await updateArchiveStateWithUniqueName(child, false, allSubjects, scope)
     }
-  })
+  }, parentScope)
 }
 
 /**
@@ -201,10 +202,10 @@ export async function unarchiveSubject(id: EntityId): Promise<void> {
  * La materia padre NO se archiva.
  * @param {string} id ID de la sección
  */
-export async function archiveSection(id: EntityId): Promise<void> {
-  return runTransaction(async () => {
-    await updateSubjectRow(id, { archived: true })
-  })
+export async function archiveSection(id: EntityId, parentScope?: object): Promise<void> {
+  return runTransaction(async (scope) => {
+    await updateSubjectRow(id, { archived: true }, scope)
+  }, parentScope)
 }
 
 /**
@@ -213,22 +214,22 @@ export async function archiveSection(id: EntityId): Promise<void> {
  * para que la sección y sus notas tengan una ruta navegable.
  * @param {string} id ID de la sección
  */
-export async function unarchiveSection(id: EntityId): Promise<void> {
-  return runTransaction(async () => {
-    const section = await getSubjectRowById(id) as Subject | undefined
+export async function unarchiveSection(id: EntityId, parentScope?: object): Promise<void> {
+  return runTransaction(async (scope) => {
+    const section = await getSubjectRowById(id, scope) as Subject | undefined
     if (!section) return
 
-    let allSubjects = await getAllSubjectRowsIncludingArchived() as Subject[]
+    let allSubjects = await getAllSubjectRowsIncludingArchived(scope) as Subject[]
 
     if (section.parentSubjectId) {
-      const parent = await getSubjectRowById(section.parentSubjectId) as Subject | undefined
+      const parent = await getSubjectRowById(section.parentSubjectId, scope) as Subject | undefined
       if (parent?.archived && !parent.deletedAt) {
-        allSubjects = await updateArchiveStateWithUniqueName(parent, false, allSubjects)
+        allSubjects = await updateArchiveStateWithUniqueName(parent, false, allSubjects, scope)
       }
     }
 
-    await updateArchiveStateWithUniqueName(section, false, allSubjects)
-  })
+    await updateArchiveStateWithUniqueName(section, false, allSubjects, scope)
+  }, parentScope)
 }
 
 /**

--- a/src/services/SubjectService.trash.ts
+++ b/src/services/SubjectService.trash.ts
@@ -76,7 +76,8 @@ function getUniqueNameForLevel(
 async function restoreSubjectRowWithUniqueName(
   subject: Subject,
   parentSubjectId: EntityId | null,
-  allSubjects: Subject[]
+  allSubjects: Subject[],
+  scope: object
 ): Promise<Subject[]> {
   const targetParentId = parentSubjectId || null
   const uniqueName = getUniqueNameForLevel(subject.name, targetParentId, subject.id, allSubjects)
@@ -93,9 +94,9 @@ async function restoreSubjectRowWithUniqueName(
   }
 
   if (Object.keys(changes).length > 0) {
-    await updateSubjectRow(subject.id, changes)
+    await updateSubjectRow(subject.id, changes, scope)
   }
-  await restoreSubjectRow(subject.id)
+  await restoreSubjectRow(subject.id, scope)
 
   const restoredSubject: Subject = {
     ...subject,
@@ -117,25 +118,25 @@ async function restoreSubjectRowWithUniqueName(
  * Envía a la papelera: la materia, sus secciones hijas y todas las notas.
  * @param {string} id ID de la materia
  */
-export async function deleteSubject(id: EntityId): Promise<void> {
-  return runTransaction(async () => {
+export async function deleteSubject(id: EntityId, parentScope?: object): Promise<void> {
+  return runTransaction(async (scope) => {
     // 1. Obtener secciones hijas para eliminar sus notas también
-    const childIds = (await getChildSubjectIds(id)) as EntityId[]
+    const childIds = (await getChildSubjectIds(id, scope)) as EntityId[]
 
     // 2. Soft-delete de notas del subject padre
-    await softDeleteNotesBySubject(id)
+    await softDeleteNotesBySubject(id, scope)
 
     // 3. Soft-delete de notas de cada sección hija
     for (const childId of childIds) {
-      await softDeleteNotesBySubject(childId)
+      await softDeleteNotesBySubject(childId, scope)
     }
 
     // 4. Soft-delete de secciones hijas
-    await softDeleteChildSubjects(id)
+    await softDeleteChildSubjects(id, scope)
 
     // 5. Soft-delete del subject padre
-    await deleteSubjectRow(id)
-  })
+    await deleteSubjectRow(id, scope)
+  }, parentScope)
 }
 
 /**
@@ -143,14 +144,14 @@ export async function deleteSubject(id: EntityId): Promise<void> {
  * La materia padre NO se elimina.
  * @param {string} id ID de la sección
  */
-export async function deleteSection(id: EntityId): Promise<void> {
-  return runTransaction(async () => {
+export async function deleteSection(id: EntityId, parentScope?: object): Promise<void> {
+  return runTransaction(async (scope) => {
     // 1. Soft-delete de notas de esta sección
-    await softDeleteNotesBySubject(id)
+    await softDeleteNotesBySubject(id, scope)
 
     // 2. Soft-delete de la sección
-    await deleteSubjectRow(id)
-  })
+    await deleteSubjectRow(id, scope)
+  }, parentScope)
 }
 
 /**
@@ -158,31 +159,31 @@ export async function deleteSection(id: EntityId): Promise<void> {
  * Restaura: la materia, sus secciones hijas y todas las notas.
  * @param {string} id ID de la materia
  */
-export async function restoreSubject(id: EntityId): Promise<void> {
-  return runTransaction(async () => {
-    const subject = (await getSubjectRowById(id)) as Subject | undefined
+export async function restoreSubject(id: EntityId, parentScope?: object): Promise<void> {
+  return runTransaction(async (scope) => {
+    const subject = (await getSubjectRowById(id, scope)) as Subject | undefined
     if (!subject) return
 
-    let allSubjects = (await getAllSubjectRowsIncludingArchived()) as Subject[]
-    const deletedSubjects = (await getDeletedSubjectRows()) as Subject[]
+    let allSubjects = (await getAllSubjectRowsIncludingArchived(scope)) as Subject[]
+    const deletedSubjects = (await getDeletedSubjectRows(scope)) as Subject[]
     const childSubjects = deletedSubjects.filter(child => child.parentSubjectId === id)
 
     // 1. Restaurar la materia con un nombre navegable único.
-    allSubjects = await restoreSubjectRowWithUniqueName(subject, null, allSubjects)
+    allSubjects = await restoreSubjectRowWithUniqueName(subject, null, allSubjects, scope)
 
     // 2. Restaurar secciones hijas una por una para resolver duplicados previos.
     for (const child of childSubjects) {
-      allSubjects = await restoreSubjectRowWithUniqueName(child, id, allSubjects)
+      allSubjects = await restoreSubjectRowWithUniqueName(child, id, allSubjects, scope)
     }
 
     // 3. Restaurar notas del subject padre
-    await restoreNotesBySubject(id)
+    await restoreNotesBySubject(id, scope)
 
     // 4. Restaurar notas de cada sección hija
     for (const child of childSubjects) {
-      await restoreNotesBySubject(child.id)
+      await restoreNotesBySubject(child.id, scope)
     }
-  })
+  }, parentScope)
 }
 
 /**
@@ -191,32 +192,32 @@ export async function restoreSubject(id: EntityId): Promise<void> {
  * para que la sección tenga una ruta navegable.
  * @param {string} id ID de la sección
  */
-export async function restoreSection(id: EntityId): Promise<void> {
-  return runTransaction(async () => {
-    const section = (await getSubjectRowById(id)) as Subject | undefined
+export async function restoreSection(id: EntityId, parentScope?: object): Promise<void> {
+  return runTransaction(async (scope) => {
+    const section = (await getSubjectRowById(id, scope)) as Subject | undefined
     if (!section) return
 
-    let allSubjects = (await getAllSubjectRowsIncludingArchived()) as Subject[]
+    let allSubjects = (await getAllSubjectRowsIncludingArchived(scope)) as Subject[]
     let targetParentId: EntityId | null = section.parentSubjectId || null
 
     // Verificar si el padre sigue existiendo como contenedor navegable.
     if (section.parentSubjectId) {
-      const parent = (await getSubjectRowById(section.parentSubjectId)) as Subject | undefined
+      const parent = (await getSubjectRowById(section.parentSubjectId, scope)) as Subject | undefined
       if (!parent) {
         targetParentId = null
       } else if (parent.deletedAt) {
-        allSubjects = await restoreSubjectRowWithUniqueName(parent, null, allSubjects)
+        allSubjects = await restoreSubjectRowWithUniqueName(parent, null, allSubjects, scope)
       } else if (parent.archived) {
-        allSubjects = await restoreSubjectRowWithUniqueName(parent, parent.parentSubjectId, allSubjects)
+        allSubjects = await restoreSubjectRowWithUniqueName(parent, parent.parentSubjectId, allSubjects, scope)
       }
     }
 
     // Restaurar la sección con nombre único en su nivel.
-    await restoreSubjectRowWithUniqueName(section, targetParentId, allSubjects)
+    await restoreSubjectRowWithUniqueName(section, targetParentId, allSubjects, scope)
 
     // Restaurar sus notas
-    await restoreNotesBySubject(id)
-  })
+    await restoreNotesBySubject(id, scope)
+  }, parentScope)
 }
 
 /**
@@ -224,23 +225,25 @@ export async function restoreSection(id: EntityId): Promise<void> {
  * Si su materia padre está eliminada, la nota cae en Entrada (subjectId = null).
  * @param {string} noteId ID de la nota
  */
-export async function restoreNoteFromTrash(noteId: EntityId): Promise<void> {
-  // Primero necesitamos leer la nota para saber si su materia sigue viva
-  const note = (await getNoteById(noteId)) as Note | undefined
-  if (!note) return
+export async function restoreNoteFromTrash(noteId: EntityId, parentScope?: object): Promise<void> {
+  return runTransaction(async (scope) => {
+    // Primero necesitamos leer la nota para saber si su materia sigue viva
+    const note = (await getNoteById(noteId, scope)) as Note | undefined
+    if (!note) return
 
-  // Restaurar la nota
-  await restoreNoteRow(noteId)
+    // Restaurar la nota
+    await restoreNoteRow(noteId, scope)
 
-  // Si tenía materia, verificar que siga activa
-  if (note.subjectId) {
-    const subject = (await getSubjectRowById(note.subjectId)) as Subject | undefined
-    if (!subject || subject.deletedAt) {
-      // Materia eliminada: la nota pierde su subject (va a Entrada)
-      const changes: NoteChanges = { subjectId: null }
-      await updateNote(noteId, changes)
+    // Si tenía materia, verificar que siga activa
+    if (note.subjectId) {
+      const subject = (await getSubjectRowById(note.subjectId, scope)) as Subject | undefined
+      if (!subject || subject.deletedAt) {
+        // Materia eliminada: la nota pierde su subject (va a Entrada)
+        const changes: NoteChanges = { subjectId: null }
+        await updateNote(noteId, changes, scope)
+      }
     }
-  }
+  }, parentScope)
 }
 
 /**
@@ -309,9 +312,11 @@ export async function getTrashItems(): Promise<TrashItems> {
 /**
  * Vacía toda la papelera (notas + materias). DELETE físico.
  */
-export async function emptyTrash(): Promise<void> {
-  await emptyTrashNotes()
-  await emptyTrashSubjects()
+export async function emptyTrash(parentScope?: object): Promise<void> {
+  return runTransaction(async (scope) => {
+    await emptyTrashNotes(scope)
+    await emptyTrashSubjects(scope)
+  }, parentScope)
 }
 
 /**
@@ -319,7 +324,9 @@ export async function emptyTrash(): Promise<void> {
  * Se ejecuta al inicio de cada sesión.
  * @param {number} days Días de retención (default: 30)
  */
-export async function autoPurge(days = 30): Promise<void> {
-  await purgeOldDeletedNotes(days)
-  await purgeOldDeletedSubjects(days)
+export async function autoPurge(days = 30, parentScope?: object): Promise<void> {
+  return runTransaction(async (scope) => {
+    await purgeOldDeletedNotes(days, scope)
+    await purgeOldDeletedSubjects(days, scope)
+  }, parentScope)
 }

--- a/src/services/backup/BackupImportDataSource.ts
+++ b/src/services/backup/BackupImportDataSource.ts
@@ -17,7 +17,7 @@ import type { Subject } from '../../domain/subjects'
 type SqlValue = string | number | null
 
 interface ImportDatabase {
-  run: (sql: string, values: SqlValue[], transaction?: boolean) => Promise<unknown>
+  run: (sql: string, values: SqlValue[]) => Promise<unknown>
 }
 
 function boolToInteger(value: boolean): number {
@@ -29,7 +29,7 @@ function nullable(value: string | null | undefined): string | null {
 }
 
 async function runImportSql(db: ImportDatabase, sql: string, values: SqlValue[]): Promise<void> {
-  await db.run(sql, values, false)
+  await db.run(sql, values)
 }
 
 async function insertSubject(db: ImportDatabase, subject: Subject): Promise<void> {
@@ -115,8 +115,8 @@ export async function applyBackupImportPlan(plan: BackupImportPlan): Promise<Bac
     return result
   }
 
-  await runTransaction(async () => {
-    const db = getDb() as ImportDatabase
+  await runTransaction(async (scope) => {
+    const db = getDb(scope) as ImportDatabase
 
     for (const subject of plan.data.subjects) {
       await insertSubject(db, subject)

--- a/src/services/sqlite/academicEvents.js
+++ b/src/services/sqlite/academicEvents.js
@@ -6,7 +6,7 @@
 // La validacion de negocio la hace AcademicEventService.
 // =============================================================
 
-import { getDb, persistWeb, isWriteTransactionActive } from './connection.js'
+import { getDb } from './connection.js'
 import { DatabaseError } from './errors.js'
 
 async function runWriteOperation(operation, action) {
@@ -18,16 +18,6 @@ async function runWriteOperation(operation, action) {
   }
 }
 
-async function runSql(db, sql, values) {
-  if (isWriteTransactionActive()) {
-    await db.run(sql, values || [], false)
-  } else if (values === undefined) {
-    await db.run(sql)
-  } else {
-    await db.run(sql, values)
-  }
-  await persistWeb()
-}
 
 function normalizeNullable(value) {
   return value || null
@@ -50,10 +40,11 @@ function monthRange(year, month) {
 /**
  * Inserta una fecha academica.
  * @param {object} event Objeto con id, type, title, date, subjectId, createdAt, updatedAt
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function createAcademicEventRow(event) {
+export async function createAcademicEventRow(event, scope) {
   return runWriteOperation('createAcademicEventRow', async () => {
-    const db = getDb()
+    const db = getDb(scope)
 
     const sql = `
       INSERT INTO academic_events (id, type, title, date, subjectId, createdAt, updatedAt)
@@ -69,15 +60,16 @@ export async function createAcademicEventRow(event) {
       event.updatedAt,
     ]
 
-    await runSql(db, sql, values)
+    await db.run(sql, values)
   })
 }
 
 /**
  * Obtiene todas las fechas academicas ordenadas cronologicamente.
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function getAcademicEventRows() {
-  const db = getDb()
+export async function getAcademicEventRows(scope) {
+  const db = getDb(scope)
   const sql = `SELECT * FROM academic_events ORDER BY date ASC, createdAt ASC`
   const res = await db.query(sql)
 
@@ -86,9 +78,10 @@ export async function getAcademicEventRows() {
 
 /**
  * Obtiene una fecha academica por su ID.
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function getAcademicEventRowById(id) {
-  const db = getDb()
+export async function getAcademicEventRowById(id, scope) {
+  const db = getDb(scope)
   const sql = `SELECT * FROM academic_events WHERE id = ?`
   const res = await db.query(sql, [id])
 
@@ -99,9 +92,10 @@ export async function getAcademicEventRowById(id) {
  * Obtiene las fechas academicas de un mes. El mes usa base 1: enero = 1.
  * @param {number} year Año completo, por ejemplo 2026
  * @param {number} month Mes base 1, por ejemplo 6 para junio
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function getAcademicEventRowsByMonth(year, month) {
-  const db = getDb()
+export async function getAcademicEventRowsByMonth(year, month, scope) {
+  const db = getDb(scope)
   const { start, end } = monthRange(year, month)
 
   const sql = `
@@ -116,9 +110,10 @@ export async function getAcademicEventRowsByMonth(year, month) {
 
 /**
  * Obtiene las fechas academicas de un dia especifico (`YYYY-MM-DD`).
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function getAcademicEventRowsByDate(date) {
-  const db = getDb()
+export async function getAcademicEventRowsByDate(date, scope) {
+  const db = getDb(scope)
 
   const sql = `
     SELECT * FROM academic_events
@@ -132,9 +127,10 @@ export async function getAcademicEventRowsByDate(date) {
 
 /**
  * Obtiene proximas fechas academicas desde `today` inclusive.
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function getUpcomingAcademicEventRows(today, limit = 5) {
-  const db = getDb()
+export async function getUpcomingAcademicEventRows(today, limit = 5, scope) {
+  const db = getDb(scope)
 
   const sql = `
     SELECT * FROM academic_events
@@ -149,10 +145,11 @@ export async function getUpcomingAcademicEventRows(today, limit = 5) {
 
 /**
  * Actualiza campos de una fecha academica existente.
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function updateAcademicEventRow(id, changes) {
+export async function updateAcademicEventRow(id, changes, scope) {
   return runWriteOperation('updateAcademicEventRow', async () => {
-    const db = getDb()
+    const db = getDb(scope)
     const fields = []
     const values = []
 
@@ -181,18 +178,19 @@ export async function updateAcademicEventRow(id, changes) {
 
     values.push(id)
     const sql = `UPDATE academic_events SET ${fields.join(', ')} WHERE id = ?`
-    await runSql(db, sql, values)
+    await db.run(sql, values)
   })
 }
 
 /**
  * Elimina fisicamente una fecha academica.
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function deleteAcademicEventRow(id) {
+export async function deleteAcademicEventRow(id, scope) {
   return runWriteOperation('deleteAcademicEventRow', async () => {
-    const db = getDb()
+    const db = getDb(scope)
     const sql = `DELETE FROM academic_events WHERE id = ?`
 
-    await runSql(db, sql, [id])
+    await db.run(sql, [id])
   })
 }

--- a/src/services/sqlite/connection.js
+++ b/src/services/sqlite/connection.js
@@ -10,79 +10,66 @@
 import { Capacitor } from '@capacitor/core'
 import { SQLiteConnection, CapacitorSQLite } from '@capacitor-community/sqlite'
 import { defineCustomElements } from 'jeep-sqlite/loader'
+import { createWriteCoordinator } from './writeCoordinator.js'
+import { migrateLegacyNotes } from './legacyMigration.js'
 
 // --- Constantes de la base de datos ---
 const DB_NAME = 'lumapse-db'
 let sqliteConnection = null
 let db = null
-let transactionDepth = 0
+let coordinator = null
+let initialization = null
+let ready = false
 
-/**
- * Retorna la instancia activa de la base de datos.
- * Los módulos CRUD (notes.js, subjects.js) usan este getter
- * en lugar de acceder directamente a la variable `db`.
- * @returns {object} Instancia de conexión SQLite
- * @throws {Error} Si la base de datos no fue inicializada
- */
-export function getDb() {
-  if (!db) throw new Error('Database not initialized')
-  return db
+// No se expone la conexión nativa: incluso el CRUD independiente pasa por la cola.
+export function getDb(scope) {
+  if (!ready || !coordinator) throw new Error('Database not initialized')
+  return coordinator.getDb(scope)
 }
 
-/**
- * Indica si hay una transacción explícita abierta desde la capa de negocio.
- * Los módulos CRUD lo usan para evitar transacciones implícitas anidadas.
- * @returns {boolean}
- */
-export function isWriteTransactionActive() {
-  return transactionDepth > 0
+export function isWriteTransactionActive(scope) {
+  return coordinator?.isActive(scope) || false
 }
 
-/**
- * Helper para persistir cambios en la versión Web (WASM).
- * En la web, los cambios en memoria deben guardarse a IndexedDB explícitamente.
- */
-export async function persistWeb() {
-  if (transactionDepth > 0) return
-  if (Capacitor.getPlatform() === 'web' && sqliteConnection) {
-    try {
-      await sqliteConnection.saveToStore(DB_NAME)
-    } catch (e) {
-      console.error('Error al guardar datos SQLite en el almacenamiento Web:', e)
-    }
+async function saveWebStore() {
+  if (Capacitor.getPlatform() === 'web') {
+    await sqliteConnection.saveToStore(DB_NAME)
   }
 }
 
+export function persistWeb(scope) {
+  if (!coordinator) return Promise.reject(new Error('Database not initialized'))
+  return coordinator.persist(scope)
+}
+
+// El callback recibe el capability que debe pasar explícitamente a sus colaboradores.
 /**
- * Ejecuta una operación crítica dentro de una transacción SQLite explícita.
- * Si falla cualquier escritura, revierte todos los cambios de la cascada.
- * @param {Function} action Operación async a ejecutar dentro de la transacción
- * @returns {Promise<*>} Resultado retornado por action
+ * @template T
+ * @param {(scope: object) => Promise<T>} action
+ * @param {object} [scope]
+ * @returns {Promise<T>}
  */
-export async function runTransaction(action) {
-  const activeDb = getDb()
+export async function runTransaction(action, scope) {
+  getDb(scope)
+  return coordinator.transaction(action, scope)
+}
 
-  if (transactionDepth > 0) {
-    return action()
-  }
+async function readConnectionFlag(method) {
+  const { result } = await db[method]()
+  if (typeof result !== 'boolean') throw new Error(`SQLite ${method} state unknown`)
+  return result
+}
 
-  await activeDb.beginTransaction()
-  transactionDepth = 1
-
-  try {
-    const result = await action()
-    await activeDb.commitTransaction()
-    transactionDepth = 0
-    await persistWeb()
-    return result
-  } catch (error) {
-    try {
-      await activeDb.rollbackTransaction()
-    } catch (rollbackError) {
-      console.error('Error al revertir transacción SQLite:', rollbackError)
+async function recoverConnection() {
+  await coordinator?.drain()
+  // Cerrar jeep-sqlite puede persistir: nunca cerrar con una transacción incierta.
+  if (db) {
+    if (await readConnectionFlag('isDBOpen')) {
+      if (await readConnectionFlag('isTransactionActive')) await db.rollbackTransaction()
+      if (await readConnectionFlag('isTransactionActive')) throw new Error('SQLite transaction still active')
     }
-    transactionDepth = 0
-    throw error
+    await sqliteConnection.closeConnection(DB_NAME, false)
+    db = null
   }
 }
 
@@ -91,9 +78,11 @@ export async function runTransaction(action) {
  */
 async function initWebComponent() {
   defineCustomElements(window)
-  const jeepSqlite = document.createElement('jeep-sqlite')
-  jeepSqlite.setAttribute('wasmPath', '/assets')
-  document.body.appendChild(jeepSqlite)
+  if (!document.querySelector('jeep-sqlite')) {
+    const jeepSqlite = document.createElement('jeep-sqlite')
+    jeepSqlite.setAttribute('wasmPath', '/assets')
+    document.body.appendChild(jeepSqlite)
+  }
   await window.customElements.whenDefined('jeep-sqlite')
 }
 
@@ -101,9 +90,18 @@ async function initWebComponent() {
  * Inicializa la conexión SQLite, crea las tablas y realiza
  * la migración desde IndexedDB si es la primera vez.
  */
-export async function initDatabase() {
+export function initDatabase() {
+  if (initialization) return initialization
+  if (ready && coordinator?.isHealthy()) return Promise.resolve()
+  ready = false
+  initialization = initialize().finally(() => { initialization = null })
+  return initialization
+}
+
+async function initialize() {
   try {
-    sqliteConnection = new SQLiteConnection(CapacitorSQLite)
+    await recoverConnection()
+    sqliteConnection ??= new SQLiteConnection(CapacitorSQLite)
     const platform = Capacitor.getPlatform()
 
     if (platform === 'web') {
@@ -161,17 +159,20 @@ export async function initDatabase() {
       );
     `
     await db.execute(schema)
-    await persistWeb()
+    await saveWebStore()
 
     // Migraciones idempotentes para instalaciones existentes
     await runMigrations()
-    await persistWeb()
+    await saveWebStore()
 
     // Realizar migración de IndexedDB a SQLite si corresponde
-    await migrateFromIndexedDB()
+    coordinator = createWriteCoordinator(db, saveWebStore)
+    await migrateLegacyNotes(coordinator)
+    ready = true
 
     console.log('Base de datos SQLite inicializada correctamente.')
   } catch (error) {
+    coordinator?.invalidate(error)
     console.error('Error crítico al inicializar base de datos SQLite:', error)
     throw error
   }
@@ -179,9 +180,7 @@ export async function initDatabase() {
 
 /**
  * Ejecuta migraciones de schema de forma idempotente.
- * SQLite lanza un error si la columna ya existe — lo ignoramos silenciosamente.
- * Esto permite que el mismo código sirva tanto para instalaciones nuevas
- * (donde las columnas ya están en el CREATE TABLE) como para las existentes.
+ * Consulta columnas reales antes del ALTER; ningún fallo SQL se interpreta por mensaje.
  */
 async function runMigrations() {
   if (!db) return
@@ -214,88 +213,16 @@ async function runMigrations() {
 
   for (const [migrationName, sql] of migrations) {
     try {
+      if (sql.startsWith('ALTER ')) {
+        const [table, column] = migrationName.split('.')
+        const result = await db.query(`PRAGMA table_info(${table})`)
+        if (!result.values?.length) throw new Error(`Missing migration table: ${table}`)
+        if (result.values.some(field => field.name === column)) continue
+      }
       await db.run(sql)
-    } catch (e) {
-      const msg = e?.message || ''
-      if (!msg.includes('duplicate column name') && !msg.includes('already exists')) {
-        console.warn(`[Migración] Advertencia en "${migrationName}": ${msg}`)
-      }
+    } catch (cause) {
+      throw new Error(`SQLite migration failed: ${migrationName}`, { cause })
     }
-  }
-}
-
-/**
- * Ejecuta una migración automática (one-time) de IndexedDB a SQLite.
- */
-async function migrateFromIndexedDB() {
-  if (!db) return
-
-  try {
-    // Verificar si ya se migró
-    const checkRes = await db.query('SELECT value FROM metadata WHERE key = ?', ['indexeddb_migrated'])
-    if (checkRes.values && checkRes.values.length > 0 && checkRes.values[0].value === 'true') {
-      return // Ya migrado anteriormente
-    }
-
-    console.log('Iniciando chequeo de migración de IndexedDB...')
-    const notesToMigrate = await new Promise((resolve) => {
-      // Intentar abrir la IndexedDB nativa del MVP
-      const request = window.indexedDB.open('lumapse-db')
-      
-      request.onsuccess = (event) => {
-        const idb = event.target.result
-        if (!idb.objectStoreNames.contains('notes')) {
-          idb.close()
-          resolve([])
-          return
-        }
-        
-        const transaction = idb.transaction('notes', 'readonly')
-        const store = transaction.objectStore('notes')
-        const getAllRequest = store.getAll()
-        
-        getAllRequest.onsuccess = () => {
-          resolve(getAllRequest.result || [])
-          idb.close()
-        }
-        
-        getAllRequest.onerror = () => {
-          resolve([])
-          idb.close()
-        }
-      }
-      
-      request.onerror = () => {
-        resolve([])
-      }
-    })
-
-    if (notesToMigrate.length > 0) {
-      console.log(`Se encontraron ${notesToMigrate.length} notas en IndexedDB. Migrando a SQLite...`)
-      for (const note of notesToMigrate) {
-        const sql = `
-          INSERT OR REPLACE INTO notes (id, title, content, pinned, archived, createdAt, updatedAt)
-          VALUES (?, ?, ?, ?, ?, ?, ?)
-        `
-        const values = [
-          note.id,
-          note.title || 'Sin título',
-          note.content || '',
-          note.pinned ? 1 : 0,
-          note.archived ? 1 : 0,
-          note.createdAt || new Date().toISOString(),
-          note.updatedAt || new Date().toISOString()
-        ]
-        await db.run(sql, values)
-      }
-      console.log('Notas migradas exitosamente a SQLite.')
-    }
-    
-    // Marcar migración como completada
-    await db.run("INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)", ['indexeddb_migrated', 'true'])
-    await persistWeb()
-  } catch (error) {
-    console.warn('Advertencia durante la migración de IndexedDB:', error)
   }
 }
 

--- a/src/services/sqlite/connection.js
+++ b/src/services/sqlite/connection.js
@@ -19,6 +19,7 @@ let sqliteConnection = null
 let db = null
 let coordinator = null
 let initialization = null
+let closing = null
 let ready = false
 
 // No se expone la conexión nativa: incluso el CRUD independiente pasa por la cola.
@@ -91,11 +92,27 @@ async function initWebComponent() {
  * la migración desde IndexedDB si es la primera vez.
  */
 export function initDatabase() {
+  if (closing) return Promise.reject(new Error('Database connection is closing'))
   if (initialization) return initialization
   if (ready && coordinator?.isHealthy()) return Promise.resolve()
   ready = false
   initialization = initialize().finally(() => { initialization = null })
   return initialization
+}
+
+/** Cierra sin borrar datos antes de recargar una WebView parcialmente montada. */
+export function closeDatabaseForReload() {
+  if (closing) return closing
+  ready = false
+  closing = Promise.resolve().then(async () => {
+    await initialization
+    ready = false
+    // Bloquear también fachadas retenidas; drenar lo activo antes de cerrar.
+    coordinator?.invalidate(new Error('SQLite connection is closing for reload'))
+    await recoverConnection()
+    coordinator = null
+  }).finally(() => { closing = null })
+  return closing
 }
 
 async function initialize() {

--- a/src/services/sqlite/legacyMigration.js
+++ b/src/services/sqlite/legacyMigration.js
@@ -1,0 +1,59 @@
+// Migración one-time: ausencia comprobada es normal; errores de lectura no son vacío.
+function readLegacyNotes() {
+  return new Promise((resolve, reject) => {
+    let absent = false
+    let blocked = false
+    const request = window.indexedDB.open('lumapse-db')
+    request.onupgradeneeded = () => {
+      absent = true
+      request.transaction.abort() // No crear una base legada vacía para comprobar su ausencia.
+    }
+    request.onerror = () => absent ? resolve([]) : reject(request.error)
+    request.onblocked = () => {
+      blocked = true
+      reject(new Error('Legacy IndexedDB open blocked'))
+    }
+    request.onsuccess = () => {
+      const idb = request.result
+      if (blocked || !idb.objectStoreNames.contains('notes')) {
+        idb.close()
+        resolve([])
+        return
+      }
+      try {
+        const transaction = idb.transaction('notes', 'readonly')
+        const read = transaction.objectStore('notes').getAll()
+        transaction.oncomplete = () => { idb.close(); resolve(read.result || []) }
+        transaction.onerror = transaction.onabort = () => {
+          idb.close()
+          reject(transaction.error || read.error || new Error('Legacy IndexedDB read aborted'))
+        }
+      } catch (error) {
+        idb.close()
+        reject(error)
+      }
+    }
+  })
+}
+
+export async function migrateLegacyNotes(coordinator) {
+  try {
+    const check = await coordinator.getDb().query('SELECT value FROM metadata WHERE key = ?', ['indexeddb_migrated'])
+    if (check.values?.[0]?.value === 'true') return
+    const notes = await readLegacyNotes()
+    await coordinator.transaction(async db => {
+      for (const note of notes) {
+        // Un reintento nunca reemplaza una nota que ya existe en SQLite.
+        await db.run(`INSERT OR IGNORE INTO notes (id, title, content, pinned, archived, createdAt, updatedAt)
+          VALUES (?, ?, ?, ?, ?, ?, ?)`, [
+          note.id, note.title || 'Sin título', note.content || '',
+          note.pinned ? 1 : 0, note.archived ? 1 : 0,
+          note.createdAt || new Date().toISOString(), note.updatedAt || new Date().toISOString(),
+        ])
+      }
+      await db.run('INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)', ['indexeddb_migrated', 'true'])
+    })
+  } catch (cause) {
+    throw new Error('SQLite migration failed: indexeddb_migrated', { cause })
+  }
+}

--- a/src/services/sqlite/notes.js
+++ b/src/services/sqlite/notes.js
@@ -6,7 +6,7 @@
 // notas en la tabla `notes` de SQLite.
 // =============================================================
 
-import { getDb, persistWeb, generateUUID, isWriteTransactionActive } from './connection.js'
+import { getDb, generateUUID } from './connection.js'
 import { DatabaseError } from './errors.js'
 
 // --- Operaciones CRUD ---
@@ -20,26 +20,17 @@ async function runWriteOperation(operation, action) {
   }
 }
 
-async function runSql(db, sql, values) {
-  if (isWriteTransactionActive()) {
-    await db.run(sql, values || [], false)
-  } else if (values === undefined) {
-    await db.run(sql)
-  } else {
-    await db.run(sql, values)
-  }
-  await persistWeb()
-}
 
 /**
  * Crea una nueva nota en la base de datos.
  * @param {string} title Título de la nota
  * @param {string} content Contenido Markdown
  * @param {string|null} subjectId ID de materia asociada (null = Entrada)
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function createNote(title = 'Sin título', content = '', subjectId = null) {
+export async function createNote(title = 'Sin título', content = '', subjectId = null, scope) {
   return runWriteOperation('createNote', async () => {
-    const db = getDb()
+    const db = getDb(scope)
 
     const note = {
       id: generateUUID(),
@@ -59,7 +50,7 @@ export async function createNote(title = 'Sin título', content = '', subjectId 
     `
     const values = [note.id, note.title, note.content, note.pinned, note.archived, note.statusEmoji, note.subjectId, note.createdAt, note.updatedAt]
 
-    await runSql(db, sql, values)
+    await db.run(sql, values)
 
     return {
       ...note,
@@ -72,9 +63,10 @@ export async function createNote(title = 'Sin título', content = '', subjectId 
 
 /**
  * Obtiene una nota por su ID.
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function getNoteById(id) {
-  const db = getDb()
+export async function getNoteById(id, scope) {
+  const db = getDb(scope)
 
   const sql = `SELECT * FROM notes WHERE id = ?`
   const res = await db.query(sql, [id])
@@ -92,9 +84,10 @@ export async function getNoteById(id) {
 
 /**
  * Obtiene todas las notas ordenadas por fecha de actualización descendente.
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function getAllNotes() {
-  const db = getDb()
+export async function getAllNotes(scope) {
+  const db = getDb(scope)
 
   const sql = `SELECT * FROM notes WHERE deletedAt IS NULL ORDER BY updatedAt DESC`
   const res = await db.query(sql)
@@ -108,12 +101,13 @@ export async function getAllNotes() {
 
 /**
  * Actualiza campos de una nota existente.
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function updateNote(id, changes) {
+export async function updateNote(id, changes, scope) {
   return runWriteOperation('updateNote', async () => {
-    const db = getDb()
+    const db = getDb(scope)
 
-    const existing = await getNoteById(id)
+    const existing = await getNoteById(id, scope)
     if (!existing) {
       throw new Error(`Nota con id "${id}" no encontrada.`)
     }
@@ -153,7 +147,7 @@ export async function updateNote(id, changes) {
     values.push(id)
 
     const sql = `UPDATE notes SET ${fields.join(', ')} WHERE id = ?`
-    await runSql(db, sql, values)
+    await db.run(sql, values)
 
     return {
       ...existing,
@@ -165,21 +159,23 @@ export async function updateNote(id, changes) {
 
 /**
  * Soft-delete: marca una nota como eliminada (papelera).
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function deleteNote(id) {
+export async function deleteNote(id, scope) {
   return runWriteOperation('deleteNote', async () => {
-    const db = getDb()
+    const db = getDb(scope)
 
     const sql = `UPDATE notes SET deletedAt = ? WHERE id = ?`
-    await runSql(db, sql, [new Date().toISOString(), id])
+    await db.run(sql, [new Date().toISOString(), id])
   })
 }
 
 /**
  * Cuenta el total de notas activas (no eliminadas).
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function countNotes() {
-  const db = getDb()
+export async function countNotes(scope) {
+  const db = getDb(scope)
 
   const sql = `SELECT COUNT(*) as count FROM notes WHERE deletedAt IS NULL`
   const res = await db.query(sql)
@@ -194,9 +190,10 @@ export async function countNotes() {
 
 /**
  * Obtiene todas las notas en la papelera, ordenadas por fecha de eliminación.
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function getDeletedNotes() {
-  const db = getDb()
+export async function getDeletedNotes(scope) {
+  const db = getDb(scope)
 
   const sql = `SELECT * FROM notes WHERE deletedAt IS NOT NULL ORDER BY deletedAt DESC`
   const res = await db.query(sql)
@@ -210,45 +207,49 @@ export async function getDeletedNotes() {
 
 /**
  * Restaura una nota eliminada (quita deletedAt).
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function restoreNote(id) {
+export async function restoreNote(id, scope) {
   return runWriteOperation('restoreNote', async () => {
-    const db = getDb()
+    const db = getDb(scope)
 
     const sql = `UPDATE notes SET deletedAt = NULL WHERE id = ?`
-    await runSql(db, sql, [id])
+    await db.run(sql, [id])
   })
 }
 
 /**
  * Elimina permanentemente una nota (DELETE físico).
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function permanentlyDeleteNote(id) {
+export async function permanentlyDeleteNote(id, scope) {
   return runWriteOperation('permanentlyDeleteNote', async () => {
-    const db = getDb()
+    const db = getDb(scope)
 
     const sql = `DELETE FROM notes WHERE id = ?`
-    await runSql(db, sql, [id])
+    await db.run(sql, [id])
   })
 }
 
 /**
  * Vacía la papelera de notas (DELETE físico de todas las eliminadas).
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function emptyTrashNotes() {
+export async function emptyTrashNotes(scope) {
   return runWriteOperation('emptyTrashNotes', async () => {
-    const db = getDb()
+    const db = getDb(scope)
 
     const sql = `DELETE FROM notes WHERE deletedAt IS NOT NULL`
-    await runSql(db, sql)
+    await db.run(sql)
   })
 }
 
 /**
  * Cuenta las notas en la papelera.
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function countDeletedNotes() {
-  const db = getDb()
+export async function countDeletedNotes(scope) {
+  const db = getDb(scope)
 
   const sql = `SELECT COUNT(*) as count FROM notes WHERE deletedAt IS NOT NULL`
   const res = await db.query(sql)
@@ -259,31 +260,33 @@ export async function countDeletedNotes() {
 /**
  * Purga notas eliminadas hace más de N días (auto-purgado).
  * @param {number} days Días de retención (default: 30)
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function purgeOldDeletedNotes(days = 30) {
+export async function purgeOldDeletedNotes(days = 30, scope) {
   return runWriteOperation('purgeOldDeletedNotes', async () => {
-    const db = getDb()
+    const db = getDb(scope)
 
     const cutoff = new Date()
     cutoff.setDate(cutoff.getDate() - days)
     const cutoffISO = cutoff.toISOString()
 
     const sql = `DELETE FROM notes WHERE deletedAt IS NOT NULL AND deletedAt < ?`
-    await runSql(db, sql, [cutoffISO])
+    await db.run(sql, [cutoffISO])
   })
 }
 
 /**
  * Soft-delete en cascada: todas las notas de un subject.
  * @param {string} subjectId ID de la materia
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function softDeleteNotesBySubject(subjectId) {
+export async function softDeleteNotesBySubject(subjectId, scope) {
   return runWriteOperation('softDeleteNotesBySubject', async () => {
-    const db = getDb()
+    const db = getDb(scope)
     const now = new Date().toISOString()
 
     const sql = `UPDATE notes SET deletedAt = ? WHERE subjectId = ? AND deletedAt IS NULL`
-    await runSql(db, sql, [now, subjectId])
+    await db.run(sql, [now, subjectId])
   })
 }
 
@@ -291,12 +294,13 @@ export async function softDeleteNotesBySubject(subjectId) {
  * Restaurar en cascada: todas las notas eliminadas de un subject.
  * Solo restaura notas cuyo deletedAt no sea NULL.
  * @param {string} subjectId ID de la materia
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function restoreNotesBySubject(subjectId) {
+export async function restoreNotesBySubject(subjectId, scope) {
   return runWriteOperation('restoreNotesBySubject', async () => {
-    const db = getDb()
+    const db = getDb(scope)
 
     const sql = `UPDATE notes SET deletedAt = NULL WHERE subjectId = ? AND deletedAt IS NOT NULL`
-    await runSql(db, sql, [subjectId])
+    await db.run(sql, [subjectId])
   })
 }

--- a/src/services/sqlite/subjects.js
+++ b/src/services/sqlite/subjects.js
@@ -7,7 +7,7 @@
 // La validación de negocio la hace SubjectService.
 // =============================================================
 
-import { getDb, persistWeb, isWriteTransactionActive } from './connection.js'
+import { getDb } from './connection.js'
 import { DatabaseError } from './errors.js'
 
 async function runWriteOperation(operation, action) {
@@ -19,25 +19,16 @@ async function runWriteOperation(operation, action) {
   }
 }
 
-async function runSql(db, sql, values) {
-  if (isWriteTransactionActive()) {
-    await db.run(sql, values || [], false)
-  } else if (values === undefined) {
-    await db.run(sql)
-  } else {
-    await db.run(sql, values)
-  }
-  await persistWeb()
-}
 
 /**
  * Inserta una materia en la base de datos.
  * La validación de negocio (nombre, unicidad, profundidad) la hace SubjectService.
  * @param {object} subject Objeto con id, name, color, parentSubjectId, createdAt
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function createSubjectRow(subject) {
+export async function createSubjectRow(subject, scope) {
   return runWriteOperation('createSubjectRow', async () => {
-    const db = getDb()
+    const db = getDb(scope)
 
     const sql = `
       INSERT INTO subjects (id, name, parentSubjectId, archived, color, createdAt)
@@ -52,15 +43,16 @@ export async function createSubjectRow(subject) {
       subject.createdAt
     ]
 
-    await runSql(db, sql, values)
+    await db.run(sql, values)
   })
 }
 
 /**
  * Obtiene todas las materias no archivadas, ordenadas por nombre.
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function getAllSubjectRows() {
-  const db = getDb()
+export async function getAllSubjectRows(scope) {
+  const db = getDb(scope)
 
   const sql = `SELECT * FROM subjects WHERE archived = 0 AND deletedAt IS NULL ORDER BY name ASC`
   const res = await db.query(sql)
@@ -74,9 +66,10 @@ export async function getAllSubjectRows() {
 /**
  * Obtiene todas las materias no eliminadas, incluyendo archivadas.
  * Usado por validaciones para evitar duplicados invisibles.
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function getAllSubjectRowsIncludingArchived() {
-  const db = getDb()
+export async function getAllSubjectRowsIncludingArchived(scope) {
+  const db = getDb(scope)
 
   const sql = `SELECT * FROM subjects WHERE deletedAt IS NULL ORDER BY name ASC`
   const res = await db.query(sql)
@@ -89,9 +82,10 @@ export async function getAllSubjectRowsIncludingArchived() {
 
 /**
  * Obtiene una materia por su ID.
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function getSubjectRowById(id) {
-  const db = getDb()
+export async function getSubjectRowById(id, scope) {
+  const db = getDb(scope)
 
   const sql = `SELECT * FROM subjects WHERE id = ?`
   const res = await db.query(sql, [id])
@@ -105,10 +99,11 @@ export async function getSubjectRowById(id) {
 
 /**
  * Actualiza campos de una materia existente.
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function updateSubjectRow(id, changes) {
+export async function updateSubjectRow(id, changes, scope) {
   return runWriteOperation('updateSubjectRow', async () => {
-    const db = getDb()
+    const db = getDb(scope)
 
     const fields = []
     const values = []
@@ -134,28 +129,30 @@ export async function updateSubjectRow(id, changes) {
 
     values.push(id)
     const sql = `UPDATE subjects SET ${fields.join(', ')} WHERE id = ?`
-    await runSql(db, sql, values)
+    await db.run(sql, values)
   })
 }
 
 /**
  * Soft-delete: marca una materia como eliminada (papelera).
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function deleteSubjectRow(id) {
+export async function deleteSubjectRow(id, scope) {
   return runWriteOperation('deleteSubjectRow', async () => {
-    const db = getDb()
+    const db = getDb(scope)
 
     const sql = `UPDATE subjects SET deletedAt = ? WHERE id = ?`
-    await runSql(db, sql, [new Date().toISOString(), id])
+    await db.run(sql, [new Date().toISOString(), id])
   })
 }
 
 /**
  * Cuenta las notas activas (no archivadas, no eliminadas) de una materia.
  * @param {string} subjectId ID de la materia
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function countNotesBySubject(subjectId) {
-  const db = getDb()
+export async function countNotesBySubject(subjectId, scope) {
+  const db = getDb(scope)
 
   const sql = `SELECT COUNT(*) as count FROM notes WHERE subjectId = ? AND archived = 0 AND deletedAt IS NULL`
   const res = await db.query(sql, [subjectId])
@@ -165,9 +162,10 @@ export async function countNotesBySubject(subjectId) {
 
 /**
  * Cuenta las notas activas sin materia asignada (Entrada/Inbox).
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function getInboxCount() {
-  const db = getDb()
+export async function getInboxCount(scope) {
+  const db = getDb(scope)
 
   const sql = `SELECT COUNT(*) as count FROM notes WHERE subjectId IS NULL AND archived = 0 AND deletedAt IS NULL`
   const res = await db.query(sql)
@@ -179,9 +177,10 @@ export async function getInboxCount() {
  * Obtiene los IDs de todos los subjects archivados (no eliminados).
  * Usado por noteFilters para saber qué notas ocultar/mostrar por herencia.
  * @returns {string[]} IDs de subjects archivados
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function getArchivedSubjectIds() {
-  const db = getDb()
+export async function getArchivedSubjectIds(scope) {
+  const db = getDb(scope)
 
   const sql = `SELECT id FROM subjects WHERE archived = 1 AND deletedAt IS NULL`
   const res = await db.query(sql)
@@ -193,9 +192,10 @@ export async function getArchivedSubjectIds() {
  * Cuenta notas de un subject (incluyendo notas archivadas, excluyendo eliminadas).
  * Se usa para el conteo en la vista de materias archivadas.
  * @param {string} subjectId ID de la materia/sección
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function countNotesBySubjectIncludingArchived(subjectId) {
-  const db = getDb()
+export async function countNotesBySubjectIncludingArchived(subjectId, scope) {
+  const db = getDb(scope)
 
   const sql = `SELECT COUNT(*) as count FROM notes WHERE subjectId = ? AND deletedAt IS NULL`
   const res = await db.query(sql, [subjectId])
@@ -207,9 +207,10 @@ export async function countNotesBySubjectIncludingArchived(subjectId) {
  * Obtiene materias archivadas como árbol (para mostrar en drawer/vista archivadas).
  * Incluye materias activas como contenedor cuando tienen secciones archivadas.
  * @returns {{ tree: object[] }}
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function getArchivedSubjectTree() {
-  const db = getDb()
+export async function getArchivedSubjectTree(scope) {
+  const db = getDb(scope)
 
   const sql = `SELECT * FROM subjects WHERE deletedAt IS NULL ORDER BY name ASC`
   const res = await db.query(sql)
@@ -226,11 +227,11 @@ export async function getArchivedSubjectTree() {
     const rootChildren = archivedChildren.filter(c => c.parentSubjectId === root.id)
     if (!root.archived && rootChildren.length === 0) continue
 
-    const rootCount = await countNotesBySubjectIncludingArchived(root.id)
+    const rootCount = await countNotesBySubjectIncludingArchived(root.id, scope)
     const childrenWithCounts = []
 
     for (const child of rootChildren) {
-      const childCount = await countNotesBySubjectIncludingArchived(child.id)
+      const childCount = await countNotesBySubjectIncludingArchived(child.id, scope)
       childrenWithCounts.push({ ...child, noteCount: childCount })
     }
 
@@ -248,9 +249,10 @@ export async function getArchivedSubjectTree() {
 
 /**
  * Obtiene materias/secciones eliminadas.
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function getDeletedSubjectRows() {
-  const db = getDb()
+export async function getDeletedSubjectRows(scope) {
+  const db = getDb(scope)
 
   const sql = `SELECT * FROM subjects WHERE deletedAt IS NOT NULL ORDER BY deletedAt DESC`
   const res = await db.query(sql)
@@ -263,64 +265,69 @@ export async function getDeletedSubjectRows() {
 
 /**
  * Restaura una materia eliminada (quita deletedAt).
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function restoreSubjectRow(id) {
+export async function restoreSubjectRow(id, scope) {
   return runWriteOperation('restoreSubjectRow', async () => {
-    const db = getDb()
+    const db = getDb(scope)
 
     const sql = `UPDATE subjects SET deletedAt = NULL WHERE id = ?`
-    await runSql(db, sql, [id])
+    await db.run(sql, [id])
   })
 }
 
 /**
  * Elimina permanentemente una materia (DELETE físico).
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function permanentlyDeleteSubjectRow(id) {
+export async function permanentlyDeleteSubjectRow(id, scope) {
   return runWriteOperation('permanentlyDeleteSubjectRow', async () => {
-    const db = getDb()
+    const db = getDb(scope)
 
     const sql = `DELETE FROM subjects WHERE id = ?`
-    await runSql(db, sql, [id])
+    await db.run(sql, [id])
   })
 }
 
 /**
  * Vacía la papelera de materias (DELETE físico).
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function emptyTrashSubjects() {
+export async function emptyTrashSubjects(scope) {
   return runWriteOperation('emptyTrashSubjects', async () => {
-    const db = getDb()
+    const db = getDb(scope)
 
     const sql = `DELETE FROM subjects WHERE deletedAt IS NOT NULL`
-    await runSql(db, sql)
+    await db.run(sql)
   })
 }
 
 /**
  * Soft-delete secciones hijas de una materia.
  * @param {string} parentId ID de la materia padre
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function softDeleteChildSubjects(parentId) {
+export async function softDeleteChildSubjects(parentId, scope) {
   return runWriteOperation('softDeleteChildSubjects', async () => {
-    const db = getDb()
+    const db = getDb(scope)
     const now = new Date().toISOString()
 
     const sql = `UPDATE subjects SET deletedAt = ? WHERE parentSubjectId = ? AND deletedAt IS NULL`
-    await runSql(db, sql, [now, parentId])
+    await db.run(sql, [now, parentId])
   })
 }
 
 /**
  * Restaura secciones hijas de una materia.
  * @param {string} parentId ID de la materia padre
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function restoreChildSubjects(parentId) {
+export async function restoreChildSubjects(parentId, scope) {
   return runWriteOperation('restoreChildSubjects', async () => {
-    const db = getDb()
+    const db = getDb(scope)
 
     const sql = `UPDATE subjects SET deletedAt = NULL WHERE parentSubjectId = ? AND deletedAt IS NOT NULL`
-    await runSql(db, sql, [parentId])
+    await db.run(sql, [parentId])
   })
 }
 
@@ -328,12 +335,13 @@ export async function restoreChildSubjects(parentId) {
  * Archiva secciones hijas de una materia (cascada).
  * Solo archiva las que NO están archivadas y NO están eliminadas.
  * @param {string} parentId ID de la materia padre
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function archiveChildSubjects(parentId) {
+export async function archiveChildSubjects(parentId, scope) {
   return runWriteOperation('archiveChildSubjects', async () => {
-    const db = getDb()
+    const db = getDb(scope)
     const sql = `UPDATE subjects SET archived = 1 WHERE parentSubjectId = ? AND archived = 0 AND deletedAt IS NULL`
-    await runSql(db, sql, [parentId])
+    await db.run(sql, [parentId])
   })
 }
 
@@ -341,37 +349,40 @@ export async function archiveChildSubjects(parentId) {
  * Desarchiva secciones hijas de una materia (cascada).
  * Solo desarchiva las que están archivadas y NO están eliminadas.
  * @param {string} parentId ID de la materia padre
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function unarchiveChildSubjects(parentId) {
+export async function unarchiveChildSubjects(parentId, scope) {
   return runWriteOperation('unarchiveChildSubjects', async () => {
-    const db = getDb()
+    const db = getDb(scope)
     const sql = `UPDATE subjects SET archived = 0 WHERE parentSubjectId = ? AND archived = 1 AND deletedAt IS NULL`
-    await runSql(db, sql, [parentId])
+    await db.run(sql, [parentId])
   })
 }
 
 /**
  * Purga materias eliminadas hace más de N días.
  * @param {number} days Días de retención (default: 30)
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function purgeOldDeletedSubjects(days = 30) {
+export async function purgeOldDeletedSubjects(days = 30, scope) {
   return runWriteOperation('purgeOldDeletedSubjects', async () => {
-    const db = getDb()
+    const db = getDb(scope)
 
     const cutoff = new Date()
     cutoff.setDate(cutoff.getDate() - days)
     const cutoffISO = cutoff.toISOString()
 
     const sql = `DELETE FROM subjects WHERE deletedAt IS NOT NULL AND deletedAt < ?`
-    await runSql(db, sql, [cutoffISO])
+    await db.run(sql, [cutoffISO])
   })
 }
 
 /**
  * Cuenta el total de items en papelera (notas + materias).
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function countTrashItems() {
-  const db = getDb()
+export async function countTrashItems(scope) {
+  const db = getDb(scope)
 
   const notesRes = await db.query(`SELECT COUNT(*) as count FROM notes WHERE deletedAt IS NOT NULL`)
   const subjectsRes = await db.query(`SELECT COUNT(*) as count FROM subjects WHERE deletedAt IS NOT NULL`)
@@ -386,9 +397,10 @@ export async function countTrashItems() {
  * Obtiene los IDs de las secciones hijas de una materia (incluye eliminadas).
  * @param {string} parentId ID de la materia padre
  * @returns {string[]} IDs de secciones hijas
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function getChildSubjectIds(parentId) {
-  const db = getDb()
+export async function getChildSubjectIds(parentId, scope) {
+  const db = getDb(scope)
 
   const sql = `SELECT id FROM subjects WHERE parentSubjectId = ?`
   const res = await db.query(sql, [parentId])
@@ -399,9 +411,10 @@ export async function getChildSubjectIds(parentId) {
 /**
  * Cuenta notas eliminadas de un subject específico (para preview en papelera).
  * @param {string} subjectId ID de la materia
+ * @param {object} [scope] Propietario explícito para composición transaccional.
  */
-export async function countDeletedNotesBySubject(subjectId) {
-  const db = getDb()
+export async function countDeletedNotesBySubject(subjectId, scope) {
+  const db = getDb(scope)
 
   const sql = `SELECT COUNT(*) as count FROM notes WHERE subjectId = ? AND deletedAt IS NOT NULL`
   const res = await db.query(sql, [subjectId])

--- a/src/services/sqlite/writeCoordinator.js
+++ b/src/services/sqlite/writeCoordinator.js
@@ -1,0 +1,115 @@
+// Una cola por conexión; el capability de una transacción nunca es ambiental.
+export function createWriteCoordinator(db, persist) {
+  let tail = Promise.resolve()
+  let fault = null
+  const scopes = new WeakMap()
+
+  function assertHealthy() {
+    if (fault) throw new Error('SQLite connection requires recovery', { cause: fault })
+  }
+
+  function enqueue(action) {
+    const result = tail.then(() => {
+      assertHealthy()
+      return action()
+    })
+    // Recupera la cola, no el resultado público ni la salud de la conexión.
+    tail = result.then(() => undefined, () => undefined)
+    return result
+  }
+
+  function getScope(scope) {
+    const state = scopes.get(scope)
+    if (!state?.active) throw new Error('Invalid or expired SQLite transaction scope')
+    assertHealthy()
+    return state
+  }
+
+  function createScope() {
+    const state = { active: true, tail: Promise.resolve(), failure: null }
+    async function schedule(action) {
+      getScope(scope)
+      const result = state.tail.then(action)
+      state.tail = result.then(() => undefined, error => { state.failure ??= error })
+      return result
+    }
+    const scope = Object.freeze({
+      run: (sql, values = []) => schedule(() => db.run(sql, values, false)),
+      query: (sql, values = []) => schedule(() => db.query(sql, values)),
+    })
+    scopes.set(scope, state)
+    return { scope, state }
+  }
+
+  async function executeTransaction(action) {
+    const { scope, state } = createScope()
+    let phase = 'begin'
+    try {
+      await db.beginTransaction()
+      phase = 'action'
+      const result = await action(scope)
+      state.active = false
+      await state.tail
+      if (state.failure) throw state.failure
+      phase = 'commit'
+      await db.commitTransaction()
+      phase = 'persist'
+      await persist()
+      return result
+    } catch (error) {
+      state.active = false
+      await state.tail
+      // Un begin/commit ambiguo o persistencia fallida exige recuperación explícita.
+      if (phase !== 'action') fault = error
+      if (phase !== 'persist') {
+        try {
+          await db.rollbackTransaction()
+        } catch (rollbackError) {
+          fault = error
+          console.error('[SQLite] Falló rollback; conexión en cuarentena:', rollbackError)
+        }
+      }
+      throw error
+    } finally {
+      state.active = false
+    }
+  }
+
+  async function transaction(action, scope) {
+    if (scope === undefined) return enqueue(() => executeTransaction(action))
+    const state = getScope(scope)
+    try {
+      return await action(scope)
+    } catch (error) {
+      state.failure ??= error // Ni un catch interno puede confirmar una cascada incompleta.
+      throw error
+    }
+  }
+
+  const connection = Object.freeze({
+    run: (sql, values) => transaction(scope => scope.run(sql, values)),
+    query: (sql, values = []) => enqueue(() => db.query(sql, values)),
+  })
+
+  return {
+    getDb(scope) {
+      assertHealthy()
+      if (scope !== undefined) getScope(scope)
+      return scope === undefined ? connection : scope
+    },
+    transaction,
+    isActive: scope => Boolean(scopes.get(scope)?.active),
+    persist(scope) {
+      if (scope !== undefined) {
+        getScope(scope)
+        return Promise.resolve() // Resultado provisional; persiste la propietaria.
+      }
+      return enqueue(async () => {
+        try { await persist() } catch (error) { fault = error; throw error }
+      })
+    },
+    invalidate(error) { fault = error },
+    isHealthy: () => !fault,
+    drain: () => tail,
+  }
+}

--- a/tests/unit/SubjectService.test.js
+++ b/tests/unit/SubjectService.test.js
@@ -39,8 +39,10 @@ vi.mock('../../src/services/sqlite/notes.js', () => ({
   restoreNote: vi.fn().mockResolvedValue(undefined),
 }))
 
+const scope = vi.hoisted(() => Object.freeze({ owner: 'transaction' }))
+
 vi.mock('../../src/services/sqlite/connection.js', () => ({
-  runTransaction: vi.fn(async action => action()),
+  runTransaction: vi.fn(async action => action(scope)),
 }))
 
 function subject(overrides = {}) {
@@ -249,13 +251,13 @@ describe('SubjectService', () => {
     it('llama softDeleteNotesBySubject para el subject padre', async () => {
       await SubjectService.deleteSubject('subj-1')
 
-      expect(NoteRows.softDeleteNotesBySubject).toHaveBeenCalledWith('subj-1')
+      expect(NoteRows.softDeleteNotesBySubject).toHaveBeenCalledWith('subj-1', scope)
     })
 
     it('llama getChildSubjectIds para obtener secciones hijas', async () => {
       await SubjectService.deleteSubject('subj-1')
 
-      expect(SubjectRows.getChildSubjectIds).toHaveBeenCalledWith('subj-1')
+      expect(SubjectRows.getChildSubjectIds).toHaveBeenCalledWith('subj-1', scope)
     })
 
     it('llama softDeleteNotesBySubject para cada sección hija', async () => {
@@ -263,20 +265,20 @@ describe('SubjectService', () => {
 
       await SubjectService.deleteSubject('subj-1')
 
-      expect(NoteRows.softDeleteNotesBySubject).toHaveBeenCalledWith('sec-1')
-      expect(NoteRows.softDeleteNotesBySubject).toHaveBeenCalledWith('sec-2')
+      expect(NoteRows.softDeleteNotesBySubject).toHaveBeenCalledWith('sec-1', scope)
+      expect(NoteRows.softDeleteNotesBySubject).toHaveBeenCalledWith('sec-2', scope)
     })
 
     it('llama softDeleteChildSubjects para el subject padre', async () => {
       await SubjectService.deleteSubject('subj-1')
 
-      expect(SubjectRows.softDeleteChildSubjects).toHaveBeenCalledWith('subj-1')
+      expect(SubjectRows.softDeleteChildSubjects).toHaveBeenCalledWith('subj-1', scope)
     })
 
     it('llama deleteSubjectRow para el subject padre', async () => {
       await SubjectService.deleteSubject('subj-1')
 
-      expect(SubjectRows.deleteSubjectRow).toHaveBeenCalledWith('subj-1')
+      expect(SubjectRows.deleteSubjectRow).toHaveBeenCalledWith('subj-1', scope)
     })
 
     it('el orden es correcto: notas padre, notas hijos, hijos, padre', async () => {
@@ -308,7 +310,7 @@ describe('SubjectService', () => {
 
       await SubjectService.restoreSubject('subj-1')
 
-      expect(SubjectRows.restoreSubjectRow).toHaveBeenCalledWith('subj-1')
+      expect(SubjectRows.restoreSubjectRow).toHaveBeenCalledWith('subj-1', scope)
     })
 
     it('restaura secciones hijas una por una', async () => {
@@ -320,7 +322,7 @@ describe('SubjectService', () => {
 
       await SubjectService.restoreSubject('subj-1')
 
-      expect(SubjectRows.restoreSubjectRow).toHaveBeenCalledWith('sec-1')
+      expect(SubjectRows.restoreSubjectRow).toHaveBeenCalledWith('sec-1', scope)
     })
 
     it('llama restoreNotesBySubject para el subject padre', async () => {
@@ -328,7 +330,7 @@ describe('SubjectService', () => {
 
       await SubjectService.restoreSubject('subj-1')
 
-      expect(NoteRows.restoreNotesBySubject).toHaveBeenCalledWith('subj-1')
+      expect(NoteRows.restoreNotesBySubject).toHaveBeenCalledWith('subj-1', scope)
     })
 
     it('llama restoreNotesBySubject para cada sección hija', async () => {
@@ -341,8 +343,8 @@ describe('SubjectService', () => {
 
       await SubjectService.restoreSubject('subj-1')
 
-      expect(NoteRows.restoreNotesBySubject).toHaveBeenCalledWith('sec-1')
-      expect(NoteRows.restoreNotesBySubject).toHaveBeenCalledWith('sec-2')
+      expect(NoteRows.restoreNotesBySubject).toHaveBeenCalledWith('sec-1', scope)
+      expect(NoteRows.restoreNotesBySubject).toHaveBeenCalledWith('sec-2', scope)
     })
 
     it('renombra al restaurar si ya existe una materia activa con el mismo nombre', async () => {
@@ -355,8 +357,8 @@ describe('SubjectService', () => {
 
       expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('deleted-root', {
         name: 'Programación II (restaurada)',
-      })
-      expect(SubjectRows.restoreSubjectRow).toHaveBeenCalledWith('deleted-root')
+      }, scope)
+      expect(SubjectRows.restoreSubjectRow).toHaveBeenCalledWith('deleted-root', scope)
     })
   })
 
@@ -364,13 +366,13 @@ describe('SubjectService', () => {
     it('archiva secciones hijas', async () => {
       await SubjectService.archiveSubject('subj-1')
 
-      expect(SubjectRows.archiveChildSubjects).toHaveBeenCalledWith('subj-1')
+      expect(SubjectRows.archiveChildSubjects).toHaveBeenCalledWith('subj-1', scope)
     })
 
     it('archiva el subject padre', async () => {
       await SubjectService.archiveSubject('subj-1')
 
-      expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('subj-1', { archived: true })
+      expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('subj-1', { archived: true }, scope)
     })
 
     it('NO archiva las notas', async () => {
@@ -398,7 +400,7 @@ describe('SubjectService', () => {
 
       await SubjectService.unarchiveSubject('subj-1')
 
-      expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('subj-1', { archived: false })
+      expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('subj-1', { archived: false }, scope)
     })
 
     it('desarchiva secciones hijas una por una', async () => {
@@ -410,7 +412,7 @@ describe('SubjectService', () => {
 
       await SubjectService.unarchiveSubject('subj-1')
 
-      expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('sec-1', { archived: false })
+      expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('sec-1', { archived: false }, scope)
     })
 
     it('NO desarchiva las notas', async () => {
@@ -434,7 +436,7 @@ describe('SubjectService', () => {
       expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('archived-root', {
         archived: false,
         name: 'Programación II (restaurada)',
-      })
+      }, scope)
     })
   })
 
@@ -442,7 +444,7 @@ describe('SubjectService', () => {
     it('archiva solo la sección, sin tocar notas', async () => {
       await SubjectService.archiveSection('sec-1')
 
-      expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('sec-1', { archived: true })
+      expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('sec-1', { archived: true }, scope)
       expect(NoteRows.archiveNotesBySubject).not.toHaveBeenCalled()
     })
   })
@@ -464,7 +466,7 @@ describe('SubjectService', () => {
 
       await SubjectService.unarchiveSection('sec-1')
 
-      expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('sec-1', { archived: false })
+      expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('sec-1', { archived: false }, scope)
       expect(NoteRows.unarchiveNotesBySubject).not.toHaveBeenCalled()
     })
 
@@ -479,8 +481,8 @@ describe('SubjectService', () => {
 
       await SubjectService.unarchiveSection('sec-1')
 
-      expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('subj-1', { archived: false })
-      expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('sec-1', { archived: false })
+      expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('subj-1', { archived: false }, scope)
+      expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('sec-1', { archived: false }, scope)
       expect(SubjectRows.updateSubjectRow.mock.invocationCallOrder[0])
         .toBeLessThan(SubjectRows.updateSubjectRow.mock.invocationCallOrder[1])
     })
@@ -497,7 +499,7 @@ describe('SubjectService', () => {
       await SubjectService.unarchiveSection('sec-1')
 
       expect(SubjectRows.updateSubjectRow).toHaveBeenCalledTimes(1)
-      expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('sec-1', { archived: false })
+      expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('sec-1', { archived: false }, scope)
     })
 
     it('renombra al restaurar si ya existe una sección hermana con el mismo nombre', async () => {
@@ -515,7 +517,7 @@ describe('SubjectService', () => {
       expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('archived-sec', {
         archived: false,
         name: 'Unidad I (restaurada)',
-      })
+      }, scope)
     })
   })
 
@@ -539,8 +541,8 @@ describe('SubjectService', () => {
     it('elimina notas de la sección y luego la sección', async () => {
       await SubjectService.deleteSection('sec-1')
 
-      expect(NoteRows.softDeleteNotesBySubject).toHaveBeenCalledWith('sec-1')
-      expect(SubjectRows.deleteSubjectRow).toHaveBeenCalledWith('sec-1')
+      expect(NoteRows.softDeleteNotesBySubject).toHaveBeenCalledWith('sec-1', scope)
+      expect(SubjectRows.deleteSubjectRow).toHaveBeenCalledWith('sec-1', scope)
       expect(NoteRows.softDeleteNotesBySubject.mock.invocationCallOrder[0])
         .toBeLessThan(SubjectRows.deleteSubjectRow.mock.invocationCallOrder[0])
     })
@@ -562,9 +564,9 @@ describe('SubjectService', () => {
 
       await SubjectService.restoreSection('sec-1')
 
-      expect(SubjectRows.restoreSubjectRow).toHaveBeenCalledWith('subj-1')
-      expect(SubjectRows.restoreSubjectRow).toHaveBeenCalledWith('sec-1')
-      expect(NoteRows.restoreNotesBySubject).toHaveBeenCalledWith('sec-1')
+      expect(SubjectRows.restoreSubjectRow).toHaveBeenCalledWith('subj-1', scope)
+      expect(SubjectRows.restoreSubjectRow).toHaveBeenCalledWith('sec-1', scope)
+      expect(NoteRows.restoreNotesBySubject).toHaveBeenCalledWith('sec-1', scope)
       expect(SubjectRows.restoreSubjectRow.mock.invocationCallOrder[0])
         .toBeLessThan(SubjectRows.restoreSubjectRow.mock.invocationCallOrder[1])
     })
@@ -576,8 +578,8 @@ describe('SubjectService', () => {
 
       await SubjectService.restoreSection('sec-1')
 
-      expect(SubjectRows.updateSubjectRow).not.toHaveBeenCalledWith('sec-1', { parentSubjectId: null })
-      expect(SubjectRows.restoreSubjectRow).toHaveBeenCalledWith('sec-1')
+      expect(SubjectRows.updateSubjectRow).not.toHaveBeenCalledWith('sec-1', { parentSubjectId: null }, scope)
+      expect(SubjectRows.restoreSubjectRow).toHaveBeenCalledWith('sec-1', scope)
     })
 
     it('si el padre está archivado, lo desarchiva para que la sección sea navegable', async () => {
@@ -590,8 +592,8 @@ describe('SubjectService', () => {
 
       await SubjectService.restoreSection('sec-1')
 
-      expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('subj-1', { archived: false })
-      expect(SubjectRows.restoreSubjectRow).toHaveBeenCalledWith('sec-1')
+      expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('subj-1', { archived: false }, scope)
+      expect(SubjectRows.restoreSubjectRow).toHaveBeenCalledWith('sec-1', scope)
     })
 
     it('renombra al restaurar si ya existe una sección hermana con el mismo nombre', async () => {
@@ -607,8 +609,8 @@ describe('SubjectService', () => {
 
       expect(SubjectRows.updateSubjectRow).toHaveBeenCalledWith('deleted-sec', {
         name: 'Unidad I (restaurada)',
-      })
-      expect(SubjectRows.restoreSubjectRow).toHaveBeenCalledWith('deleted-sec')
+      }, scope)
+      expect(SubjectRows.restoreSubjectRow).toHaveBeenCalledWith('deleted-sec', scope)
     })
   })
 
@@ -627,7 +629,7 @@ describe('SubjectService', () => {
 
       await SubjectService.restoreNoteFromTrash('note-1')
 
-      expect(NoteRows.restoreNote).toHaveBeenCalledWith('note-1')
+      expect(NoteRows.restoreNote).toHaveBeenCalledWith('note-1', scope)
       expect(NoteRows.updateNote).not.toHaveBeenCalled()
     })
 
@@ -637,7 +639,7 @@ describe('SubjectService', () => {
 
       await SubjectService.restoreNoteFromTrash('note-1')
 
-      expect(NoteRows.updateNote).toHaveBeenCalledWith('note-1', { subjectId: null })
+      expect(NoteRows.updateNote).toHaveBeenCalledWith('note-1', { subjectId: null }, scope)
     })
   })
 
@@ -687,8 +689,8 @@ describe('SubjectService', () => {
     it('autoPurge() purga notas y materias con el mismo umbral', async () => {
       await SubjectService.autoPurge(15)
 
-      expect(NoteRows.purgeOldDeletedNotes).toHaveBeenCalledWith(15)
-      expect(SubjectRows.purgeOldDeletedSubjects).toHaveBeenCalledWith(15)
+      expect(NoteRows.purgeOldDeletedNotes).toHaveBeenCalledWith(15, scope)
+      expect(SubjectRows.purgeOldDeletedSubjects).toHaveBeenCalledWith(15, scope)
     })
   })
 

--- a/tests/unit/layout/appStartup.test.js
+++ b/tests/unit/layout/appStartup.test.js
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAppStartup } from '../../../src/layout/appStartup.js'
+import { deferred } from '../services/sqlite/sqliteFixture.js'
+
+let app
+beforeEach(() => {
+  document.body.innerHTML = '<div id="app"></div>'
+  app = document.querySelector('#app')
+})
+
+describe('arranque single-flight', () => {
+  it('devuelve la misma promesa mientras prepara y no repite un montaje exitoso', async () => {
+    const ready = deferred()
+    const prepare = vi.fn(() => ready.promise), mount = vi.fn()
+    const startup = createAppStartup({ app, prepare, mount })
+    const first = startup.start()
+    expect(startup.start()).toBe(first)
+    expect(app.querySelector('[role="status"]')).not.toBeNull()
+    ready.resolve()
+    await expect(first).resolves.toBe(true)
+    await expect(startup.start()).resolves.toBe(true)
+    expect(prepare).toHaveBeenCalledTimes(1)
+    expect(mount).toHaveBeenCalledTimes(1)
+  })
+
+  it('un error de montaje obliga a recargar, no a duplicar componentes parciales', async () => {
+    const prepare = vi.fn(), mount = vi.fn(() => { throw new Error('partial mount') }), reload = vi.fn()
+    const startup = createAppStartup({ app, prepare, mount, reload })
+    await expect(startup.start()).resolves.toBe(false)
+    expect(document.activeElement.id).toBe('startup-title')
+    const button = app.querySelector('button')
+    button.click()
+    button.click()
+    await expect(startup.start()).resolves.toBe(false)
+    await vi.dynamicImportSettled()
+    expect(reload).toHaveBeenCalledTimes(1)
+    expect(mount).toHaveBeenCalledTimes(1)
+    expect(prepare).toHaveBeenCalledTimes(1)
+  })
+
+  it('puede reintentar también una lectura inicial fallida sin montar una UI incompleta', async () => {
+    const prepare = vi.fn().mockRejectedValueOnce(new Error('SQL private')).mockResolvedValue(undefined)
+    const mount = vi.fn()
+    const startup = createAppStartup({ app, prepare, mount })
+    await expect(startup.start()).resolves.toBe(false)
+    expect(mount).not.toHaveBeenCalled()
+    expect(app.textContent).not.toContain('SQL private')
+    await expect(startup.start()).resolves.toBe(true)
+    expect(mount).toHaveBeenCalledTimes(1)
+  })
+
+  it('espera liberar la conexión nativa antes de recargar una WebView parcialmente montada', async () => {
+    const release = deferred(), reload = vi.fn(), beforeReload = vi.fn(() => release.promise)
+    const startup = createAppStartup({
+      app, prepare: vi.fn(), mount: () => { throw new Error('mount') },
+      beforeReload, reload,
+    })
+    await startup.start()
+    app.querySelector('button').click()
+    app.querySelector('button').click()
+    await Promise.resolve()
+    expect(beforeReload).toHaveBeenCalledTimes(1)
+    expect(reload).not.toHaveBeenCalled()
+    release.resolve()
+    await vi.dynamicImportSettled()
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('mantiene reintento si el cierre nativo falla, sin recargar ni duplicar componentes', async () => {
+    const reload = vi.fn(), mount = vi.fn(() => { throw new Error('mount') })
+    const startup = createAppStartup({
+      app, prepare: vi.fn(), mount, reload,
+      beforeReload: vi.fn().mockRejectedValue(new Error('uncertain connection')),
+    })
+    await startup.start()
+    app.querySelector('button').click()
+    await vi.dynamicImportSettled()
+    expect(reload).not.toHaveBeenCalled()
+    expect(app.querySelector('button').disabled).toBe(false)
+    expect(mount).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/main.test.js
+++ b/tests/unit/main.test.js
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  initDatabase: vi.fn(), closeDatabaseForReload: vi.fn(), load: vi.fn(), mount: vi.fn(),
+  subscribe: vi.fn(() => vi.fn()),
+}))
+vi.mock('../../src/services/sqlite/connection.js', () => ({ initDatabase: mocks.initDatabase, closeDatabaseForReload: mocks.closeDatabaseForReload }))
+vi.mock('../../src/store/NoteStore.js', () => ({
+  loadSubjects: mocks.load, loadNotes: mocks.load, loadAcademicEvents: mocks.load,
+  loadAcademicEventsByMonth: mocks.load, loadUpcomingAcademicEvents: mocks.load,
+  loadTrashCount: mocks.load, subscribe: mocks.subscribe, subscribeToStoreErrors: mocks.subscribe,
+}))
+vi.mock('../../src/services/SubjectService.js', () => ({ SUBJECT_COLORS: [], autoPurge: vi.fn() }))
+vi.mock('../../src/components/feed/NoteList.js', () => ({ NoteList: mocks.mount }))
+vi.mock('../../src/components/note-editor/NoteEditor.js', () => ({ NoteEditor: mocks.mount }))
+vi.mock('../../src/components/academic-events/Heatmap.js', () => ({ Heatmap: mocks.mount }))
+vi.mock('../../src/components/academic-events/UpcomingAcademicEvents.js', () => ({ UpcomingAcademicEvents: mocks.mount }))
+vi.mock('../../src/layout/drawerController.js', () => ({ initDrawer: mocks.mount }))
+
+function deferred() {
+  let resolve, reject
+  const promise = new Promise((yes, no) => { resolve = yes; reject = no })
+  return { promise, resolve, reject }
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+  document.body.innerHTML = '<div id="app"></div>'
+  mocks.initDatabase.mockResolvedValue(undefined)
+  mocks.closeDatabaseForReload.mockResolvedValue(undefined)
+  mocks.load.mockResolvedValue(undefined)
+  mocks.mount.mockImplementation(function () {})
+})
+
+describe('AUD-005: composition root recuperable', () => {
+  it('no monta componentes ni suscripciones antes de completar los datos iniciales', async () => {
+    const data = deferred()
+    mocks.load.mockReturnValueOnce(data.promise)
+    await import('../../src/main.js')
+    expect(mocks.mount).not.toHaveBeenCalled()
+    expect(mocks.subscribe).not.toHaveBeenCalled()
+    data.resolve()
+    await vi.dynamicImportSettled()
+  })
+
+  it('muestra error seguro y permite reintentar sin doble inicialización', async () => {
+    const database = deferred()
+    mocks.initDatabase.mockReturnValueOnce(database.promise)
+    await import('../../src/main.js')
+    database.reject(new Error('SQL: private title'))
+    await vi.dynamicImportSettled()
+    const alert = document.querySelector('[role="alert"]')
+    expect(alert?.textContent).toContain('No se pudo iniciar Lumapse')
+    expect(document.body.textContent).not.toContain('private title')
+    expect(mocks.mount).not.toHaveBeenCalled()
+    const retry = document.querySelector('#startup-retry')
+    expect(retry).not.toBeNull()
+    retry.click()
+    retry.click()
+    await vi.dynamicImportSettled()
+    expect(mocks.initDatabase).toHaveBeenCalledTimes(2)
+    expect(mocks.mount).toHaveBeenCalledTimes(5)
+    expect(mocks.subscribe).toHaveBeenCalledTimes(2)
+    expect(document.querySelector('#composer-container')).not.toBeNull()
+  })
+})
+
+
+it('conecta el cierre SQLite al reintento de un montaje parcial fallido', async () => {
+  const release = deferred()
+  mocks.mount.mockImplementationOnce(function () { throw new Error('partial mount') })
+  mocks.closeDatabaseForReload.mockReturnValueOnce(release.promise)
+  await import('../../src/main.js')
+  await vi.dynamicImportSettled()
+  document.querySelector('#startup-retry').click()
+  await Promise.resolve()
+  expect(mocks.closeDatabaseForReload).toHaveBeenCalledTimes(1)
+  release.reject(new Error('native connection uncertain'))
+  await vi.dynamicImportSettled()
+  expect(document.querySelector('#startup-retry').disabled).toBe(false)
+  expect(mocks.mount).toHaveBeenCalledTimes(1)
+})

--- a/tests/unit/services/backup/BackupImportDataSource.test.js
+++ b/tests/unit/services/backup/BackupImportDataSource.test.js
@@ -3,13 +3,15 @@ import * as Connection from '../../../../src/services/sqlite/connection.js'
 import { buildBackupManifest } from '../../../../src/services/backup/BackupFormat.ts'
 import { applyBackupImportPlan } from '../../../../src/services/backup/BackupImportDataSource.ts'
 
+const scope = vi.hoisted(() => Object.freeze({ owner: 'import' }))
+
 const mockDb = vi.hoisted(() => ({
   run: vi.fn(),
 }))
 
 vi.mock('../../../../src/services/sqlite/connection.js', () => ({
   getDb: vi.fn(() => mockDb),
-  runTransaction: vi.fn(async action => action()),
+  runTransaction: vi.fn(async action => action(scope)),
 }))
 
 const CREATED_AT = '2026-06-03T12:30:00.000Z'
@@ -102,13 +104,14 @@ describe('BackupImportDataSource', () => {
 
     expect(Connection.runTransaction).toHaveBeenCalledTimes(1)
     expect(Connection.getDb).toHaveBeenCalledTimes(1)
+    expect(Connection.getDb).toHaveBeenCalledWith(scope)
     expect(mockDb.run).toHaveBeenCalledTimes(3)
     expect(mockDb.run.mock.calls[0][0]).toContain('INSERT INTO subjects')
     expect(mockDb.run.mock.calls[1][0]).toContain('INSERT INTO notes')
     expect(mockDb.run.mock.calls[2][0]).toContain('INSERT INTO academic_events')
-    expect(mockDb.run.mock.calls[0][2]).toBe(false)
-    expect(mockDb.run.mock.calls[1][2]).toBe(false)
-    expect(mockDb.run.mock.calls[2][2]).toBe(false)
+    expect(mockDb.run.mock.calls[0]).toHaveLength(2)
+    expect(mockDb.run.mock.calls[1]).toHaveLength(2)
+    expect(mockDb.run.mock.calls[2]).toHaveLength(2)
     expect(result.imported).toEqual({
       subjects: 1,
       notes: 1,

--- a/tests/unit/services/sqlite/academicEvents.test.js
+++ b/tests/unit/services/sqlite/academicEvents.test.js
@@ -10,8 +10,6 @@ const mockDb = vi.hoisted(() => ({
 
 vi.mock('../../../../src/services/sqlite/connection.js', () => ({
   getDb: vi.fn(() => mockDb),
-  persistWeb: vi.fn().mockResolvedValue(undefined),
-  isWriteTransactionActive: vi.fn(() => false),
 }))
 
 function eventRow(overrides = {}) {
@@ -31,7 +29,6 @@ beforeEach(() => {
   vi.clearAllMocks()
   mockDb.run.mockResolvedValue(undefined)
   mockDb.query.mockResolvedValue({ values: [] })
-  connection.isWriteTransactionActive.mockReturnValue(false)
 })
 
 describe('sqlite/academicEvents', () => {
@@ -67,22 +64,27 @@ describe('sqlite/academicEvents', () => {
       ])
     })
 
-    it('llama persistWeb despues de insertar', async () => {
-      await AcademicEvents.createAcademicEventRow(eventRow())
-
-      expect(connection.persistWeb).toHaveBeenCalled()
-      expect(mockDb.run.mock.invocationCallOrder[0]).toBeLessThan(connection.persistWeb.mock.invocationCallOrder[0])
+    it('espera la finalización de la escritura coordinada', async () => {
+      let release
+      mockDb.run.mockReturnValueOnce(new Promise(resolve => { release = resolve }))
+      const finished = vi.fn()
+      const pending = AcademicEvents.createAcademicEventRow(eventRow()).then(finished)
+      await Promise.resolve()
+      expect(finished).not.toHaveBeenCalled()
+      release()
+      await pending
+      expect(finished).toHaveBeenCalledTimes(1)
     })
 
-    it('desactiva la transaccion implicita si ya hay una transaccion explicita', async () => {
-      connection.isWriteTransactionActive.mockReturnValue(true)
+    it('transmite el propietario explícito a la fachada', async () => {
+      const scope = {}
 
-      await AcademicEvents.createAcademicEventRow(eventRow())
+      await AcademicEvents.createAcademicEventRow(eventRow(), scope)
+      expect(connection.getDb).toHaveBeenCalledWith(scope)
 
       expect(mockDb.run).toHaveBeenCalledWith(
         expect.stringContaining('INSERT INTO academic_events'),
         expect.any(Array),
-        false,
       )
     })
   })
@@ -198,7 +200,7 @@ describe('sqlite/academicEvents', () => {
       await AcademicEvents.updateAcademicEventRow('event-1', {})
 
       expect(mockDb.run).not.toHaveBeenCalled()
-      expect(connection.persistWeb).not.toHaveBeenCalled()
+      expect(mockDb.run).not.toHaveBeenCalled()
     })
   })
 
@@ -212,10 +214,16 @@ describe('sqlite/academicEvents', () => {
       )
     })
 
-    it('llama persistWeb despues de borrar', async () => {
-      await AcademicEvents.deleteAcademicEventRow('event-1')
-
-      expect(connection.persistWeb).toHaveBeenCalled()
+    it('espera la finalización de la escritura coordinada', async () => {
+      let release
+      mockDb.run.mockReturnValueOnce(new Promise(resolve => { release = resolve }))
+      const finished = vi.fn()
+      const pending = AcademicEvents.deleteAcademicEventRow('event-1').then(finished)
+      await Promise.resolve()
+      expect(finished).not.toHaveBeenCalled()
+      release()
+      await pending
+      expect(finished).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/tests/unit/services/sqlite/connection.integration.test.js
+++ b/tests/unit/services/sqlite/connection.integration.test.js
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { importConnection } from './connectionHarness.js'
+import { sqliteFixture, deferred } from './sqliteFixture.js'
+
+let fixture, module, db, manager
+beforeEach(async () => {
+  document.body.innerHTML = ''
+  fixture = await sqliteFixture()
+  const harness = await importConnection({ platform: 'android' })
+  module = harness.module
+  db = harness.mockDb
+  manager = harness.mockSqliteConnection
+  Object.assign(db, fixture.adapter)
+  fixture.database.run("CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT); INSERT INTO metadata VALUES ('indexeddb_migrated', 'true')")
+})
+afterEach(() => fixture.close())
+
+describe('schema y recuperación sobre SQLite real', () => {
+  it('migra una instalación existente sin perder notas y no repite ALTERs al reabrir', async () => {
+    fixture.database.run(`CREATE TABLE notes (id TEXT PRIMARY KEY, title TEXT, content TEXT, pinned INTEGER DEFAULT 0,
+      archived INTEGER DEFAULT 0, createdAt TEXT NOT NULL, updatedAt TEXT NOT NULL);
+      INSERT INTO notes (id,title,createdAt,updatedAt) VALUES ('old','Fixture conservada','2026','2026')`)
+    await module.initDatabase()
+    expect((await module.getDb().query('SELECT title, deletedAt, subjectId, statusEmoji FROM notes')).values)
+      .toEqual([{ title: 'Fixture conservada', deletedAt: null, subjectId: null, statusEmoji: null }])
+    // Forzar reapertura segura a través de una avería controlada, no de datos reales.
+    db.beginTransaction.mockRejectedValueOnce(new Error('begin failed'))
+    await expect(module.runTransaction(async () => {})).rejects.toThrow('begin failed')
+    db.run.mockClear()
+    await module.initDatabase()
+    expect(db.run.mock.calls.some(([sql]) => sql.startsWith('ALTER TABLE'))).toBe(false)
+    expect((await module.getDb().query('SELECT title FROM notes')).values).toEqual([{ title: 'Fixture conservada' }])
+    expect(manager.closeConnection).toHaveBeenCalledTimes(1)
+  })
+
+  it('una migración fallida conserva contexto y el reintento completa el schema', async () => {
+    const cause = new Error('disk I/O error')
+    db.run.mockRejectedValueOnce(cause)
+    await expect(module.initDatabase()).rejects.toMatchObject({ message: 'SQLite migration failed: notes.statusEmoji', cause })
+    expect(() => module.getDb()).toThrow('not initialized')
+    await module.initDatabase()
+    const fields = (await module.getDb().query('PRAGMA table_info(notes)')).values.map(field => field.name)
+    expect(fields).toEqual(expect.arrayContaining(['subjectId', 'deletedAt', 'statusEmoji']))
+    expect(manager.closeConnection).toHaveBeenCalledTimes(1)
+  })
+
+  it('un rollback incierto bloquea el reintento hasta comprobar una recuperación segura', async () => {
+    await module.initDatabase()
+    const cause = new Error('write failed')
+    db.rollbackTransaction.mockRejectedValueOnce(new Error('rollback failed'))
+    await expect(module.runTransaction(async () => { throw cause })).rejects.toBe(cause)
+    db.rollbackTransaction.mockRejectedValueOnce(new Error('still unavailable'))
+    await expect(module.initDatabase()).rejects.toThrow('still unavailable')
+    expect(manager.closeConnection).not.toHaveBeenCalled()
+    await module.initDatabase()
+    expect(manager.closeConnection).toHaveBeenCalledTimes(1)
+    await expect(module.getDb().query('SELECT * FROM notes')).resolves.toEqual({ values: [] })
+  })
+
+  it('no cierra una conexión si el plugin no confirma su estado transaccional', async () => {
+    await module.initDatabase()
+    db.beginTransaction.mockRejectedValueOnce(new Error('begin failed'))
+    await expect(module.runTransaction(async () => {})).rejects.toThrow('begin failed')
+    db.isTransactionActive.mockResolvedValueOnce({})
+    await expect(module.initDatabase()).rejects.toThrow('state unknown')
+    expect(manager.closeConnection).not.toHaveBeenCalled()
+    await module.initDatabase()
+    expect(manager.closeConnection).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('consumidores reales, sin acceso a una transacción ajena', () => {
+  it.each(['notes', 'subjects', 'academicEvents'])('CRUD %s durante una transacción no se revierte con ella', async kind => {
+    await module.initDatabase()
+    const notes = await import('../../../../src/services/sqlite/notes.js')
+    const subjects = await import('../../../../src/services/sqlite/subjects.js')
+    const events = await import('../../../../src/services/sqlite/academicEvents.js')
+    const entered = deferred(), release = deferred()
+    const first = module.runTransaction(async scope => {
+      await notes.createNote('solo A', '', null, scope)
+      entered.resolve()
+      await release.promise
+      throw new Error('A failed')
+    })
+    const rejected = expect(first).rejects.toThrow('A failed')
+    await entered.promise
+    const writes = {
+      notes: () => notes.createNote('solo B'),
+      subjects: () => subjects.createSubjectRow({ id: 'B', name: 'B', createdAt: '2026' }),
+      academicEvents: () => events.createAcademicEventRow({ id: 'B', type: 'tp', date: '2026-09-04', createdAt: '2026', updatedAt: '2026' }),
+    }
+    const second = writes[kind]()
+    release.resolve()
+    await Promise.all([rejected, second])
+    const table = kind === 'academicEvents' ? 'academic_events' : kind
+    expect((await module.getDb().query(`SELECT * FROM ${table}`)).values).toHaveLength(1)
+    expect((await notes.getAllNotes()).some(note => note.title === 'solo A')).toBe(false)
+  })
+
+  it('las cascadas de materia conservan atomicidad ante un fallo en la segunda escritura', async () => {
+    await module.initDatabase()
+    const subjects = await import('../../../../src/services/SubjectService.js')
+    const root = await subjects.createSubject('Materia')
+    await subjects.createSubject('Sección', null, root.id)
+    const original = db.run.getMockImplementation()
+    db.run.mockImplementation(async (sql, values, transaction) => {
+      if (sql.includes('WHERE id = ?')) throw new Error('parent failed')
+      return original(sql, values, transaction)
+    })
+    await expect(subjects.archiveSubject(root.id)).rejects.toThrow('parent failed')
+    expect((await module.getDb().query('SELECT archived FROM subjects')).values).toEqual([{ archived: 0 }, { archived: 0 }])
+    db.run.mockImplementation(original)
+    await subjects.archiveSubject(root.id)
+    expect((await module.getDb().query('SELECT archived FROM subjects')).values).toEqual([{ archived: 1 }, { archived: 1 }])
+  })
+
+  it('vaciar papelera no confirma notas si falla el borrado de materias', async () => {
+    await module.initDatabase()
+    const subjects = await import('../../../../src/services/SubjectService.js')
+    const notes = await import('../../../../src/services/sqlite/notes.js')
+    const note = await notes.createNote('Fixture papelera')
+    await notes.deleteNote(note.id)
+    const original = db.run.getMockImplementation()
+    db.run.mockImplementation(async (sql, ...args) => {
+      if (sql.includes('DELETE FROM subjects')) throw new Error('subjects failed')
+      return original(sql, ...args)
+    })
+    await expect(subjects.emptyTrash()).rejects.toThrow('subjects failed')
+    expect(await notes.getDeletedNotes()).toHaveLength(1)
+  })
+
+  it('una cascada puede componerse con su propietario y revierte junto a él', async () => {
+    await module.initDatabase()
+    const subjects = await import('../../../../src/services/SubjectService.js')
+    const root = await subjects.createSubject('Materia')
+    await expect(module.runTransaction(async scope => {
+      await subjects.archiveSubject(root.id, scope)
+      throw new Error('outer failed')
+    })).rejects.toThrow('outer failed')
+    expect((await subjects.getSubjectById(root.id)).archived).toBe(false)
+  })
+
+  it('importa atómicamente sin borrar datos previos, incluso ante un ID duplicado', async () => {
+    await module.initDatabase()
+    const { applyBackupImportPlan } = await import('../../../../src/services/backup/BackupImportDataSource.ts')
+    const notes = await import('../../../../src/services/sqlite/notes.js')
+    const existing = await notes.createNote('Existente')
+    const plan = {
+      data: {
+        subjects: [{ id: 'import-subject', name: 'Importada', createdAt: '2026' }],
+        notes: [{ ...existing, title: 'No reemplazar' }], academicEvents: [],
+      },
+      skipped: [], renamedSubjects: [], relationshipRepairs: [], warnings: [],
+    }
+    await expect(applyBackupImportPlan(plan)).rejects.toThrow('UNIQUE')
+    expect((await module.getDb().query('SELECT * FROM subjects')).values).toEqual([])
+    expect((await notes.getNoteById(existing.id)).title).toBe('Existente')
+    plan.data.notes[0].id = 'import-note'
+    await expect(applyBackupImportPlan(plan)).resolves.toMatchObject({ imported: { subjects: 1, notes: 1, academicEvents: 0 } })
+    expect(await notes.getAllNotes()).toHaveLength(2)
+  })
+})

--- a/tests/unit/services/sqlite/connection.test.js
+++ b/tests/unit/services/sqlite/connection.test.js
@@ -260,3 +260,66 @@ describe('runTransaction()', () => {
     expect(module.isWriteTransactionActive()).toBe(false)
   })
 })
+
+
+describe('cierre seguro antes de recargar WebView', () => {
+  it('espera el trabajo activo, bloquea nuevas operaciones y cierra una sola vez', async () => {
+    const { module, mockDb, mockSqliteConnection } = await importConnection({ platform: 'android' })
+    await module.initDatabase()
+    const entered = deferred(), release = deferred()
+    const write = module.runTransaction(async () => {
+      entered.resolve()
+      await release.promise
+    })
+    await entered.promise
+    const retained = module.getDb()
+    const closing = module.closeDatabaseForReload()
+    expect(module.closeDatabaseForReload()).toBe(closing)
+    expect(() => module.getDb()).toThrow('not initialized')
+    await expect(module.initDatabase()).rejects.toThrow('closing')
+    await Promise.resolve()
+    expect(mockSqliteConnection.closeConnection).not.toHaveBeenCalled()
+    release.resolve()
+    await Promise.all([write, closing])
+    await expect(retained.query('SELECT 1')).rejects.toThrow('recovery')
+    expect(mockDb.commitTransaction).toHaveBeenCalledTimes(1)
+    expect(mockSqliteConnection.closeConnection).toHaveBeenCalledTimes(1)
+    await module.initDatabase()
+    expect(() => module.getDb()).not.toThrow()
+  })
+
+  it('no cierra con estado incierto y permite repetir el cierre seguro', async () => {
+    const { module, mockDb, mockSqliteConnection } = await importConnection({ platform: 'android' })
+    await module.initDatabase()
+    mockDb.isTransactionActive.mockResolvedValueOnce({})
+    await expect(module.closeDatabaseForReload()).rejects.toThrow('state unknown')
+    expect(mockSqliteConnection.closeConnection).not.toHaveBeenCalled()
+    expect(() => module.getDb()).toThrow('not initialized')
+    await expect(module.closeDatabaseForReload()).resolves.toBeUndefined()
+    expect(mockSqliteConnection.closeConnection).toHaveBeenCalledTimes(1)
+  })
+
+  it('propaga el fallo de closeConnection sin perder la conexión que debe cerrar', async () => {
+    const { module, mockSqliteConnection } = await importConnection({ platform: 'android' })
+    await module.initDatabase()
+    const cause = new Error('native close failed')
+    mockSqliteConnection.closeConnection.mockRejectedValueOnce(cause)
+    await expect(module.closeDatabaseForReload()).rejects.toBe(cause)
+    await expect(module.closeDatabaseForReload()).resolves.toBeUndefined()
+    expect(mockSqliteConnection.closeConnection).toHaveBeenCalledTimes(2)
+  })
+
+  it('espera una inicialización en curso antes de liberar su conexión', async () => {
+    const { module, mockDb, mockSqliteConnection } = await importConnection({ platform: 'android' })
+    const opened = deferred()
+    mockDb.open.mockReturnValueOnce(opened.promise)
+    const initializing = module.initDatabase()
+    const closing = module.closeDatabaseForReload()
+    await Promise.resolve()
+    expect(mockSqliteConnection.closeConnection).not.toHaveBeenCalled()
+    opened.resolve()
+    await Promise.all([initializing, closing])
+    expect(mockSqliteConnection.closeConnection).toHaveBeenCalledTimes(1)
+    expect(() => module.getDb()).toThrow('not initialized')
+  })
+})

--- a/tests/unit/services/sqlite/connection.test.js
+++ b/tests/unit/services/sqlite/connection.test.js
@@ -1,49 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-async function importConnection({ platform = 'web', existingConnection = false } = {}) {
-  vi.resetModules()
-
-  const mockDb = {
-    open: vi.fn().mockResolvedValue(undefined),
-    execute: vi.fn().mockResolvedValue(undefined),
-    run: vi.fn().mockResolvedValue(undefined),
-    query: vi.fn().mockResolvedValue({ values: [{ value: 'true' }] }),
-    beginTransaction: vi.fn().mockResolvedValue(undefined),
-    commitTransaction: vi.fn().mockResolvedValue(undefined),
-    rollbackTransaction: vi.fn().mockResolvedValue(undefined),
-  }
-
-  const mockSqliteConnection = {
-    isConnection: vi.fn().mockResolvedValue({ result: existingConnection }),
-    createConnection: vi.fn().mockResolvedValue(mockDb),
-    retrieveConnection: vi.fn().mockResolvedValue(mockDb),
-    initWebStore: vi.fn().mockResolvedValue(undefined),
-    saveToStore: vi.fn().mockResolvedValue(undefined),
-  }
-
-  const MockSQLiteConnection = vi.fn(function SQLiteConnectionMock() {
-    return mockSqliteConnection
-  })
-  const mockCapacitor = { getPlatform: vi.fn(() => platform) }
-  const defineCustomElements = vi.fn((win) => {
-    if (!win.customElements.get('jeep-sqlite')) {
-      win.customElements.define('jeep-sqlite', class extends win.HTMLElement {})
-    }
-  })
-
-  vi.doMock('@capacitor/core', () => ({ Capacitor: mockCapacitor }))
-  vi.doMock('@capacitor-community/sqlite', () => ({
-    SQLiteConnection: MockSQLiteConnection,
-    CapacitorSQLite: {},
-  }))
-  vi.doMock('jeep-sqlite/loader', () => ({ defineCustomElements }))
-
-  const module = await import('../../../../src/services/sqlite/connection.js')
-  return { module, mockDb, mockSqliteConnection, mockCapacitor, defineCustomElements }
-}
+import { importConnection } from './connectionHarness.js'
 
 beforeEach(() => {
   vi.clearAllMocks()
+  document.body.innerHTML = ''
 })
 
 describe('generateUUID()', () => {
@@ -90,6 +51,96 @@ describe('getDb()', () => {
   })
 })
 
+function deferred() {
+  let resolve
+  const promise = new Promise(r => { resolve = r })
+  return { promise, resolve }
+}
+
+describe('AUD-005: coordinación independiente', () => {
+  it('una operación independiente espera el rollback de la propietaria', async () => {
+    const { module, mockDb } = await importConnection()
+    await module.initDatabase()
+    const entered = deferred()
+    const release = deferred()
+    const events = []
+    mockDb.rollbackTransaction.mockImplementation(async () => { events.push('rollback A') })
+    const cause = new Error('A failed')
+    const first = module.runTransaction(async () => {
+      entered.resolve()
+      await release.promise
+      throw cause
+    })
+    const rejected = expect(first).rejects.toBe(cause)
+    await entered.promise
+    const second = module.runTransaction(async () => { events.push('write B') })
+    release.resolve()
+    await Promise.all([rejected, second])
+    expect(events).toEqual(['rollback A', 'write B'])
+    expect(mockDb.commitTransaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('un CRUD independiente no se incorpora a la transacción abierta', async () => {
+    const { module, mockDb } = await importConnection()
+    const notes = await import('../../../../src/services/sqlite/notes.js')
+    await module.initDatabase()
+    const entered = deferred()
+    const release = deferred()
+    const events = []
+    mockDb.run.mockImplementation(async () => { events.push('CRUD') })
+    mockDb.rollbackTransaction.mockImplementation(async () => { events.push('rollback') })
+    const first = module.runTransaction(async () => {
+      entered.resolve()
+      await release.promise
+      throw new Error('rollback owner')
+    })
+    const rejected = expect(first).rejects.toThrow('rollback owner')
+    await entered.promise
+    const crud = notes.createNote('independiente')
+    release.resolve()
+    await Promise.all([rejected, crud])
+    expect(events).toEqual(['rollback', 'CRUD'])
+  })
+
+  it('no informa éxito si saveToStore falla después del commit', async () => {
+    const { module, mockSqliteConnection } = await importConnection()
+    await module.initDatabase()
+    const cause = new Error('store unavailable')
+    mockSqliteConnection.saveToStore.mockRejectedValueOnce(cause)
+    await expect(module.runTransaction(async () => 'ok')).rejects.toBe(cause)
+  })
+
+  it('aborta una migración inesperadamente fallida', async () => {
+    const { module, mockDb } = await importConnection()
+    const cause = new Error('disk I/O error')
+    mockDb.run.mockRejectedValueOnce(cause)
+    await expect(module.initDatabase()).rejects.toMatchObject({ cause })
+  })
+
+  it('comparte una sola inicialización concurrente', async () => {
+    const { module, mockDb, mockSqliteConnection } = await importConnection()
+    const opened = deferred()
+    mockDb.open.mockReturnValue(opened.promise)
+    const first = module.initDatabase()
+    const second = module.initDatabase()
+    opened.resolve()
+    await Promise.all([first, second])
+    expect(mockSqliteConnection.createConnection).toHaveBeenCalledTimes(1)
+    expect(document.querySelectorAll('jeep-sqlite')).toHaveLength(1)
+  })
+
+  it('reintenta un open fallido sin consultar transacciones de una base cerrada', async () => {
+    const { module, mockDb, mockSqliteConnection } = await importConnection()
+    mockDb.open.mockRejectedValueOnce(new Error('open failed'))
+    mockDb.isDBOpen = vi.fn().mockResolvedValue({ result: false })
+    mockDb.isTransactionActive.mockRejectedValue(new Error('database not opened'))
+    await expect(module.initDatabase()).rejects.toThrow('open failed')
+    await expect(module.initDatabase()).resolves.toBeUndefined()
+    expect(mockDb.isTransactionActive).not.toHaveBeenCalled()
+    expect(mockSqliteConnection.closeConnection).toHaveBeenCalledTimes(1)
+  })
+})
+
 describe('initDatabase() schema', () => {
   it('crea academic_events e indices en instalaciones nuevas', async () => {
     const { module, mockDb } = await importConnection()
@@ -125,10 +176,10 @@ describe('initDatabase() schema', () => {
 })
 
 describe('persistWeb()', () => {
-  it('no lanza error si sqliteConnection es null', async () => {
+  it('rechaza persistir si no existe conexión', async () => {
     const { module } = await importConnection()
 
-    await expect(module.persistWeb()).resolves.toBeUndefined()
+    await expect(module.persistWeb()).rejects.toThrow('Database not initialized')
   })
 
   it('llama saveToStore si la plataforma es "web"', async () => {
@@ -158,8 +209,8 @@ describe('runTransaction()', () => {
     await module.initDatabase()
     mockSqliteConnection.saveToStore.mockClear()
 
-    const result = await module.runTransaction(async () => {
-      await module.persistWeb()
+    const result = await module.runTransaction(async scope => {
+      await module.persistWeb(scope)
       return 'ok'
     })
 
@@ -189,8 +240,8 @@ describe('runTransaction()', () => {
     const { module, mockDb } = await importConnection()
     await module.initDatabase()
 
-    await module.runTransaction(async () => {
-      await module.runTransaction(async () => 'inner')
+    await module.runTransaction(async scope => {
+      await module.runTransaction(async () => 'inner', scope)
     })
 
     expect(mockDb.beginTransaction).toHaveBeenCalledTimes(1)
@@ -202,8 +253,9 @@ describe('runTransaction()', () => {
     await module.initDatabase()
 
     expect(module.isWriteTransactionActive()).toBe(false)
-    await module.runTransaction(async () => {
-      expect(module.isWriteTransactionActive()).toBe(true)
+    await module.runTransaction(async scope => {
+      expect(module.isWriteTransactionActive(scope)).toBe(true)
+      expect(module.isWriteTransactionActive()).toBe(false)
     })
     expect(module.isWriteTransactionActive()).toBe(false)
   })

--- a/tests/unit/services/sqlite/connectionHarness.js
+++ b/tests/unit/services/sqlite/connectionHarness.js
@@ -1,0 +1,46 @@
+import { vi } from 'vitest'
+
+export async function importConnection({ platform = 'web', existingConnection = false } = {}) {
+  vi.resetModules()
+
+  const mockDb = {
+    open: vi.fn().mockResolvedValue(undefined),
+    execute: vi.fn().mockResolvedValue(undefined),
+    run: vi.fn().mockResolvedValue(undefined),
+    query: vi.fn(async sql => ({ values: sql.startsWith('PRAGMA') ? [{ name: 'id' }] : [{ value: 'true' }] })),
+    isTransactionActive: vi.fn().mockResolvedValue({ result: false }),
+    isDBOpen: vi.fn().mockResolvedValue({ result: true }),
+    beginTransaction: vi.fn().mockResolvedValue(undefined),
+    commitTransaction: vi.fn().mockResolvedValue(undefined),
+    rollbackTransaction: vi.fn().mockResolvedValue(undefined),
+  }
+
+  const mockSqliteConnection = {
+    closeConnection: vi.fn().mockResolvedValue(undefined),
+    isConnection: vi.fn().mockResolvedValue({ result: existingConnection }),
+    createConnection: vi.fn().mockResolvedValue(mockDb),
+    retrieveConnection: vi.fn().mockResolvedValue(mockDb),
+    initWebStore: vi.fn().mockResolvedValue(undefined),
+    saveToStore: vi.fn().mockResolvedValue(undefined),
+  }
+
+  const MockSQLiteConnection = vi.fn(function SQLiteConnectionMock() {
+    return mockSqliteConnection
+  })
+  const mockCapacitor = { getPlatform: vi.fn(() => platform) }
+  const defineCustomElements = vi.fn((win) => {
+    if (!win.customElements.get('jeep-sqlite')) {
+      win.customElements.define('jeep-sqlite', class extends win.HTMLElement {})
+    }
+  })
+
+  vi.doMock('@capacitor/core', () => ({ Capacitor: mockCapacitor }))
+  vi.doMock('@capacitor-community/sqlite', () => ({
+    SQLiteConnection: MockSQLiteConnection,
+    CapacitorSQLite: {},
+  }))
+  vi.doMock('jeep-sqlite/loader', () => ({ defineCustomElements }))
+
+  const module = await import('../../../../src/services/sqlite/connection.js')
+  return { module, mockDb, mockSqliteConnection, mockCapacitor, defineCustomElements }
+}

--- a/tests/unit/services/sqlite/legacyMigration.test.js
+++ b/tests/unit/services/sqlite/legacyMigration.test.js
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { migrateLegacyNotes } from '../../../../src/services/sqlite/legacyMigration.js'
+import { createWriteCoordinator } from '../../../../src/services/sqlite/writeCoordinator.js'
+import { sqliteFixture } from './sqliteFixture.js'
+
+let fixture, coordinator
+beforeEach(async () => {
+  fixture = await sqliteFixture()
+  fixture.database.run(`CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT);
+    CREATE TABLE notes (id TEXT PRIMARY KEY, title TEXT, content TEXT, pinned INTEGER, archived INTEGER, createdAt TEXT, updatedAt TEXT)`)
+  coordinator = createWriteCoordinator(fixture.adapter, async () => {})
+})
+afterEach(() => fixture.close())
+
+function legacyStore({ notes = [], absent = false, missingStore = false, openError, readError, blocked = false } = {}) {
+  const idb = { close: vi.fn(), objectStoreNames: { contains: () => !missingStore } }
+  const transaction = { objectStore: () => ({ getAll: () => ({ result: notes }) }), error: readError }
+  idb.transaction = () => {
+    queueMicrotask(() => readError ? transaction.onerror() : transaction.oncomplete())
+    return transaction
+  }
+  const open = vi.fn(() => {
+    const request = { result: idb, error: openError, transaction: { abort: () => queueMicrotask(() => request.onerror()) } }
+    queueMicrotask(() => {
+      if (absent) request.onupgradeneeded()
+      else if (openError) request.onerror()
+      else if (blocked) { request.onblocked(); request.onsuccess() }
+      else request.onsuccess()
+    })
+    return request
+  })
+  vi.stubGlobal('indexedDB', { open })
+  return { open, idb }
+}
+const flag = async () => (await coordinator.getDb().query('SELECT * FROM metadata')).values
+
+describe('migración legada estricta y no destructiva', () => {
+  it.each([{ absent: true }, { missingStore: true }])('tolera ausencia comprobada %j y registra el resultado', async options => {
+    legacyStore(options)
+    await migrateLegacyNotes(coordinator)
+    expect(await flag()).toEqual([{ key: 'indexeddb_migrated', value: 'true' }])
+  })
+
+  it('no reemplaza notas SQLite existentes y no vuelve a importar después del éxito', async () => {
+    fixture.database.run("INSERT INTO notes (id,title) VALUES ('same','SQLite conservada')")
+    const { open, idb } = legacyStore({ notes: [{ id: 'same', title: 'Legada antigua' }, { id: 'new', title: 'Nueva' }] })
+    await migrateLegacyNotes(coordinator)
+    await migrateLegacyNotes(coordinator)
+    expect(open).toHaveBeenCalledTimes(1)
+    expect(idb.close).toHaveBeenCalledTimes(1)
+    expect((await coordinator.getDb().query('SELECT title FROM notes ORDER BY id')).values)
+      .toEqual([{ title: 'Nueva' }, { title: 'SQLite conservada' }])
+  })
+
+  it.each(['openError', 'readError'])('no interpreta %s como base vacía', async errorType => {
+    const cause = new Error('read unavailable')
+    legacyStore({ [errorType]: cause })
+    await expect(migrateLegacyNotes(coordinator)).rejects.toMatchObject({ cause })
+    expect(await flag()).toEqual([])
+    expect(fixture.adapter.beginTransaction).not.toHaveBeenCalled()
+  })
+
+  it('cierra una apertura tardía bloqueada y no marca éxito', async () => {
+    const { idb } = legacyStore({ blocked: true })
+    await expect(migrateLegacyNotes(coordinator)).rejects.toMatchObject({ cause: expect.objectContaining({ message: 'Legacy IndexedDB open blocked' }) })
+    expect(idb.close).toHaveBeenCalledTimes(1)
+    expect(await flag()).toEqual([])
+  })
+
+  it('revierte notas y marcador conjuntamente cuando falla una escritura', async () => {
+    legacyStore({ notes: [{ id: 'one' }, { id: 'two' }] })
+    const cause = new Error('disk I/O')
+    const original = fixture.adapter.run.getMockImplementation()
+    fixture.adapter.run.mockImplementation(async (sql, values, transaction) => {
+      if (values[0] === 'two') throw cause
+      return original(sql, values, transaction)
+    })
+    await expect(migrateLegacyNotes(coordinator)).rejects.toMatchObject({ cause })
+    expect(await flag()).toEqual([])
+    expect((await coordinator.getDb().query('SELECT * FROM notes')).values).toEqual([])
+    fixture.adapter.run.mockImplementation(original)
+    await migrateLegacyNotes(coordinator)
+    expect((await coordinator.getDb().query('SELECT * FROM notes')).values).toHaveLength(2)
+  })
+})

--- a/tests/unit/services/sqlite/notes.test.js
+++ b/tests/unit/services/sqlite/notes.test.js
@@ -9,9 +9,7 @@ const mockDb = vi.hoisted(() => ({
 
 vi.mock('../../../../src/services/sqlite/connection.js', () => ({
   getDb: vi.fn(() => mockDb),
-  persistWeb: vi.fn().mockResolvedValue(undefined),
   generateUUID: vi.fn(() => 'test-uuid-1234'),
-  isWriteTransactionActive: vi.fn(() => false),
 }))
 
 function dbRow(overrides = {}) {
@@ -35,7 +33,6 @@ beforeEach(() => {
   vi.setSystemTime(new Date('2024-01-15T10:00:00.000Z'))
   mockDb.run.mockResolvedValue(undefined)
   mockDb.query.mockResolvedValue({ values: [] })
-  connection.isWriteTransactionActive.mockReturnValue(false)
 })
 
 describe('sqlite/notes', () => {
@@ -86,11 +83,16 @@ describe('sqlite/notes', () => {
       await expect(Notes.createNote()).resolves.toMatchObject({ archived: false })
     })
 
-    it('llama persistWeb() después de db.run', async () => {
-      await Notes.createNote()
-
-      expect(connection.persistWeb).toHaveBeenCalled()
-      expect(mockDb.run.mock.invocationCallOrder[0]).toBeLessThan(connection.persistWeb.mock.invocationCallOrder[0])
+    it('espera la finalización de la escritura coordinada', async () => {
+      let release
+      mockDb.run.mockReturnValueOnce(new Promise(resolve => { release = resolve }))
+      const finished = vi.fn()
+      const pending = Notes.createNote().then(finished)
+      await Promise.resolve()
+      expect(finished).not.toHaveBeenCalled()
+      release()
+      await pending
+      expect(finished).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -192,12 +194,17 @@ describe('sqlite/notes', () => {
       expect(updated.updatedAt).toBe('2024-01-15T10:00:00.000Z')
     })
 
-    it('llama persistWeb() después de db.run', async () => {
+    it('espera la finalización de la escritura coordinada', async () => {
       mockDb.query.mockResolvedValue({ values: [dbRow()] })
-
-      await Notes.updateNote('note-1', { title: 'Nueva' })
-
-      expect(connection.persistWeb).toHaveBeenCalled()
+      let release
+      mockDb.run.mockReturnValueOnce(new Promise(resolve => { release = resolve }))
+      const finished = vi.fn()
+      const pending = Notes.updateNote('note-1', { title: 'Nueva' }).then(finished)
+      await Promise.resolve()
+      expect(finished).not.toHaveBeenCalled()
+      release()
+      await pending
+      expect(finished).toHaveBeenCalledTimes(1)
     })
 
     it('retorna el objeto merged de existing + changes + updatedAt', async () => {
@@ -224,21 +231,27 @@ describe('sqlite/notes', () => {
       )
     })
 
-    it('llama persistWeb()', async () => {
-      await Notes.deleteNote('note-1')
-
-      expect(connection.persistWeb).toHaveBeenCalled()
+    it('espera la finalización de la escritura coordinada', async () => {
+      let release
+      mockDb.run.mockReturnValueOnce(new Promise(resolve => { release = resolve }))
+      const finished = vi.fn()
+      const pending = Notes.deleteNote('note-1').then(finished)
+      await Promise.resolve()
+      expect(finished).not.toHaveBeenCalled()
+      release()
+      await pending
+      expect(finished).toHaveBeenCalledTimes(1)
     })
 
-    it('desactiva la transacción implícita si ya hay una transacción explícita', async () => {
-      connection.isWriteTransactionActive.mockReturnValue(true)
+    it('transmite el propietario explícito a la fachada', async () => {
+      const scope = {}
 
-      await Notes.deleteNote('note-1')
+      await Notes.deleteNote('note-1', scope)
+      expect(connection.getDb).toHaveBeenCalledWith(scope)
 
       expect(mockDb.run).toHaveBeenCalledWith(
         'UPDATE notes SET deletedAt = ? WHERE id = ?',
         ['2024-01-15T10:00:00.000Z', 'note-1'],
-        false,
       )
     })
   })
@@ -250,10 +263,16 @@ describe('sqlite/notes', () => {
       expect(mockDb.run).toHaveBeenCalledWith('DELETE FROM notes WHERE id = ?', ['note-1'])
     })
 
-    it('llama persistWeb()', async () => {
-      await Notes.permanentlyDeleteNote('note-1')
-
-      expect(connection.persistWeb).toHaveBeenCalled()
+    it('espera la finalización de la escritura coordinada', async () => {
+      let release
+      mockDb.run.mockReturnValueOnce(new Promise(resolve => { release = resolve }))
+      const finished = vi.fn()
+      const pending = Notes.permanentlyDeleteNote('note-1').then(finished)
+      await Promise.resolve()
+      expect(finished).not.toHaveBeenCalled()
+      release()
+      await pending
+      expect(finished).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/tests/unit/services/sqlite/sqliteFixture.js
+++ b/tests/unit/services/sqlite/sqliteFixture.js
@@ -1,0 +1,39 @@
+import initSqlJs from 'sql.js'
+import { vi } from 'vitest'
+
+// SQLite real en memoria. Solo los límites async del plugin son reemplazables.
+export async function sqliteFixture() {
+  const SQL = await initSqlJs()
+  const database = new SQL.Database()
+  database.run('PRAGMA foreign_keys = ON')
+  let active = false
+  const adapter = {
+    open: vi.fn(async () => {}),
+    execute: vi.fn(async sql => { database.run(sql) }),
+    run: vi.fn(async (sql, values = []) => {
+      database.run(sql, values)
+      return { changes: { changes: database.getRowsModified() } }
+    }),
+    query: vi.fn(async (sql, values = []) => {
+      const statement = database.prepare(sql)
+      try {
+        statement.bind(values)
+        const rows = []
+        while (statement.step()) rows.push(statement.getAsObject())
+        return { values: rows }
+      } finally { statement.free() }
+    }),
+    beginTransaction: vi.fn(async () => { database.run('BEGIN'); active = true }),
+    commitTransaction: vi.fn(async () => { database.run('COMMIT'); active = false }),
+    rollbackTransaction: vi.fn(async () => { database.run('ROLLBACK'); active = false }),
+    isTransactionActive: vi.fn(async () => ({ result: active })),
+    isDBOpen: vi.fn(async () => ({ result: true })),
+  }
+  return { adapter, database, close: () => database.close() }
+}
+
+export function deferred() {
+  let resolve, reject
+  const promise = new Promise((yes, no) => { resolve = yes; reject = no })
+  return { promise, resolve, reject }
+}

--- a/tests/unit/services/sqlite/subjects.test.js
+++ b/tests/unit/services/sqlite/subjects.test.js
@@ -9,8 +9,6 @@ const mockDb = vi.hoisted(() => ({
 
 vi.mock('../../../../src/services/sqlite/connection.js', () => ({
   getDb: vi.fn(() => mockDb),
-  persistWeb: vi.fn().mockResolvedValue(undefined),
-  isWriteTransactionActive: vi.fn(() => false),
 }))
 
 function row(overrides = {}) {
@@ -31,7 +29,6 @@ beforeEach(() => {
   vi.setSystemTime(new Date('2024-01-15T10:00:00.000Z'))
   mockDb.run.mockResolvedValue(undefined)
   mockDb.query.mockResolvedValue({ values: [] })
-  connection.isWriteTransactionActive.mockReturnValue(false)
 })
 
 describe('sqlite/subjects', () => {
@@ -52,10 +49,16 @@ describe('sqlite/subjects', () => {
       )
     })
 
-    it('llama persistWeb después de insertar', async () => {
-      await Subjects.createSubjectRow(row())
-
-      expect(connection.persistWeb).toHaveBeenCalled()
+    it('espera la finalización de la escritura coordinada', async () => {
+      let release
+      mockDb.run.mockReturnValueOnce(new Promise(resolve => { release = resolve }))
+      const finished = vi.fn()
+      const pending = Subjects.createSubjectRow(row()).then(finished)
+      await Promise.resolve()
+      expect(finished).not.toHaveBeenCalled()
+      release()
+      await pending
+      expect(finished).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -121,7 +124,7 @@ describe('sqlite/subjects', () => {
       await Subjects.updateSubjectRow('subj-1', {})
 
       expect(mockDb.run).not.toHaveBeenCalled()
-      expect(connection.persistWeb).not.toHaveBeenCalled()
+      expect(mockDb.run).not.toHaveBeenCalled()
     })
   })
 
@@ -272,15 +275,15 @@ describe('sqlite/subjects', () => {
       )
     })
 
-    it('desactiva la transacción implícita si ya hay una transacción explícita', async () => {
-      connection.isWriteTransactionActive.mockReturnValue(true)
+    it('transmite el propietario explícito a la fachada', async () => {
+      const scope = {}
 
-      await Subjects.archiveChildSubjects('subj-1')
+      await Subjects.archiveChildSubjects('subj-1', scope)
+      expect(connection.getDb).toHaveBeenCalledWith(scope)
 
       expect(mockDb.run).toHaveBeenCalledWith(
         'UPDATE subjects SET archived = 1 WHERE parentSubjectId = ? AND archived = 0 AND deletedAt IS NULL',
         ['subj-1'],
-        false,
       )
     })
 

--- a/tests/unit/services/sqlite/writeCoordinator.test.js
+++ b/tests/unit/services/sqlite/writeCoordinator.test.js
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createWriteCoordinator } from '../../../../src/services/sqlite/writeCoordinator.js'
+import { sqliteFixture, deferred } from './sqliteFixture.js'
+
+let fixture, db, coordinator, persist
+beforeEach(async () => {
+  fixture = await sqliteFixture()
+  db = fixture.adapter
+  await db.execute('CREATE TABLE items (id TEXT PRIMARY KEY)')
+  persist = vi.fn(async () => {})
+  coordinator = createWriteCoordinator(db, persist)
+})
+afterEach(() => fixture.close())
+const insert = (scope, id) => scope.run('INSERT INTO items VALUES (?)', [id])
+const rows = async () => (await coordinator.getDb().query('SELECT id FROM items ORDER BY id')).values
+
+describe('propiedad explícita con SQLite real', () => {
+  it('aísla dos transacciones intercaladas y la lectura externa no ve datos sucios', async () => {
+    const entered = deferred(), release = deferred()
+    const first = coordinator.transaction(async scope => {
+      await insert(scope, 'A')
+      entered.resolve()
+      await release.promise
+      throw new Error('A abortada')
+    })
+    const failure = expect(first).rejects.toThrow('A abortada')
+    await entered.promise
+    const second = coordinator.transaction(scope => insert(scope, 'B'))
+    const read = rows()
+    release.resolve()
+    await Promise.all([failure, second])
+    expect(await read).toEqual([{ id: 'B' }])
+    expect(persist).toHaveBeenCalledTimes(1)
+  })
+
+  it('anida con el mismo capability, sin commits parciales ni deadlock', async () => {
+    await expect(coordinator.transaction(async scope => {
+      await insert(scope, 'A')
+      await coordinator.transaction(inner => insert(inner, 'B'), scope)
+      throw new Error('revertir ambas')
+    })).rejects.toThrow('revertir ambas')
+    expect(await rows()).toEqual([])
+    expect(db.beginTransaction).toHaveBeenCalledTimes(1)
+    expect(db.commitTransaction).not.toHaveBeenCalled()
+    await coordinator.transaction(scope => insert(scope, 'C'))
+    expect(await rows()).toEqual([{ id: 'C' }])
+  })
+
+  it('un fallo interno capturado sigue invalidando toda la transacción', async () => {
+    const cause = new Error('inner')
+    await expect(coordinator.transaction(async scope => {
+      await insert(scope, 'A')
+      await coordinator.transaction(async () => { throw cause }, scope).catch(() => {})
+    })).rejects.toBe(cause)
+    expect(await rows()).toEqual([])
+  })
+
+  it('un error SQL capturado tampoco permite confirmar parcialmente', async () => {
+    await expect(coordinator.transaction(async scope => {
+      await insert(scope, 'A')
+      await insert(scope, 'A').catch(() => {})
+    })).rejects.toThrow('UNIQUE')
+    expect(await rows()).toEqual([])
+  })
+
+  it('rechaza capabilities falsos, expirados y de otra conexión', async () => {
+    let expired
+    await coordinator.transaction(async scope => { expired = scope })
+    expect(() => coordinator.getDb(expired)).toThrow('expired')
+    await expect(coordinator.transaction(async () => {}, {})).rejects.toThrow('Invalid')
+    const other = createWriteCoordinator(db, persist)
+    await coordinator.transaction(async scope => {
+      expect(() => other.getDb(scope)).toThrow('Invalid')
+    })
+  })
+
+  it('no libera la cola ni informa éxito antes de completar saveToStore', async () => {
+    const saving = deferred(), release = deferred()
+    persist.mockImplementationOnce(() => { saving.resolve(); return release.promise })
+    let complete = false
+    const first = coordinator.getDb().run('INSERT INTO items VALUES (?)', ['A']).then(() => { complete = true })
+    await saving.promise
+    const second = coordinator.getDb().run('INSERT INTO items VALUES (?)', ['B'])
+    expect(complete).toBe(false)
+    expect(db.beginTransaction).toHaveBeenCalledTimes(1)
+    release.resolve()
+    await Promise.all([first, second])
+    expect(await rows()).toEqual([{ id: 'A' }, { id: 'B' }])
+  })
+
+  it.each(['beginTransaction', 'commitTransaction', 'rollbackTransaction'])('cuarentena tras fallo de %s sin sustituir la causa', async method => {
+    const cause = new Error('original')
+    db[method].mockRejectedValueOnce(method === 'rollbackTransaction' ? new Error('rollback') : cause)
+    await expect(coordinator.transaction(async scope => {
+      await insert(scope, 'A')
+      if (method === 'rollbackTransaction') throw cause
+    })).rejects.toBe(cause)
+    const next = vi.fn()
+    await expect(coordinator.transaction(next)).rejects.toMatchObject({ cause })
+    expect(next).not.toHaveBeenCalled()
+    await coordinator.drain()
+  })
+
+  it('una persistencia web fallida después de commit no intenta rollback ni permite reutilización', async () => {
+    const cause = new Error('IndexedDB unavailable')
+    persist.mockRejectedValueOnce(cause)
+    const facade = coordinator.getDb()
+    await expect(facade.run('INSERT INTO items VALUES (?)', ['A'])).rejects.toBe(cause)
+    expect(db.rollbackTransaction).not.toHaveBeenCalled()
+    await expect(facade.query('SELECT * FROM items')).rejects.toMatchObject({ cause })
+    expect(coordinator.isHealthy()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
Resolve AUD-005: isolate SQLite transaction ownership, fail unexpected migrations, and recover safely from startup failures without discarding user data.

## Changes
- Serialize independent writes and external reads through a scoped SQLite facade; propagate explicit ownership through CRUD, cascades, and backup imports.
- Preserve atomicity and quarantine uncertain begin/commit/rollback/persistence failures until verified recovery.
- Make schema migrations strict and idempotent; migrate legacy notes and their completion marker transactionally without replacing existing SQLite notes.
- Prepare database and initial data before mounting UI components. Provide accessible retry feedback and await safe native connection shutdown before reloading a partially mounted WebView.
- Add deterministic concurrency, real in-memory SQLite, migration, and startup regressions; document the contract in ADR-009.

## Traceability
- Audit: AUD-005.
- Requirements: RF-005, RF-017, RF-018, RF-026 and RNF-010.
- Architecture: ADR-006, ADR-008 and ADR-009.
- Evidence: `docs/gestion/analisis-aud-005-coordinacion-sqlite-2026-09-04.md`.
- AUD-006, AUD-008 and AUD-009 remain separate; no new features, dependencies, version bump, release, or destructive migration.

## Validation
- Canonical Mac: Node 22.20.0 / npm 10.9.3; `npm ci`, `npm run verify`, coverage, documentation, traceability, schema and DBML checks passed on the implementation checkpoint.
- 67 test files / 1035 tests passed; lint: 0 errors and 3 pre-existing warnings. Configured-scope statement coverage: 95.66%; this is not full UI coverage.
- Both npm audits reported 0 vulnerabilities at the recorded checkpoint.
- Canonical `npm run verify`, documentation and traceability checks repeated on final head `4a4a5c97c4340e4d572387faf911e35c97a608e3` before publication.
- Remote Node 26 still reproduces the documented AUD-009 Web Storage failures and AUD-008 fallback CSP findings. No checks were relaxed; canonical validation uses Node 22 without the workaround.

## Android acceptance
- Installed implementation: `0832a75fe262da7ad3633008d69278df345bbefd`, Samsung SM_G965F, app 0.4.8 / 408.
- Official deployment script completed without `--clean` or uninstalling the app.
- Installed and built APK SHA-256 match: `b311ae558f08ca92769172542f515e845925e1c5a71d7b9eeb4140c9bf207118`.
- The owner reported that general operation appeared correct and explicitly authorized merging and deleting the task branches. This does not claim individually verified completion of every suggested manual scenario or the final RNF matrix.
- The final commit changes documentation only; production code, tests, dependencies and Android configuration are unchanged from the installed implementation.

## Risks and follow-up
- Transaction scopes must be passed explicitly when composing operations; this is covered by regression tests and ADR-009.
- External reads can wait behind a transaction. Performance optimization is not part of this change.
- A persistence failure after commit remains an uncertain outcome and is not retried automatically.
- Merge only after final-head checks pass; delete only this task branch after verifying integration and clean checkouts on both hosts.

## Checklist
- [x] Conventional Commits and English GitHub metadata.
- [x] Documentation and changelog updated without publishing a new release.
- [x] Canonical automated validation and owner Android acceptance recorded.
- [x] No secrets, personal databases, generated APKs or installed dependencies committed.
