### PR TITLE
fix: improve touch interactions for note organization

### DIFF
--- a/src/components/feed/FeedActionRouter.js
+++ b/src/components/feed/FeedActionRouter.js
@@ -30,6 +30,28 @@ function handleMenuToggle(event, button, deps) {
   }
 }
 
+function handleMoveMenuToggle(event, button) {
+  event.preventDefault()
+  event.stopPropagation()
+
+  const submenu = button.nextElementSibling
+  if (!submenu?.classList.contains('note-card__move-submenu')) return
+
+  const shouldOpen = !submenu.classList.contains('is-open')
+  const dropdown = button.closest('.note-card__dropdown')
+  dropdown?.querySelectorAll('.note-card__move-submenu.is-open').forEach(openMenu => {
+    openMenu.classList.remove('is-open')
+  })
+  dropdown?.querySelectorAll('.js-btn-move-trigger[aria-expanded="true"]').forEach(trigger => {
+    trigger.setAttribute('aria-expanded', 'false')
+  })
+
+  if (shouldOpen) {
+    submenu.classList.add('is-open')
+    button.setAttribute('aria-expanded', 'true')
+  }
+}
+
 function getTaskToggle(content, lineIndex) {
   const lines = content.split('\n')
   const line = lines[lineIndex]
@@ -160,6 +182,10 @@ const ACTION_MAP = [
       await NoteStore.toggleArchive(button.dataset.id)
       deps.closeAllDropdowns()
     }
+  },
+  {
+    selector: '.js-btn-move-trigger',
+    handler: handleMoveMenuToggle
   },
   {
     selector: '.js-btn-move-to',

--- a/src/components/feed/NoteCardActions.css
+++ b/src/components/feed/NoteCardActions.css
@@ -131,11 +131,23 @@
   z-index: 20;
 }
 
-.note-card__move-wrapper:hover .note-card__move-submenu,
-.note-card__move-wrapper:focus-within .note-card__move-submenu {
+.note-card__move-submenu.is-open {
   opacity: 1;
   visibility: visible;
   transform: translateX(0);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .note-card__move-wrapper:hover .note-card__move-submenu {
+    opacity: 1;
+    visibility: visible;
+    transform: translateX(0);
+  }
+}
+
+.js-btn-move-trigger[aria-expanded="true"] {
+  background-color: var(--color-surface-hover);
+  color: var(--color-text-bright);
 }
 
 .note-card__move-color {

--- a/src/components/feed/NoteCardRenderer.js
+++ b/src/components/feed/NoteCardRenderer.js
@@ -75,7 +75,10 @@ export function renderMoveItem(noteId, subjectId, label, color, isCurrent, isChi
   const check = isCurrent ? ' ✓' : ''
 
   return `
-    <button class="note-card__dropdown-btn${childClass} js-btn-move-to${currentClass}" title="Mover a ${escapeHtmlAttribute(label)}"
+    <button class="note-card__dropdown-btn${childClass} js-btn-move-to${currentClass}"
+            type="button"
+            role="menuitem"
+            title="Mover a ${escapeHtmlAttribute(label)}"
             data-note-id="${escapeHtmlAttribute(noteId)}"
             data-subject-id="${escapeHtmlAttribute(subjectId)}"
             ${isCurrent ? 'disabled' : ''}>

--- a/src/components/feed/NoteList.js
+++ b/src/components/feed/NoteList.js
@@ -138,7 +138,7 @@ export class NoteList {
 
   closeAllDropdowns() {
     const dropdowns = this.container.querySelectorAll('.note-card__dropdown.is-open');
-    dropdowns.forEach(d => d.classList.remove('is-open'));
+    dropdowns.forEach(d => { d.classList.remove('is-open'); d.querySelector('.note-card__move-submenu.is-open')?.classList.remove('is-open'); d.querySelector('.js-btn-move-trigger[aria-expanded="true"]')?.setAttribute('aria-expanded', 'false'); });
   }
 
   handleGlobalClick(e) {
@@ -306,12 +306,12 @@ export class NoteList {
                 ${archiveLabel}
               </button>
               <div class="note-card__move-wrapper">
-                <button class="note-card__dropdown-btn js-btn-move-trigger" title="Mover nota">
+                <button class="note-card__dropdown-btn js-btn-move-trigger" type="button" title="Mover nota" aria-label="Elegir destino de la nota" aria-haspopup="menu" aria-expanded="false">
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"></path><polyline points="10 17 15 12 10 7"></polyline><line x1="15" y1="12" x2="3" y2="12"></line></svg>
                   Mover a
                   <svg class="note-card__move-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
                 </button>
-                <div class="note-card__move-submenu">
+                <div class="note-card__move-submenu" role="menu">
                   ${buildMoveMenu(note.id, note.subjectId, subjectsData)}
                 </div>
               </div>

--- a/src/layout/drawerSubjectContextMenu.js
+++ b/src/layout/drawerSubjectContextMenu.js
@@ -11,7 +11,7 @@ import { handleStoreMutationError } from '../components/common/storeActionErrors
  * @param {HTMLElement} deps.subjectsList Contenedor de materias
  * @param {object} deps.NoteStore Store de notas
  * @param {function} deps.startRenameSubject Inicia renombrado inline
- * @returns {{ consumeSuppressedClick: function }}
+ * @returns {{ consumeSuppressedClick: function, close: function }}
  */
 export function setupSubjectContextMenu({ subjectsList, NoteStore, startRenameSubject }) {
   const existingCtxMenu = document.getElementById('subject-context-menu')
@@ -20,18 +20,19 @@ export function setupSubjectContextMenu({ subjectsList, NoteStore, startRenameSu
   const ctxMenu = document.createElement('div')
   ctxMenu.id = 'subject-context-menu'
   ctxMenu.className = 'drawer__ctx-menu'
+  ctxMenu.setAttribute('role', 'menu')
   ctxMenu.style.display = 'none'
   ctxMenu.innerHTML = `
-    <button class="drawer__ctx-item js-ctx-rename">
+    <button class="drawer__ctx-item js-ctx-rename" type="button" role="menuitem">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
       Renombrar
     </button>
-    <button class="drawer__ctx-item js-ctx-archive">
+    <button class="drawer__ctx-item js-ctx-archive" type="button" role="menuitem">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="21 8 21 21 3 21 3 8"></polyline><rect x="1" y="3" width="22" height="5"></rect><line x1="10" y1="12" x2="14" y2="12"></line></svg>
       <span class="js-ctx-archive-label">Archivar</span>
     </button>
     <div class="drawer__ctx-divider"></div>
-    <button class="drawer__ctx-item drawer__ctx-item--danger js-ctx-delete">
+    <button class="drawer__ctx-item drawer__ctx-item--danger js-ctx-delete" type="button" role="menuitem">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>
       Enviar a Papelera
     </button>
@@ -41,32 +42,51 @@ export function setupSubjectContextMenu({ subjectsList, NoteStore, startRenameSu
   let ctxTarget = null
   let longPressTimer = null
   let suppressNextClick = false
+  let activeTrigger = null
 
-  function openCtxMenu(e, subjectId, isSection, subjectName) {
+  function openCtxMenu(e, subjectId, isSection, subjectName, trigger = null) {
     e.preventDefault()
     e.stopPropagation()
     ctxTarget = { subjectId, isSection, subjectName }
+    activeTrigger?.setAttribute('aria-expanded', 'false')
+    activeTrigger = trigger
+    activeTrigger?.setAttribute('aria-expanded', 'true')
 
     const type = isSection ? 'sección' : 'materia'
     ctxMenu.querySelector('.js-ctx-archive-label').textContent = `Archivar ${type}`
 
-    const subjectBtn = e.target.closest('.drawer__subject-btn')
+    const subjectBtn = e.target.closest('.drawer__subject-row')?.querySelector('.drawer__subject-btn')
     const nameRect = subjectBtn?.querySelector('.drawer__subject-name')?.getBoundingClientRect()
-    const buttonRect = subjectBtn?.getBoundingClientRect()
-    if (buttonRect) {
-      ctxMenu.style.top = `${buttonRect.bottom + 4}px`
-      ctxMenu.style.left = `${nameRect?.left || buttonRect.left}px`
+    const anchorRect = (trigger || subjectBtn)?.getBoundingClientRect()
+
+    ctxMenu.style.display = 'block'
+    ctxMenu.style.visibility = 'hidden'
+    if (anchorRect) {
+      const menuWidth = ctxMenu.offsetWidth
+      const menuHeight = ctxMenu.offsetHeight
+      const preferredLeft = trigger
+        ? anchorRect.right - menuWidth
+        : (nameRect?.left || anchorRect.left)
+      const left = Math.max(8, Math.min(preferredLeft, window.innerWidth - menuWidth - 8))
+      const preferredTop = anchorRect.bottom + 4
+      const top = preferredTop + menuHeight <= window.innerHeight - 8
+        ? preferredTop
+        : Math.max(8, anchorRect.top - menuHeight - 4)
+      ctxMenu.style.top = `${top}px`
+      ctxMenu.style.left = `${left}px`
     } else {
       ctxMenu.style.top = `${e.clientY}px`
       ctxMenu.style.left = `${e.clientX}px`
     }
-
-    ctxMenu.style.display = 'block'
+    ctxMenu.style.visibility = 'visible'
   }
 
   function closeCtxMenu() {
     ctxMenu.style.display = 'none'
+    ctxMenu.style.visibility = ''
     ctxTarget = null
+    activeTrigger?.setAttribute('aria-expanded', 'false')
+    activeTrigger = null
   }
 
   function consumeSuppressedClick() {
@@ -83,6 +103,27 @@ export function setupSubjectContextMenu({ subjectsList, NoteStore, startRenameSu
       subjectBtn.dataset.subject,
       subjectBtn.dataset.isSection === 'true',
       subjectBtn.dataset.subjectName || ''
+    )
+  })
+
+  subjectsList.addEventListener('click', (e) => {
+    const trigger = e.target.closest('.js-subject-actions')
+    if (!trigger) return
+
+    const isCurrentTrigger = activeTrigger === trigger && ctxMenu.style.display === 'block'
+    if (isCurrentTrigger) {
+      e.preventDefault()
+      e.stopPropagation()
+      closeCtxMenu()
+      return
+    }
+
+    openCtxMenu(
+      e,
+      trigger.dataset.subject,
+      trigger.dataset.isSection === 'true',
+      trigger.dataset.subjectName || '',
+      trigger,
     )
   })
 
@@ -117,6 +158,17 @@ export function setupSubjectContextMenu({ subjectsList, NoteStore, startRenameSu
       longPressTimer = null
     }
   })
+
+  function closeOnOutsidePress(e) {
+    if (ctxMenu.style.display !== 'block') return
+    if (ctxMenu.contains(e.target) || e.target.closest?.('.js-subject-actions')) return
+    closeCtxMenu()
+  }
+
+  // En Android, cerrar al comenzar el toque evita depender del click sintetizado
+  // que puede no llegar después de que la navegación oculta o re-renderiza el drawer.
+  document.addEventListener('pointerdown', closeOnOutsidePress, true)
+  document.addEventListener('touchstart', closeOnOutsidePress, { capture: true, passive: true })
 
   document.addEventListener('click', (e) => {
     if (!ctxMenu.contains(e.target)) closeCtxMenu()
@@ -178,5 +230,5 @@ export function setupSubjectContextMenu({ subjectsList, NoteStore, startRenameSu
     }
   })
 
-  return { consumeSuppressedClick }
+  return { consumeSuppressedClick, close: closeCtxMenu }
 }

--- a/src/layout/drawerSubjects.js
+++ b/src/layout/drawerSubjects.js
@@ -103,6 +103,7 @@ export function initSubjects({ NoteStore, SUBJECT_COLORS, closeDrawer, getShowin
 
   // Click en Entrada
   btnInbox.addEventListener('click', () => {
+    subjectContextMenu.close()
     NoteStore.setActiveSubject(null)
     resetArchived()
     updateSubjectActiveState(null)
@@ -206,6 +207,7 @@ export function initSubjects({ NoteStore, SUBJECT_COLORS, closeDrawer, getShowin
   function navigateToSubject(subjectId) {
     if (!subjectId) return
 
+    subjectContextMenu.close()
     NoteStore.setActiveSubject(subjectId)
     resetArchived()
     updateSubjectActiveState(subjectId)

--- a/src/layout/drawerSubjectsRender.js
+++ b/src/layout/drawerSubjectsRender.js
@@ -69,6 +69,7 @@ export function renderSubjectsList(subjectsData, { NoteStore, subjectsList, inbo
             <span class="drawer__subject-name" data-name-id="${childId}">${escapeHtmlText(child.name)}</span>
             <span class="drawer__subject-count">${escapeHtmlText(child.noteCount || 0)}</span>
           </div>
+          ${renderSubjectActionsButton(child.id, child.name, true)}
         </div>
       `
     }).join('')
@@ -110,15 +111,45 @@ export function renderSubjectsList(subjectsData, { NoteStore, subjectsList, inbo
             <span class="drawer__subject-name" data-name-id="${subjectId}">${subjectName}</span>
             <span class="drawer__subject-count">${escapeHtmlText(subject.noteCount || 0)}</span>
           </div>
-          <button class="drawer__section-add js-btn-add-section" data-parent-id="${subjectId}" data-parent-color="${subjectColorAttribute}" title="Agregar sección">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+          <button class="drawer__subject-action drawer__section-add js-btn-add-section"
+                  type="button"
+                  data-parent-id="${subjectId}"
+                  data-parent-color="${subjectColorAttribute}"
+                  aria-label="Agregar sección a ${subjectNameAttribute}"
+                  title="Agregar sección">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
           </button>
+          ${renderSubjectActionsButton(subject.id, subject.name, false)}
         </div>
         ${childrenGroupHtml}
         ${sectionFormHtml}
       </div>
     `
   }).join('')
+}
+
+function renderSubjectActionsButton(subjectIdValue, subjectNameValue, isSection) {
+  const subjectId = escapeHtmlAttribute(subjectIdValue)
+  const subjectName = escapeHtmlAttribute(subjectNameValue)
+  const itemType = isSection ? 'sección' : 'materia'
+
+  return `
+    <button class="drawer__subject-action drawer__subject-more js-subject-actions"
+            type="button"
+            data-subject="${subjectId}"
+            data-subject-name="${subjectName}"
+            data-is-section="${String(isSection)}"
+            aria-label="Más opciones de ${itemType} ${subjectName}"
+            aria-haspopup="menu"
+            aria-expanded="false"
+            title="Más opciones">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <circle cx="12" cy="5" r="1.6"></circle>
+        <circle cx="12" cy="12" r="1.6"></circle>
+        <circle cx="12" cy="19" r="1.6"></circle>
+      </svg>
+    </button>
+  `
 }
 
 function renderCollapseButton(subject, isCollapsed) {

--- a/src/styles/drawer-subjects.css
+++ b/src/styles/drawer-subjects.css
@@ -164,34 +164,39 @@
   transform: rotate(90deg);
 }
 
-/* '+' button to add section (visible on hover) */
-.drawer__section-add {
+/* Direct actions for subjects and sections */
+.drawer__subject-action {
   background: transparent;
   border: none;
   color: var(--color-text-muted);
-  width: 24px;
-  height: 24px;
+  width: 32px;
+  height: 32px;
   border-radius: var(--radius-sm);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  opacity: 0;
   transition: all var(--transition);
   flex-shrink: 0;
 }
 
-.drawer__subject-row:hover .drawer__section-add {
-  opacity: 1;
+.drawer__subject-action:hover {
+  background: var(--color-surface-hover);
+  color: var(--color-text-bright);
 }
 
-.drawer__section-add--visible {
-  opacity: 1;
+.drawer__subject-action:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
 }
 
 .drawer__section-add:hover {
-  background: var(--color-surface-hover);
   color: var(--color-accent);
+}
+
+.drawer__subject-more[aria-expanded="true"] {
+  background: var(--color-surface-hover);
+  color: var(--color-text-bright);
 }
 
 /* Inline rename input */

--- a/tests/unit/components/feed/FeedActionRouter.test.js
+++ b/tests/unit/components/feed/FeedActionRouter.test.js
@@ -102,6 +102,34 @@ beforeEach(() => {
 })
 
 describe('FeedActionRouter dropdown actions', () => {
+  it('abre y cierra el selector Mover a con toques normales', () => {
+    const deps = createDeps()
+    const feed = document.createElement('div')
+    feed.innerHTML = `
+      <div class="note-card__dropdown is-open">
+        <div class="note-card__move-wrapper">
+          <button class="js-btn-move-trigger" aria-expanded="false">Mover a</button>
+          <div class="note-card__move-submenu"></div>
+        </div>
+      </div>
+    `
+    const trigger = feed.querySelector('.js-btn-move-trigger')
+    const submenu = feed.querySelector('.note-card__move-submenu')
+    feed.addEventListener('click', createFeedActionRouter(deps))
+
+    trigger.click()
+
+    expect(submenu.classList.contains('is-open')).toBe(true)
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    expect(deps.closeAllDropdowns).not.toHaveBeenCalled()
+
+    trigger.click()
+
+    expect(submenu.classList.contains('is-open')).toBe(false)
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    expect(NoteStore.moveNote).not.toHaveBeenCalled()
+  })
+
   it('mantiene abierto el dropdown para que Copiar pueda mostrar feedback visual', () => {
     const deps = createDeps()
     const router = createFeedActionRouter(deps)

--- a/tests/unit/layout/drawerSubjects.test.js
+++ b/tests/unit/layout/drawerSubjects.test.js
@@ -154,6 +154,84 @@ describe('drawerSubjects mutation failures', () => {
 })
 
 describe('drawerSubjects collapse', () => {
+  it('muestra acciones directas sin ofrecer subsecciones dentro de una sección', () => {
+    const { subjectsList } = setupSubjectsDrawer()
+
+    const rootRows = subjectsList.querySelectorAll('.drawer__subject-group > .drawer__subject-row')
+    const sectionRow = subjectsList.querySelector('.drawer__subject-row--child')
+
+    expect(subjectsList.querySelectorAll('.js-btn-add-section')).toHaveLength(2)
+    expect(subjectsList.querySelectorAll('.js-subject-actions')).toHaveLength(3)
+    expect(rootRows[0].querySelector('.js-btn-add-section')?.getAttribute('aria-label'))
+      .toBe('Agregar sección a Programacion')
+    expect(rootRows[0].querySelector('.js-subject-actions')?.getAttribute('aria-label'))
+      .toBe('Más opciones de materia Programacion')
+    expect(sectionRow.querySelector('.js-btn-add-section')).toBeNull()
+    expect(sectionRow.querySelector('.js-subject-actions')?.getAttribute('aria-label'))
+      .toBe('Más opciones de sección Unidad 1')
+  })
+
+  it('abre renombrado desde el botón de opciones sin navegar por la materia', () => {
+    const { closeDrawer, NoteStore, subjectsList } = setupSubjectsDrawer()
+    const subjectRow = subjectsList.querySelector('.drawer__subject-group > .drawer__subject-row')
+    const actionsButton = subjectRow.querySelector('.js-subject-actions')
+
+    actionsButton.click()
+
+    const contextMenu = document.getElementById('subject-context-menu')
+    expect(contextMenu.style.display).toBe('block')
+    expect(contextMenu.querySelector('.js-ctx-archive-label').textContent).toBe('Archivar materia')
+    expect(actionsButton.getAttribute('aria-expanded')).toBe('true')
+    expect(NoteStore.setActiveSubject).not.toHaveBeenCalled()
+    expect(closeDrawer).not.toHaveBeenCalled()
+
+    contextMenu.querySelector('.js-ctx-rename').click()
+
+    expect(subjectRow.querySelector('.js-rename-input')?.dataset.subjectId).toBe('subj-1')
+    expect(actionsButton.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('identifica como sección el menú directo de una fila hija', () => {
+    const { subjectsList } = setupSubjectsDrawer()
+
+    subjectsList.querySelector('.drawer__subject-row--child .js-subject-actions').click()
+
+    const contextMenu = document.getElementById('subject-context-menu')
+    expect(contextMenu.style.display).toBe('block')
+    expect(contextMenu.querySelector('.js-ctx-archive-label').textContent).toBe('Archivar sección')
+  })
+
+  it.each([
+    ['Entrada', '#btn-inbox'],
+    ['otra materia', '[data-subject="subj-2"]'],
+    ['una sección', '[data-subject="sec-1"]'],
+  ])('cierra el menú contextual al navegar a %s', (_destination, selector) => {
+    const { subjectsList } = setupSubjectsDrawer()
+    const actionsButton = subjectsList.querySelector('.drawer__subject-group > .drawer__subject-row .js-subject-actions')
+
+    actionsButton.click()
+    expect(document.getElementById('subject-context-menu').style.display).toBe('block')
+
+    document.querySelector(selector).click()
+
+    expect(document.getElementById('subject-context-menu').style.display).toBe('none')
+    expect(actionsButton.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('cierra el menú desde el inicio de un toque fuera antes de navegar', () => {
+    const { subjectsList } = setupSubjectsDrawer()
+    const actionsButton = subjectsList.querySelector('.drawer__subject-group > .drawer__subject-row .js-subject-actions')
+    const destination = subjectsList.querySelector('[data-subject="subj-2"]')
+
+    actionsButton.click()
+    expect(document.getElementById('subject-context-menu').style.display).toBe('block')
+
+    destination.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+
+    expect(document.getElementById('subject-context-menu').style.display).toBe('none')
+    expect(actionsButton.getAttribute('aria-expanded')).toBe('false')
+  })
+
   it('renderiza flecha solo en materias con secciones', () => {
     const { subjectsList } = setupSubjectsDrawer()
 


### PR DESCRIPTION
## Summary
- open note move destinations with a normal tap instead of hover or long press
- expose add-section and overflow actions directly in subject rows
- keep sections at one hierarchy level and omit nested add actions
- dismiss subject context menus as soon as users touch or navigate elsewhere

## Validation
- `VITEST_MAX_WORKERS=1 npm run verify`
- 67 test files, 1065 tests passed
- Android manual validation on Samsung SM-G965F with local data preserved
