### PR TITLE
docs(plan): superseded after head branch rename

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,7 +4,7 @@ Este documento funciona como bandeja viva de tareas, deuda y decisiones pendient
 
 > **Hito activo:** 06 — Entrega Final
 > **Hito 05:** Cerrado documentalmente el 2026-07-15 sobre la beta operativa `v0.4.8`
-> **Última actualización:** 2026-09-05 — pre-release `v0.5.0` publicada con AUD-001 a AUD-007, correcciones táctiles y tooling de release sincronizado
+> **Última actualización:** 2026-09-12 — plan inmediato propuesto para revisión; AUD-014 reproducido, sin cambios de implementación ni versión
 > **Snapshot histórico:** [`docs/gestion/historico/backlog-historico-hito-04-2026-06-01.md`](docs/gestion/historico/backlog-historico-hito-04-2026-06-01.md)
 
 ---
@@ -18,6 +18,8 @@ Hito 05 quedó cerrado documentalmente el 2026-07-15. Entregó el quality gate, 
 Hito 06 queda activo para completar la documentación final, verificar la maquetación de los gráficos de base de datos, cerrar la matriz RNF y preparar la presentación. La segunda beta [`v0.5.0`](https://github.com/jdfesa/lumapse/releases/tag/v0.5.0) ya está publicada: fija el commit `5840755`, distribuye `lumapse-v0.5.0.apk` y reúne AUD-001 a AUD-007, las correcciones táctiles de organización y el tooling de release sincronizado. Este corte es la referencia operativa vigente, pero no se presenta todavía como versión estable ni como cierre académico definitivo.
 
 La revisión técnica priorizada del 2026-09-01 abrió trece hallazgos trazables. AUD-001 y AUD-002 quedaron resueltos mediante PR #2; AUD-003 mediante PR #3; AUD-004 mediante PR #5; AUD-007 mediante PR #6; AUD-005 mediante PR #7 y AUD-006 mediante PR #8. Los siete cierres forman parte de `v0.5.0`. El gate del corte aprobó 67 archivos y 1065 tests; la limitación local de Node 26 continúa registrada como AUD-009 y no invalida la ejecución canónica con Node 22. La validación funcional de 500 notas de AUD-003 no sustituye las mediciones de latencia y rendimiento exigidas por `RNF-002` y `RNF-004`. Los hallazgos restantes mantienen sus prioridades y no se incorporan automáticamente al alcance de Hito 06.
+
+La revisión acotada del 2026-09-12 agregó **AUD-014**: una creación de nota o fecha ya persistida puede rechazar por fallo de recarga y duplicarse al reintentar. Se reprodujo sobre SQLite en memoria, no en Android. El [plan de desarrollo inmediato](docs/gestion/plan-desarrollo-inmediato-beta-2026-09-12.md) propone abordarlo después de hacer reproducible el gate; su aceptación no implica implementación ni cierre del hallazgo.
 
 La revisión de exportación/importación corrige una sobrepromesa documental del Hito 03: los servicios base de Markdown no equivalían a un flujo de usuario validado. La opción "Compartir" para una nota individual (`RF-016`) solo tendría sentido si abre el share sheet nativo de Android y ofrece apps como WhatsApp; si termina copiando contenido, duplica una acción existente y agrega ruido. La portabilidad de workspace sí quedó resuelta de forma acotada con exportación e importación de backup `.zip` desde la vista Backup.
 
@@ -35,18 +37,21 @@ La trazabilidad de `v0.4.8` y `v0.5.0` queda distribuida entre `docs/gestion/lin
 
 ## Prioridad Inmediata — Hito 06
 
+**Propuesta pendiente de aceptación por PR:** concentrar las próximas sesiones técnicas en la siguiente secuencia. Alcance, archivos, pruebas, dependencias y criterios de salida viven en el [plan inmediato](docs/gestion/plan-desarrollo-inmediato-beta-2026-09-12.md); no se inicia implementación antes de integrar el plan con autorización.
+
 | Orden | Tarea | Criterio de cierre |
 |---|---|---|
-| 1 | Congelamiento editorial y visual | Consolidar evidencia, verificar bibliografía y confirmar legibilidad de gráficos DB en PDF y diapositivas |
-| 2 | Validación final | Consolidar el gate aprobado de `v0.5.0`, completar las mediciones RNF y repetir los casos aún no cubiertos sobre el artefacto versionado; la fricción de `Mover a` ya quedó corregida y validada |
-| 3 | Presentación y defensa | Preparar guion, demo, cheatsheet, material visual y contingencias |
-| 4 | Corte final | Decidir si `v0.5.0` será la beta de referencia de la defensa o si corresponde una versión estable posterior; mantener versión, firma, hash, tag y línea base inequívocos |
+| F1 | Gate portable y Node explícito — AUD-008/AUD-009 | Mismo `verify` local/CI, Node 22 fijado, sin falsos positivos CSP ni aceptación de crashes |
+| F2 | Confirmación de creación — AUD-014 | Una escritura confirmada no se informa como fallida por una recarga; regresiones y smoke Android proporcionales |
+| F3 | Evidencia del núcleo y 500 notas | Resultados trazables de CRUD/FPS, offline y continuidad; optimizaciones solo si una medición las justifica y se aprueba otro PR |
+
+Continúan los pendientes de **congelamiento editorial/visual**, **validación RNF restante**, **presentación/defensa** y **línea base final**. No quedan completados ni descartados por esta secuencia técnica. No se fuerza una versión estable o `1.0.0` al terminar F3.
 
 ---
 
 ## Revisión técnica priorizada — estado vivo
 
-El análisis detallado permanece en [`docs/gestion/revision-tecnica-priorizada-2026-09-01.md`](docs/gestion/revision-tecnica-priorizada-2026-09-01.md). Esta tabla fija el estado operativo después de cerrar AUD-001 a AUD-005 y AUD-007.
+El análisis original permanece en [`docs/gestion/revision-tecnica-priorizada-2026-09-01.md`](docs/gestion/revision-tecnica-priorizada-2026-09-01.md). Esta tabla fija el estado operativo después de cerrar AUD-001 a AUD-007 y registrar el complemento acotado del 2026-09-12.
 
 | ID | Prioridad | Frente | Estado operativo |
 |---|---|---|---|
@@ -57,8 +62,9 @@ El análisis detallado permanece en [`docs/gestion/revision-tecnica-priorizada-2
 | AUD-005 | P1 | Coordinación SQLite, migraciones y arranque | Cerrado e integrado mediante PR #7; 1035 tests, gate canónico y prueba manual Android aprobados. [Evidencia](docs/gestion/analisis-aud-005-coordinacion-sqlite-2026-09-04.md) |
 | AUD-006 | P1 | Resultados async obsoletos | Cerrado en [PR #8](https://github.com/jdfesa/lumapse/pull/8), incluido en `v0.5.0`; Mac/Android y regresiones aprobados. [Evidencia](docs/gestion/analisis-aud-006-ownership-solicitudes-async-2026-09-05.md) |
 | AUD-007 | P1 | Contratos incompatibles para errores de mutaciones | Cerrado en PR #6; contrato único, consumidores y Android aprobados |
-| AUD-008–AUD-009 | P1 | Portabilidad del gate y Node 26 | Pendientes; abordar sin relajar controles |
+| AUD-008–AUD-009 | P1 | Portabilidad del gate y Node 26 | Pendientes; propuesta F1 del plan inmediato, sin relajar controles |
 | AUD-010–AUD-013 | P2 | Escalabilidad, rendimiento, cohesión y margen de bundle/coverage | Monitorear o medir; no bloquean por sí solos el cierre actual |
+| AUD-014 | P1 | Creación persistida rechaza por fallo de recarga | Confirmado en notas/fechas con SQLite en memoria; propuesta F2, sin implementación ni validación Android |
 
 ---
 
@@ -99,6 +105,7 @@ Estas tareas no bloquean el MVP. Se conservan como decisiones trazables para rea
 | Documentación | Congelar documentos para la entrega académica | Alta | La documentación viva se reconcilió con `v0.5.0`; restan bibliografía, matriz RNF, revisión de maquetación y materiales de defensa |
 | Dependencias | Repetir auditorías en cada corte candidato | Recurrente | AUD-004 quedó cerrado con grafo mínimo, auditorías 0/0 y Android aprobado; revalidar porque los advisories evolucionan |
 | Tooling | Resolver portabilidad de gate y Node 26 (AUD-008/AUD-009) | Media | Distinguir falsos positivos CSP del fallback offline y eliminar la dependencia del workaround de Web Storage sin relajar controles |
+| Store / formularios | Separar creación confirmada de recarga fallida (AUD-014) | Alta | Dos caracterizaciones verifican duplicados por reintento; contrato y criterios propuestos en F2 del [plan inmediato](docs/gestion/plan-desarrollo-inmediato-beta-2026-09-12.md) |
 | Tooling DB | Ampliar el smoke test a `academic_events` y constraints relevantes | Media | El DDL completo se ejecuta, pero las aserciones explícitas de tablas/columnas/relaciones se concentran en materias, notas y metadata; decidir su ampliación antes de presentar cobertura exhaustiva |
 | Diagramas | Revisar Mermaid de casos de uso, secuencia y dominio | Baja | Completado el 2026-07-03 contra `v0.4.8`; reabrir solo si cambia el alcance o durante la exportacion final a PDF/LaTeX |
 | Informe final | Preparar conversion LaTeX/PDF | Media | Consideraciones registradas en `docs/informe-final/README.md`; mantener Markdown como fuente de verdad y abrir pipeline LaTeX solo cuando el contenido este congelado |

--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Paralelamente al desarrollo se realizó un relevamiento con potenciales usuarios
 - [Portal documental](./docs/README.md) — Jerarquía, fuentes canónicas y criterio editorial
 - [Informe final ensamblado](./docs/informe-final/INFORME-FINAL-COMPLETO.md) — Checkpoint académico generado desde los capítulos fuente
 - [Hito 06 — Entrega Final](./docs/hitos/hito-06-octubre.md) — Alcance y criterios de cierre vigentes
+- [Plan de desarrollo inmediato de la beta](./docs/gestion/plan-desarrollo-inmediato-beta-2026-09-12.md) — Propuesta para próximas sesiones, con evidencia y criterios de aceptación; pendiente de revisión por PR
 - [Cheat sheet de defensa](./docs/gestion/cheatsheet-defensa.md) — Métricas y respuestas verificables para la presentación
 - [Architecture Decision Records](./docs/adr/) — Decisiones técnicas justificadas
 - [Diagramas UML](./docs/diagramas/) — Casos de Uso, Secuencia, Modelo de Dominio (Mermaid)

--- a/TODO
+++ b/TODO
@@ -12,14 +12,22 @@
 
 **Objetivo:** cerrar documentación, gráficos de base de datos, validación final y materiales de presentación sin ampliar el producto.
 
-## Prioridad inmediata
+## Prioridad inmediata — propuesta para próximas sesiones
+
+El [plan de desarrollo inmediato de la beta](docs/gestion/plan-desarrollo-inmediato-beta-2026-09-12.md) está **pendiente de aceptación por PR**. Solo después de autorizar su merge e integrarlo se inicia F1. Ninguna de estas fases está implementada; cada una tendrá su rama, evidencia y revisión.
 
 | Orden | Frente | Criterio de cierre |
 |---|---|---|
-| 1 | Congelamiento editorial y visual | Evidencia y bibliografía consolidadas; gráficos DB legibles en PDF y diapositivas |
-| 2 | Validación final | Consolidar el gate de `v0.5.0`, completar la checklist Android pendiente y cerrar la matriz RNF con observaciones clasificadas |
-| 3 | Defensa y presentación | Guion, cheatsheet, demo y material visual preparados y ensayados |
-| 4 | Línea base final | Decidir si `v0.5.0` será la referencia de defensa o si corresponde un corte estable posterior; versión, firma, hash y tag siempre inequívocos |
+| F1 | Gate portable — AUD-008/AUD-009 | Node 22 fijado y mismo `verify` local/CI, sin depender de workaround, binario ignorado o falsos positivos CSP |
+| F2 | Creación confirmada — AUD-014 | No duplicar notas/fechas al fallar una recarga posterior a la escritura; regresiones y smoke Android |
+| F3 | Validación del núcleo | Fixture compatible de 500 notas, mediciones CRUD/FPS y casos offline/continuidad con evidencia del artefacto |
+
+El cierre editorial/visual, la matriz RNF restante, la defensa y la decisión de línea base final **siguen pendientes** en la checklist. F3 no los sustituye ni obliga a publicar `1.0.0`. WIP máximo: dos elementos entre En Curso y En Revisión.
+
+- [ ] Aceptar e integrar el PR del plan inmediato; no implementar antes de ese punto.
+- [ ] F1: cerrar AUD-008/AUD-009 en `fix/quality-gate-portability` con pruebas del gate y CI.
+- [ ] F2: cerrar el alcance confirmado de AUD-014 en `fix/post-write-refresh-contract` sin confundir fallo de escritura con fallo de refresco.
+- [ ] F3: registrar la evidencia en `docs/beta-core-validation`; no optimizar consultas/store sin medición y nueva aprobación.
 
 ## Checklist de trabajo
 

--- a/docs/gestion/README.md
+++ b/docs/gestion/README.md
@@ -4,7 +4,7 @@ Esta carpeta contiene los artefactos de **estimación, planificación y control 
 del proyecto, según los lineamientos de la cátedra PP3 (Ing. Mauricio Parada) y la bibliografía
 de Gómez (2014).
 
-> **Estado actual:** Hito 05 quedó cerrado sobre `v0.4.8`. Hito 06 — Entrega Final está activo y ya publicó la segunda beta `v0.5.0`; el foco continúa en congelamiento documental, matriz RNF, maquetación y presentación. Ver [`../hitos/hito-06-octubre.md`](../hitos/hito-06-octubre.md).
+> **Estado actual:** Hito 05 quedó cerrado sobre `v0.4.8`. Hito 06 — Entrega Final está activo y ya publicó la segunda beta `v0.5.0`; continúa el cierre académico y se propone un [ciclo técnico inmediato](./plan-desarrollo-inmediato-beta-2026-09-12.md) de verificación, integridad de creación y evidencia Android, pendiente de aceptación por PR. Ver [`../hitos/hito-06-octubre.md`](../hitos/hito-06-octubre.md).
 
 ---
 
@@ -12,6 +12,7 @@ de Gómez (2014).
 
 | Documento | Contenido | Estado |
 |---|---|---|
+| [`plan-desarrollo-inmediato-beta-2026-09-12.md`](./plan-desarrollo-inmediato-beta-2026-09-12.md) | Análisis acotado y próximas sesiones: AUD-008/AUD-009, nuevo AUD-014 y validación del núcleo con 500 notas | 📝 Propuesta para revisión; sin implementación |
 | [`definicion-flujo-kanban.md`](./definicion-flujo-kanban.md) | Definition of Workflow, WIP, políticas, SLE y métricas de flujo desde Hito 06 | ✅ Vigente |
 | [`estimacion-pert.md`](./estimacion-pert.md) | Estimación de 3 puntos (PERT) para los módulos de mayor riesgo | ✅ Completado |
 | [`lineas-base.md`](./lineas-base.md) | Registro de líneas base y releases `v0.4.8`/`v0.5.0`, más el futuro corte estable | 🔄 Activo en Hito 06 |
@@ -20,7 +21,7 @@ de Gómez (2014).
 | [`cheatsheet-defensa.md`](./cheatsheet-defensa.md) | Métricas, decisiones y respuestas breves para la defensa | 🔄 Revisión final pendiente |
 | [`firma-apk-android.md`](./firma-apk-android.md) | Política de firma, secretos y evidencia de los artefactos Android publicados | ✅ `v0.5.0` publicada |
 | [`plan-mantenibilidad-tipado-gradual-2026-06-12.md`](./plan-mantenibilidad-tipado-gradual-2026-06-12.md) | Estrategia incremental de modularidad y tipado; no habilita refactors amplios durante el cierre | 📌 Referencia |
-| [`revision-tecnica-priorizada-2026-09-01.md`](./revision-tecnica-priorizada-2026-09-01.md) | Auditoría vigente de arquitectura, seguridad, persistencia, escalabilidad y tooling con backlog priorizado | ✅ AUD-001 a AUD-007 cerrados en `v0.5.0` |
+| [`revision-tecnica-priorizada-2026-09-01.md`](./revision-tecnica-priorizada-2026-09-01.md) | Auditoría original y seguimiento vivo; complemento AUD-014 enlazado al plan inmediato | ✅ AUD-001 a AUD-007 cerrados; restantes abiertos |
 | [`analisis-aud-003-seguridad-importacion-backups-2026-09-01.md`](./analisis-aud-003-seguridad-importacion-backups-2026-09-01.md) | Revalidación e implementación de AUD-003: frontera ZIP/JSON, integridad y defensa de presentación | ✅ Cerrado en PR #3 |
 | [`analisis-aud-004-seguridad-dependencias-2026-09-02.md`](./analisis-aud-004-seguridad-dependencias-2026-09-02.md) | Revalidación y cierre de AUD-004: advisories, grafo mínimo, auditorías, gates y Android | ✅ Cerrado en PR #5 |
 | [`analisis-aud-007-contratos-errores-store-2026-09-03.md`](./analisis-aud-007-contratos-errores-store-2026-09-03.md) | Contrato emit-and-rethrow, adaptación de consumidores y evidencia automática/Android de AUD-007 | ✅ Cerrado en PR #6 |

--- a/docs/gestion/plan-desarrollo-inmediato-beta-2026-09-12.md
+++ b/docs/gestion/plan-desarrollo-inmediato-beta-2026-09-12.md
@@ -1,0 +1,247 @@
+# Plan de desarrollo inmediato de la beta — 2026-09-12
+
+**Estado:** Propuesta para revisión por PR; ninguna fase de implementación está iniciada.
+
+**Rama documental:** `docs/plan-inmediato-beta`.
+
+**Base inspeccionada:** `origin/main` en `91723d6` (2026-09-07), posterior a la publicación de `v0.5.0`.
+
+**Horizonte:** próximas tres a cuatro sesiones de trabajo, sujeto a revisión y disponibilidad Android; no es una fecha de entrega.
+
+**Responsable:** autor del proyecto, con asistencia técnica; la aceptación y el merge requieren su autorización.
+
+## 1. Decisión propuesta
+
+Trabajar en **tres entregables secuenciales y revisables**: hacer reproducible la verificación, corregir una ambigüedad de guardado confirmada y medir/validar el núcleo en Android. No agregar funcionalidades ni cambiar de arquitectura.
+
+**La primera tarea después de aceptar e integrar este PR será F1, en `fix/quality-gate-portability`.** F1 es un prerrequisito de verificación, no una razón para postergar indefinidamente el defecto funcional F2. Si excede una sesión, registrar el bloqueo y dividir su entrega antes de incorporar otro objetivo.
+
+El plan descompone el frente de **validación final de Hito 06**. No reemplaza el cierre académico de Prácticas Profesionalizantes III: bibliografía, maquetación, pruebas con estudiantes y defensa siguen pendientes. Tampoco promete `1.0.0`: una versión estable se decidirá después de reunir evidencia y aceptar explícitamente las limitaciones, en un corte separado.
+
+## 2. Qué se revisó y qué no
+
+Se partió de [`README.md`](../../README.md), [`BACKLOG.md`](../../BACKLOG.md), [`TODO`](../../TODO), [Hito 06](../hitos/hito-06-octubre.md), la [auditoría anterior](./revision-tecnica-priorizada-2026-09-01.md), los [RNF](../producto/requisitos-no-funcionales.md) y las reglas de contribución. La inspección de código fue acotada a cambios recientes y a las dependencias necesarias para contrastar sus pendientes:
+
+| Recorte | Archivos y motivo |
+|---|---|
+| Cambios del 6–7 de septiembre | README y presentación de capturas/video; no cambian el runtime |
+| AUD-007, 3 de septiembre | `NoteStore.data.js`, `NoteStore.errors.js`, `NoteEditor.js`, `AcademicEventDialog.js` y tests asociados: contrato de errores y confirmación de guardado |
+| AUD-005, 4 de septiembre | `sqlite/connection.js`, CRUD de notas/eventos, `SubjectService.crud.ts`/`SubjectService.trash.ts` y harness SQLite: persistencia, recargas y conteos |
+| AUD-006 y correcciones táctiles, 5 de septiembre | `NoteStore.academicEvents.js`, `TrashRequestOwner.js`, fragmentos/diffs de Heatmap, feed, drawer y sus tests: conservar protecciones recientes |
+| Dependencias del gate y de la medición | `package.json`, `vitest.config.js`, setup de tests, `.github/workflows/lint.yml`, `scripts/quality.sh`, auditor offline Shell/Rust, smoke SQLite y scripts existentes de datos/carga |
+
+No se realizó una auditoría integral del repositorio, un pentest, una nueva consulta de advisories, una instalación Android ni una medición de rendimiento nativo. No se leyeron bases personales ni se ejecutaron los generadores de datos antiguos. Las conclusiones siguientes separan hechos comprobados de riesgos pendientes de medición.
+
+## 3. Diagnóstico vigente
+
+| Frente | Evidencia en la base revisada | Clasificación y decisión |
+|---|---|---|
+| AUD-001 a AUD-007 y `Mover a` | Sus correcciones están integradas en `v0.5.0`; el código reciente conserva single-flight, propagación de errores y ownership de solicitudes | **Cerrados.** Mantener sus regresiones; no reabrirlos por una recomendación histórica |
+| AUD-008: gate local/CI | El fallback offline rechaza las dos entradas `http://localhost` del CSP. CI ejecuta una lista propia que omite typecheck, offline, toolchain y DB smoke; `verify` tampoco incluye el DBML que CI sí controla | **Confirmado. F1.** Unificar la unión de controles, no su mínimo común |
+| AUD-009: entorno Node | README ofrece `v22+`, CI fija 22 y no existe archivo de versión. En Node 26.7.0, sin `NODE_OPTIONS`, la suite con un worker falla 60 tests por `localStorage` indefinido | **Confirmado. F1.** Proponer Node 22 como entorno soportado explícito; no ampliar ahora la matriz a Node 26 |
+| AUD-014: escritura confirmada presentada como fallo | Dos caracterizaciones sobre SQLite en memoria prueban que crear una nota/fecha, fallar su lectura secundaria y reintentar deja dos filas con IDs distintos | **Nuevo defecto confirmado, P1. F2.** Separar persistencia de actualización de datos derivados |
+| AUD-010/AUD-011: notificaciones y conteos | `createNote`, `moveNote` y `deleteNote` encadenan loaders notificantes y otra notificación; `getSubjectTree`/`getTrashItems` conservan conteos secuenciales por contenedor | **Patrones confirmados; impacto temporal no medido. F3 mide, no optimiza por intuición** |
+| Smoke de base de datos | Ejecuta el DDL actual, pero `EXPECTED_TABLES`/`EXPECTED_COLUMNS` y las aserciones de relaciones no exigen `academic_events`, sus índices ni su `CHECK(type)` | **Brecha de cobertura**, ya registrada en backlog; no demuestra un defecto del schema. No presentarlo como validación exhaustiva |
+| Herramientas de carga heredadas | `generate-mock-data.py` genera 100 notas aleatorias con columnas antiguas (`created_at`, `is_pinned`, etc.) hacia `src/store/migrations`; `run-load-tests.py` mide DP-001 en Python/SQLite en memoria con durabilidad desactivada | **No son evidencia RNF-002/RNF-004 del APK.** F3 requiere fixture compatible y medición nativa |
+| AUD-012/AUD-013 | Cohesión, tamaño de archivos, bundle y coverage siguen como deuda/monitoreo | No abrir migración de UI, refactor masivo ni ampliación de coverage en este ciclo |
+
+### AUD-014: secuencia causal y límites de la prueba
+
+1. `NoteStore.data.createNote()` espera la inserción, agrega la nota a `state.notes` y después espera `loadSubjects()`, todavía dentro de `runStoreAction()`.
+2. Si esa lectura falla, la promesa rechaza aunque la fila ya exista. `NoteEditor.handleSave()` no llega al descarte del borrador y vuelve a habilitar el botón; el siguiente intento vuelve a crear.
+3. `NoteStore.academicEvents.createAcademicEvent()` tiene la misma frontera con `reloadUpcomingAcademicEvents()`. El diálogo permanece abierto ante rechazo.
+4. Las dos reproducciones usan servicios y coordinador reales, el DDL vigente y `sql.js`; el harness reemplaza el plugin nativo e inyecta un fallo de lectura. Un `SELECT` prueba una fila después del rechazo y dos después del reintento.
+
+Esto **no demuestra pérdida de datos, frecuencia del fallo en teléfonos ni una transacción SQLite defectuosa**. Confirma una señal de resultado incorrecta y duplicación por reintento en esos dos caminos. AUD-001/AUD-002 cubrieron fallo de escritura y taps simultáneos; no este fallo posterior a una escritura exitosa. La [reproducción autocontenida](#8-reproducción-de-aud-014) conserva la evidencia sin agregar tests permanentes antes de aprobar la implementación.
+
+## 4. Secuencia de las próximas sesiones
+
+| Orden | Entregable | Rama prevista | Dependencia | Salida revisable |
+|---|---|---|---|---|
+| Actual | Analizar y acordar el alcance | `docs/plan-inmediato-beta` | Ninguna | Este documento, pendientes reconciliados y PR sin merge automático |
+| F1 · sesión 1 | Gate portable y entorno explícito | `fix/quality-gate-portability` | PR del plan aceptado e integrado | Un PR de tooling que cierra AUD-008/AUD-009 con evidencia local/CI |
+| F2 · sesión 2, ampliable a 3 | Confirmación inequívoca de creación | `fix/post-write-refresh-contract` | F1 integrado | Un PR funcional para AUD-014, regresiones permanentes y smoke Android proporcional |
+| F3 · siguiente sesión | Validación crítica y medición con 500 notas | `docs/beta-core-validation` | F2 integrado y dispositivo autorizado disponible | Fixture/protocolo reproducibles y reporte; ninguna optimización incluida |
+
+Cada fase vuelve a `main` actualizado antes de crear su rama y espera revisión antes del merge. Se mantiene [WIP global 2](./definicion-flujo-kanban.md), contando también `En Revisión`; la secuencia propuesta usa un solo frente técnico activo. El apoyo de estudiantes/dispositivo se coordina con el autor, no se presume disponible. Registrar `startedAt`/`finishedAt` cuando sucedan, no inventarlos desde commits.
+
+### F1 — Verificación reproducible antes de tocar el comportamiento
+
+**Objetivo:** que un checkout limpio, sin binarios ignorados ni variables especiales, obtenga un resultado de calidad comparable con CI.
+
+**Cambios acotados:**
+
+1. Fijar Node 22 mediante un archivo de versión y `engines`; elegir y registrar un patch compatible con el lockfile, consumido también por CI. Corregir `v22+` en README y documentar instalación/verificación. Una versión no soportada debe producir un diagnóstico temprano, no 60 fallos engañosos. No actualizar dependencias por arrastre.
+2. Corregir la clasificación offline mediante una excepción contextual para los orígenes locales requeridos en el CSP. No eliminar la CSP ni ignorar `index.html`, todas las URLs o líneas completas que contengan `localhost`.
+3. Hacer que `npm run verify` y CI ejecuten la misma unión de controles: lint, tests, build, typecheck, toolchain, versión, DB smoke, presupuesto, diálogos nativos, a11y, trazabilidad, links, schema, DBML, jerarquía y offline. Mantener identificable qué control falla.
+4. Garantizar que la presencia de `scripts/lumapse-audit-bin` no pueda omitir controles obligatorios ni cambiar su criterio de aceptación. Puede conservarse como acelerador/diagnóstico, pero no como requisito oculto. No emprender una reescritura del auditor Rust.
+5. Retirar del camino canónico la aceptación de exit `139` por texto de resumen en `quality.sh`: un crash no equivale a gate aprobado. No convertir errores en warnings ni normalizar exits no cero.
+
+**Superficie prevista:** `package.json` y metadatos correspondientes de `package-lock.json`, nuevo archivo de versión, `.github/workflows/lint.yml`, `scripts/quality.sh`, `scripts/check-offline.sh`, pruebas acotadas de scripts, README y `scripts/README.md`. No cambiar `src/` ni el schema. Si se agrega un script, documentarlo y conectarlo a su entrypoint.
+
+**Criterios de aceptación:**
+
+- [ ] Checkout limpio en Node 22: `npm ci` y `npm run verify` terminan con exit 0, sin `NODE_OPTIONS` ni binario local preexistente; mismo comando verde en CI.
+- [ ] Regresiones offline: CSP local permitido; URL remota real rechazada, incluso compartiendo línea con un origen local; host como `localhost.example.org` no queda permitido por substring. Assets remotos JS/TS/CSS/HTML siguen detectándose.
+- [ ] Pruebas del gate: un check fallido, suite incompleta o salida anormal hacen fallar el agregado; el caso exitoso funciona con y sin el acelerador opcional.
+- [ ] Node fuera del rango declarado se rechaza o diagnostica inequívocamente antes de la suite. El workaround de Node 26 queda como antecedente, no como solución canónica.
+- [ ] No se reducen umbrales, se omiten pruebas ni se pierde un control que hoy ejecuta CI.
+
+**Cierre:** actualizar solo el estado real de AUD-008/AUD-009, registrar versiones exactas, comandos, exits y enlace de CI. No atribuir este PR a una nueva validación Android del producto: no modifica el runtime.
+
+### F2 — Confirmación de persistencia separada del refresco
+
+**Objetivo:** que una creación ya confirmada no se comunique como fallida ni invite a repetir la escritura.
+
+**Contrato propuesto para aprobación:**
+
+- Fallo **antes de confirmar la escritura**: conservar el contrato de error actual, los datos del formulario/borrador y el reintento de guardado.
+- Escritura **confirmada** y fallo de refresco: mantener como resultado la entidad persistida, completar el estado de éxito del formulario y emitir un aviso diferenciado de actualización pendiente; ofrecer recuperación de lecturas sin repetir el `INSERT`.
+- No silenciar la recarga fallida, dejar promesas sin manejar, inventar éxito de persistencia, hacer un rollback compensatorio ni borrar la fila ya confirmada para acomodar la UI.
+
+**Pasos de implementación:**
+
+1. Convertir los dos casos de caracterización en regresiones permanentes con el resultado esperado corregido. Cubrir además el error de escritura previo y el camino normal.
+2. Separar la frontera de escritura del refresco en `createNote()` y `createAcademicEvent()`. Usar un límite pequeño y explícito, no reemplazar globalmente el store ni el contrato de todas sus acciones.
+3. Definir la recuperación de la lectura fallida y su feedback desde UI/composición, sin importar `Toast` desde el store. El borrador solo se limpia cuando la escritura está efectivamente confirmada; single-flight y guards de AUD-006 deben conservarse.
+4. Integrar pruebas de editor y diálogo que comprueben la consecuencia visible, no solo un mock exitoso del store. Inspeccionar mutaciones vecinas con la misma secuencia para registrarlas como casos confirmados o pendientes; no declararlas corregidas sin prueba ni agregarlas silenciosamente al PR.
+
+**Superficie prevista:** `src/store/NoteStore.data.js`, `src/store/NoteStore.academicEvents.js`, límite pequeño de errores/feedback si resulta necesario, consumidores `NoteEditor.js`/`AcademicEventDialog.js` solo si requieren adaptación y sus tests. Reutilizar el harness de `tests/unit/services/sqlite/`; no cambiar esquema, importación ZIP, routing ni suscripciones globales.
+
+**Criterios de aceptación:**
+
+- [ ] Nota/fecha insertada + lectura secundaria fallida: existe exactamente una fila; el resultado identifica esa entidad y el formulario no ofrece reenviar la misma creación como si hubiera fallado.
+- [ ] Recuperar conteos/próximas fechas no ejecuta otra escritura; UI y estado convergen al dato persistido y el aviso no se duplica.
+- [ ] Fallo de inserción: cero filas nuevas, borrador/formulario intacto y reintento legítimo disponible. Se conservan pruebas de taps concurrentes y respuestas async obsoletas.
+- [ ] Regresiones store + SQLite + consumidores UI, suite completa y `npm run verify` pasan en el entorno fijado por F1.
+- [ ] Smoke Android de crear/editar nota y fecha, navegación, reapertura y ausencia de duplicados sobre el SHA candidato. El fallo inyectado en SQLite de tests y la prueba nativa normal se registran como evidencias diferentes.
+
+**Cierre:** evidencia por caso y SHA; AUD-014 solo se cierra para los caminos efectivamente cubiertos. La preparación segura de artefacto/dispositivo descrita en F3 también aplica al smoke de F2, antes de su integración. La aprobación de este plan no autoriza borrar datos, instalar sobre una firma incompatible ni publicar un APK.
+
+### F3 — Evidencia del núcleo, no optimización anticipada
+
+**Objetivo:** decidir con datos si hay que intervenir consultas o notificaciones, y ampliar la evidencia de continuidad/offline del producto existente.
+
+**Preparación segura:** acordar dispositivo y artefacto; registrar modelo, Android/WebView, SHA, versión/código, firma y hash. Distinguir siempre el asset firmado `v0.5.0` de un build de validación posterior. Si el binario cambia, acordar versión/code nuevos sin reutilizar la beta publicada; esto no obliga a crear un tag ni una release. Ante incompatibilidad de firma, detener la instalación y usar un entorno de prueba o una restauración expresamente autorizada; nunca desinstalar/borrar datos por defecto.
+
+**Protocolo mínimo:**
+
+1. Generar un fixture sintético determinista compatible con el backup v1: **500 notas activas visibles en el listado a medir**, 10 materias con 2 secciones cada una y 20 fechas. Añadir por separado casos archivados/papelera para no reducir las 500 visibles. Fijar semilla, fechas, distribución de contenidos, conteos y hash; conservar generador/protocolo revisables y ZIP/logs en `tmp/` o como adjuntos de evidencia, nunca como migraciones productivas. No reutilizar directamente `generate-mock-data.py`.
+2. Medir un perfil pequeño de referencia y el de 500 notas en el mismo dispositivo. Tras calentamiento declarado, tomar **30 muestras por operación** de crear, editar y enviar a papelera; medir desde la acción hasta confirmación y actualización visible, separando además persistencia y refrescos. Registrar muestras crudas, mediana, p95 y máximo. **RNF-002 exige ≤ 200 ms: un p95 favorable no permite ocultar muestras que exceden el límite.**
+3. Capturar frames durante **tres recorridos de scroll de 10 segundos** con las 500 notas visibles, sin selector de archivos/importación mezclados en la medición. Registrar herramienta, método, configuración y FPS por tramo, no solo percepción. Contrastar **RNF-004 ≥ 55 FPS**; si no hay captura fiable, mantenerlo pendiente.
+4. Contar consultas y notificaciones por crear/mover/eliminar, abrir materias y abrir papelera. Relacionar esa traza con `getSubjectTree`, `getTrashItems` y loaders del store. Usar `EXPLAIN QUERY PLAN` sobre una copia del dataset si aparece un cuello de botella de consultas, no agregar índices sin datos.
+5. Repetir sin red creación/edición/búsqueda/organización, papelera, fechas y backup/importación local; distinguir que un destino externo de compartición puede necesitar conectividad. Probar borrador nuevo y de edición al cambiar de app, bloquear/desbloquear y terminar/reabrir el proceso. No usar `clear data` como simulación de cierre inesperado.
+
+**Entregables:** protocolo y generación reproducibles, resultados por caso y una matriz incremental con requisito, método/comando, dispositivo, fecha, SHA/artefacto, valor, umbral, estado y evidencia. Actualizar la [checklist Android](./checklist-validacion-android.md), RNF y pendientes **solo con mediciones ejecutadas**. Una utilidad nueva requerirá revisión y pruebas propias; no queda autorizada una batería de scripts genéricos.
+
+**Criterio de salida:** todos los casos ejecutados o explícitamente pendientes por una dependencia externa, con límites claros. Un fallo RNF abre una corrección acotada respaldada por la medición y su propia aprobación; no se marca el requisito cumplido ni se optimiza dentro del PR de evidencia. Sin dispositivo, entregar preparación verificable y dejar F3 sin cerrar.
+
+## 5. Pendientes que se conservan fuera de este ciclo
+
+- **Cierre académico vigente:** originales bibliográficos, figuras en PDF/diapositivas, tablero y métricas de flujo, presentación/demo y contingencia. El ciclo técnico no los da por hechos ni vuelve a redactar todo el informe.
+- **Validación posterior aún necesaria:** usuarios y navegación (RNF-005/RNF-006), accesibilidad/tipografía/contraste, tráfico/trackers y matriz RNF completa. F3 es un subconjunto, no el cierre de todos los RNF.
+- **Mejora técnica candidata siguiente:** ampliar el smoke SQLite con `academic_events`, columnas, índices, tipo inválido, FK/`ON DELETE SET NULL` e idempotencia. Sigue abierta; se priorizará al terminar este ciclo o si una regresión de schema la vuelve necesaria.
+- **Solo con mediciones de F3:** agregación de conteos o reducción de notificaciones (AUD-010/AUD-011), un cuello de botella por PR, preservando conteos y semántica de archivo/papelera.
+- **No activar ahora:** refactor de routing, migración masiva a TypeScript/framework, Docker, adjuntos, compartir/importar notas individuales, nube/sincronización, onboarding y cambios de producto postergados.
+
+El horizonte termina al revisar F3 y seleccionar **como máximo el próximo objetivo**, no en una lista de funcionalidades para llegar artificialmente a `1.0.0`.
+
+## 6. Evidencia de esta sesión de análisis
+
+Entorno local: Node `26.7.0`, npm `12.0.2`; no había `NODE_OPTIONS` ni binario `scripts/lumapse-audit-bin`. No se modificó el código productivo ni el entorno soportado.
+
+| Verificación ejecutada | Resultado y alcance |
+|---|---|
+| `npm test -- --maxWorkers=1` | Exit 1: 67 archivos, 1005 tests aprobados y 60 fallidos por Web Storage en 5 archivos; AUD-009 vigente |
+| `NODE_OPTIONS=--no-experimental-webstorage npm test -- --maxWorkers=1` | Exit 0: 67 archivos / 1065 tests aprobados. **Diagnóstico con workaround, no gate canónico aprobado** |
+| Reproducción AUD-014 con configuración temporal | Exit 0: 2/2 caracterizaciones verifican el defecto actual sobre SQLite en memoria, no una corrección |
+| `bash scripts/check-offline.sh` | Exit 1: dos falsos positivos CSP (`index.html:19–20`); AUD-008 vigente |
+| `npm run check:db-smoke` | Exit 0, con la limitación de cobertura indicada en §3 |
+| `npm run typecheck` / `npm run lint` | Exit 0; lint conserva 3 warnings conocidos (complejidad/tamaño de editor y tamaño de `BackupImportPlanService.ts`) |
+| `check:docs`, `check:traceability`, `check:toolchain`, `check:schema`, `check:dbml`, `check:subjects`, `check:version` | Controles individuales aprobados; versión `0.5.0/500` sin cambios |
+
+Los logs diagnósticos locales se guardaron en `tmp/plan-inmediato-beta-2026-09-12/`, ignorado por Git. Los resultados resumidos y el reproducer se conservan aquí para no depender de esos temporales. No se ejecutaron en esta sesión el agregado `npm run verify`, un nuevo coverage, auditorías de dependencias, benchmark ni validación Android. La CI de este PR documental se registra en el propio PR y no demuestra que AUD-008/AUD-009 estén resueltos.
+
+## 7. Condiciones de aceptación de este PR documental
+
+- [ ] El autor acepta el orden F1 → F2 → F3, el alcance de AUD-014 y lo que queda fuera.
+- [ ] El contrato propuesto distingue escritura fallida de refresco fallido sin perder borradores ni ocultar errores.
+- [ ] Backlog, TODO e Hito 06 enlazan el mismo plan y no presentan tareas futuras como implementadas.
+- [ ] Checks documentales, trazabilidad y `git diff --check` aprobados; CI revisada y limitaciones locales explícitas.
+- [ ] No hay cambios en runtime, dependencias, schema, versión, APK ni datos personales.
+
+**Detención acordada:** abrir el PR y esperar su revisión. Aceptar el plan no significa que sus correcciones ya existan; solo después de autorización de merge e integración se inicia F1. No hacer merge automático, publicar release ni borrar ramas en esta sesión.
+
+## 8. Reproducción de AUD-014
+
+En la raíz del repositorio, con las dependencias ya instaladas, crear los siguientes archivos **temporales**, no incorporarlos como tests de aceptación sin invertir antes el resultado esperado. Los helpers importados ya están versionados. La configuración usa un único worker y no toca una base de usuario.
+
+`tmp/plan-inmediato-beta-2026-09-12/vitest.config.mjs`:
+
+```js
+import base from '../../vitest.config.js'
+export default {
+  ...base,
+  test: {
+    ...base.test,
+    include: ['tmp/plan-inmediato-beta-2026-09-12/post-write-refresh.test.js'],
+    maxWorkers: 1,
+  },
+}
+```
+
+`tmp/plan-inmediato-beta-2026-09-12/post-write-refresh.test.js`:
+
+```js
+import { afterEach, beforeEach, expect, it } from 'vitest'
+import { importConnection } from '../../tests/unit/services/sqlite/connectionHarness.js'
+import { sqliteFixture } from '../../tests/unit/services/sqlite/sqliteFixture.js'
+
+let fixture, connection, db
+beforeEach(async () => {
+  fixture = await sqliteFixture()
+  const harness = await importConnection({ platform: 'android' })
+  connection = harness.module
+  db = harness.mockDb
+  Object.assign(db, fixture.adapter)
+  fixture.database.run("CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT); INSERT INTO metadata VALUES ('indexeddb_migrated', 'true')")
+  await connection.initDatabase()
+})
+afterEach(() => fixture.close())
+
+it('nota confirmada: el rechazo y reintento generan dos filas', async () => {
+  const store = await import('../../src/store/NoteStore.data.js')
+  db.query.mockRejectedValueOnce(new Error('injected post-write read failure'))
+  await expect(store.createNote('PP3', 'Contenido')).rejects.toThrow('injected post-write read failure')
+  expect((await connection.getDb().query('SELECT id FROM notes')).values).toHaveLength(1)
+  await store.createNote('PP3', 'Contenido')
+  const rows = (await connection.getDb().query('SELECT id FROM notes')).values
+  expect(rows).toHaveLength(2)
+  expect(new Set(rows.map(row => row.id)).size).toBe(2)
+})
+
+it('fecha confirmada: el rechazo y reintento generan dos filas', async () => {
+  const store = await import('../../src/store/NoteStore.academicEvents.js')
+  const input = { type: 'tp', title: 'Entrega PP3', date: '2026-09-20', subjectId: null }
+  const query = db.query.getMockImplementation()
+  db.query.mockImplementation(async (sql, values) => {
+    if (sql.includes('date >= ?')) throw new Error('injected upcoming refresh failure')
+    return query(sql, values)
+  })
+  await expect(store.createAcademicEvent(input)).rejects.toThrow('injected upcoming refresh failure')
+  expect((await connection.getDb().query('SELECT id FROM academic_events')).values).toHaveLength(1)
+  db.query.mockImplementation(query)
+  await store.createAcademicEvent(input)
+  const rows = (await connection.getDb().query('SELECT id FROM academic_events')).values
+  expect(rows).toHaveLength(2)
+  expect(new Set(rows.map(row => row.id)).size).toBe(2)
+})
+```
+
+Ejecutar:
+
+```bash
+npm test -- --config tmp/plan-inmediato-beta-2026-09-12/vitest.config.mjs
+```
+
+Resultado observado: **1 archivo / 2 tests aprobados** porque caracterizan el comportamiento defectuoso. No usan dispositivo Android: `platform: 'android'` selecciona el camino del adaptador simulado. F2 debe transformar estos casos en pruebas del contrato corregido y sumar la integración con sus formularios.

--- a/docs/gestion/revision-tecnica-priorizada-2026-09-01.md
+++ b/docs/gestion/revision-tecnica-priorizada-2026-09-01.md
@@ -1,6 +1,6 @@
 # Revisión Técnica Priorizada — 2026-09-01
 
-**Estado:** Vigente — AUD-001 a AUD-007 cerrados e incluidos en `v0.5.0`; AUD-008 a AUD-013 continúan como seguimiento
+**Estado:** Vigente — AUD-001 a AUD-007 cerrados e incluidos en `v0.5.0`; AUD-008 a AUD-013 continúan como seguimiento; AUD-014 agregado por revisión acotada del 2026-09-12
 **Rama original de auditoría:** `fix/note-save-integrity`
 **Commit base original revisado:** `cd60c0e` (`main`)
 **Versión original revisada:** `0.4.8` (Beta); cierres publicados en `v0.5.0`<br>
@@ -90,6 +90,10 @@ store, no como métrica integral de toda la aplicación.
 
 ## 6. Registro priorizado de hallazgos
 
+La auditoría original registró trece hallazgos. El complemento AUD-014 y la secuencia inmediata
+propuesta se documentan en el [plan del 2026-09-12](./plan-desarrollo-inmediato-beta-2026-09-12.md),
+sin convertir la evidencia histórica de las secciones siguientes en una nueva auditoría integral.
+
 | ID | Prioridad | Hallazgo | Naturaleza | Estado |
 |---|---|---|---|---|
 | AUD-001 | P0 | Pérdida de borrador ante error SQLite | Bug confirmado | Resuelto en PR #2 |
@@ -105,6 +109,7 @@ store, no como métrica integral de toda la aplicación.
 | AUD-011 | P2 | Conteos N+1 y posibles índices faltantes | Rendimiento | Pendiente de medición |
 | AUD-012 | P2 | Deriva de cohesión entre features de presentación | Arquitectura | Pendiente |
 | AUD-013 | P2 | Poco margen de bundle y visibilidad parcial de coverage UI | Mantenibilidad | Monitorear |
+| AUD-014 | P1 | Creación persistida presentada como fallo al rechazar una recarga | Defecto confirmado en notas y fechas | Pendiente; reproducción y propuesta F2 en el plan del 2026-09-12 |
 
 ## 7. Hallazgos detallados
 
@@ -425,13 +430,18 @@ test(editor): cover failed and concurrent note saves
 | 3 | `fix/aud-004-dependency-security` | Cerrado en PR #5: AUD-004 |
 | 4 | `fix/store-action-contract` | Cerrado en PR #6: AUD-007 |
 | 5 | `fix/sqlite-write-coordination` | Cerrado en PR #7: propiedad SQLite y arranque recuperable |
-| 6 | `fix/async-request-ownership` | Implementado; validación canónica/Android e integración pendientes |
+| 6 | `fix/async-request-ownership` | Cerrado en PR #8 e incluido en `v0.5.0`; conservar evidencia de las limitaciones locales del gate |
 | 7 | `fix/quality-gate-portability` | Unificar gate local/CI y resolver matriz Node |
 | 8 | `refactor/store-batched-updates` | Refresh atómico y suscripciones más selectivas |
 | 9 | `refactor/subject-query-aggregation` | Eliminar N+1 con evidencia de rendimiento |
 | 10 | `refactor/content-view-routing` | Recuperar cohesión del feed y fronteras de features |
 
 El orden puede ajustarse por riesgo operativo, pero cada rama debe preservar un alcance revisable.
+
+**Complemento 2026-09-12:** la tabla anterior conserva la secuencia original. Para las próximas
+sesiones se propone F1 (AUD-008/AUD-009), F2 (AUD-014) y F3 (medición/validación), según el
+[plan inmediato](./plan-desarrollo-inmediato-beta-2026-09-12.md). Las optimizaciones y refactors de
+las filas 8 a 10 no quedan autorizados ni iniciados por este plan.
 
 ## 10. Comandos y evidencia de validación
 

--- a/docs/hitos/hito-06-octubre.md
+++ b/docs/hitos/hito-06-octubre.md
@@ -10,7 +10,7 @@
 
 **Estado:** Activo — segunda beta `v0.5.0` publicada; cierre académico, matriz RNF y presentación pendientes
 
-**Última actualización:** 2026-09-05
+**Última actualización:** 2026-09-12
 
 ---
 
@@ -103,6 +103,13 @@ Las ideas conservadas siguen en [`../../BACKLOG.md`](../../BACKLOG.md) y no comp
 
 ## Orden de Trabajo
 
+El orden académico general se conserva abajo. Para las próximas sesiones del frente técnico se
+propone el [plan inmediato de la beta](../gestion/plan-desarrollo-inmediato-beta-2026-09-12.md):
+F1, reproducibilidad del gate (AUD-008/AUD-009); F2, confirmación de creación ante fallos de
+recarga (AUD-014); F3, evidencia Android y medición con 500 notas. **La propuesta requiere
+aceptación e integración por PR antes de implementar.** No agrega funcionalidades ni fija una
+fecha para `1.0.0`; los pendientes académicos y la matriz RNF completa siguen abiertos.
+
 | Orden | Frente | Salida esperada |
 |---|---|---|
 | 1 | Sincronización documental | Evidencia de `v0.5.0` reflejada sin reescribir la historia de `v0.4.8` |
@@ -125,6 +132,7 @@ Se mantiene WIP máximo de dos elementos activos en total entre `En Curso` y `En
 | `Mover a` requería pulsación prolongada | Cerrado en PR #9 | Toque normal y menús contextuales validados en Android; conservar como antecedente resuelto |
 | Rendimiento con mayor volumen de notas | Riesgo medio de evidencia | Medición de latencia y percepción con al menos 500 notas; no solo importación funcional |
 | `npm run verify` depende del entorno vigente | Riesgo medio de tooling | Resolver por separado falsos positivos CSP de AUD-008 y colisión Web Storage de Node 26 de AUD-009 |
+| AUD-014 — creación confirmada y recarga fallida | P1 confirmado en SQLite en memoria; sin corrección | Dos reproducciones generan duplicados al reintentar; F2 propone separar el resultado de escritura del refresco y validar consumidores/Android |
 
 ## Criterios de Cierre
 
@@ -147,6 +155,7 @@ Se mantiene WIP máximo de dos elementos activos en total entre `En Curso` y `En
 
 - [`../../TODO`](../../TODO) — tareas inmediatas.
 - [`../../BACKLOG.md`](../../BACKLOG.md) — deuda, políticas e ideas postergadas.
+- [`../gestion/plan-desarrollo-inmediato-beta-2026-09-12.md`](../gestion/plan-desarrollo-inmediato-beta-2026-09-12.md) — propuesta de próximas sesiones, evidencia y criterios de aceptación; sin implementación.
 - [`../gestion/lineas-base.md`](../gestion/lineas-base.md) — cortes congelados y futura línea base final.
 - [`../gestion/seguimiento-velocidad.md`](../gestion/seguimiento-velocidad.md) — SP entregados por hito.
 - [`../gestion/definicion-flujo-kanban.md`](../gestion/definicion-flujo-kanban.md) — estados, políticas, WIP y métricas de flujo.


### PR DESCRIPTION
## Status

Superseded by #13.

GitHub closed this pull request automatically when its mixed-language head branch, `docs/plan-inmediato-beta`, was renamed to the English-only `docs/immediate-beta-plan` to comply with the repository workflow convention.

This closure was not a review rejection or merge decision. No implementation was performed and no branch was merged. Please continue the review in #13, which preserves the original planning work, adds the agreed Node.js 22.20.0/npm 10.9.3 baseline, and uses English for all pull request metadata while keeping project documentation in Spanish.
